### PR TITLE
Throw error on duplicated tests

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -29,19 +29,24 @@ function getFunctionsToRun() {
   local functions_to_run=()
 
   for function_name in $function_names; do
-    if [[ $function_name == ${prefix}* ]]; then
-      local lower_case_function_name
-      lower_case_function_name=$(echo "$function_name" | tr '[:upper:]' '[:lower:]')
-      local lower_case_filter
-      lower_case_filter=$(echo "$filter" | tr '[:upper:]' '[:lower:]')
-
-      if [[ -z $filter || $lower_case_function_name == *"$lower_case_filter"* ]]; then
-        if [[ "${functions_to_run[*]}" =~ ${function_name} ]]; then
-          return 1
-        fi
-        functions_to_run+=("$function_name")
-      fi
+    if [[ $function_name != ${prefix}* ]]; then
+      continue
     fi
+
+    local lower_case_function_name
+    lower_case_function_name=$(echo "$function_name" | tr '[:upper:]' '[:lower:]')
+    local lower_case_filter
+    lower_case_filter=$(echo "$filter" | tr '[:upper:]' '[:lower:]')
+
+    if [[ -n $filter && $lower_case_function_name != *"$lower_case_filter"* ]]; then
+      continue
+    fi
+
+    if [[ "${functions_to_run[*]}" =~ ${function_name} ]]; then
+      return 1
+    fi
+
+    functions_to_run+=("$function_name")
   done
 
   echo "${functions_to_run[@]}"

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -36,6 +36,9 @@ function getFunctionsToRun() {
       lower_case_filter=$(echo "$filter" | tr '[:upper:]' '[:lower:]')
 
       if [[ -z $filter || $lower_case_function_name == *"$lower_case_filter"* ]]; then
+        if [[ "${functions_to_run[*]}" =~ ${function_name} ]]; then
+          return 1
+        fi
         functions_to_run+=("$function_name")
       fi
     fi

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -20,3 +20,26 @@ function normalizeTestFunctionName() {
 
   echo "$result"
 }
+
+function getFunctionsToRun() {
+  local prefix=$1
+  local filter=$2
+  local function_names=$3
+
+  local functions_to_run=()
+
+  for function_name in $function_names; do
+    if [[ $function_name == ${prefix}* ]]; then
+      local lower_case_function_name
+      lower_case_function_name=$(echo "$function_name" | tr '[:upper:]' '[:lower:]')
+      local lower_case_filter
+      lower_case_filter=$(echo "$filter" | tr '[:upper:]' '[:lower:]')
+
+      if [[ -z $filter || $lower_case_function_name == *"$lower_case_filter"* ]]; then
+        functions_to_run+=("$function_name")
+      fi
+    fi
+  done
+
+  echo "${functions_to_run[@]}"
+}

--- a/src/test_runner.sh
+++ b/src/test_runner.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 
-function callTestFunctions() {
-  local script="$1"
-  local filter="$2"
-  local prefix="test"
-  # Use declare -F to list all function names
-  local function_names
-  function_names=$(declare -F | awk '{print $3}')
+function getFunctionsToRun() {
+  local prefix=$1
+  local function_names=$2
+  local filter=$3
+
   local functions_to_run=()
 
   for function_name in $function_names; do
@@ -21,6 +19,20 @@ function callTestFunctions() {
       fi
     fi
   done
+
+  echo "${functions_to_run[@]}"
+}
+
+function callTestFunctions() {
+  local script="$1"
+  local filter="$2"
+  local prefix="test"
+  # Use declare -F to list all function names
+  local function_names
+  function_names=$(declare -F | awk '{print $3}')
+  local functions_to_run
+  # shellcheck disable=SC2207
+  functions_to_run=($(getFunctionsToRun "$prefix" "$function_names" "$filter"))
 
   if [ "${#functions_to_run[@]}" -gt 0 ]; then
     echo "Running $script"

--- a/src/test_runner.sh
+++ b/src/test_runner.sh
@@ -1,28 +1,5 @@
 #!/bin/bash
 
-function getFunctionsToRun() {
-  local prefix=$1
-  local function_names=$2
-  local filter=$3
-
-  local functions_to_run=()
-
-  for function_name in $function_names; do
-    if [[ $function_name == ${prefix}* ]]; then
-      local lower_case_function_name
-      lower_case_function_name=$(echo "$function_name" | tr '[:upper:]' '[:lower:]')
-      local lower_case_filter
-      lower_case_filter=$(echo "$filter" | tr '[:upper:]' '[:lower:]')
-
-      if [[ -z $filter || $lower_case_function_name == *"$lower_case_filter"* ]]; then
-        functions_to_run+=("$function_name")
-      fi
-    fi
-  done
-
-  echo "${functions_to_run[@]}"
-}
-
 function callTestFunctions() {
   local script="$1"
   local filter="$2"
@@ -32,7 +9,7 @@ function callTestFunctions() {
   function_names=$(declare -F | awk '{print $3}')
   local functions_to_run
   # shellcheck disable=SC2207
-  functions_to_run=($(getFunctionsToRun "$prefix" "$function_names" "$filter"))
+  functions_to_run=($(getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [ "${#functions_to_run[@]}" -gt 0 ]; then
     echo "Running $script"

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -39,3 +39,9 @@ function test_getFunctionsToRun_filter_no_matching_functions_should_return_empty
   result3=$(getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")
   assertEquals "" "$result3"
 }
+
+function test_getFunctionsToRun_fail_when_duplicates() {
+  local functions=("prefix_function1" "prefix_function1")
+
+  assertGeneralError "$(getFunctionsToRun "prefix" "" "${functions[*]}")"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -1,17 +1,41 @@
 #!/bin/bash
 
-function test_empty_normalizeTestFunctionName() {
+function test_normalizeTestFunctionName_empty() {
   assertEquals "" "$(normalizeTestFunctionName)"
 }
 
-function test_one_word_normalizeTestFunctionName() {
+function test_normalizeTestFunctionName_one_word() {
   assertEquals "Word" "$(normalizeTestFunctionName "word")"
 }
 
-function test_snake_case_normalizeTestFunctionName() {
+function test_normalizeTestFunctionName_snake_case() {
   assertEquals "Some logic" "$(normalizeTestFunctionName "test_some_logic")"
 }
 
-function test_camel_case_normalizeTestFunctionName() {
+function test_normalizeTestFunctionName_camel_case() {
   assertEquals "SomeLogic" "$(normalizeTestFunctionName "testSomeLogic")"
+}
+
+function test_getFunctionsToRun_no_filter_should_return_all_functions() {
+  local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
+
+  local result1
+  result1=$(getFunctionsToRun "prefix" "" "${functions[*]}")
+  assertEquals "prefix_function1 prefix_function2 prefix_function3" "$result1"
+}
+
+function test_getFunctionsToRun_with_filter_should_return_matching_functions() {
+  local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
+
+  local result2
+  result2=$(getFunctionsToRun "prefix" "function1" "${functions[*]}")
+  assertEquals "prefix_function1" "$result2"
+}
+
+function test_getFunctionsToRun_filter_no_matching_functions_should_return_empty() {
+  local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
+
+  local result3
+  result3=$(getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")
+  assertEquals "" "$result3"
 }


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/Chemaclass/bashunit/issues/56

If you have to test with the same name, we should throw an error or say something, because it could be a bad situation

## 🔖 Changes

- Refactor extract function `getFunctionsToRun()`
- assertGeneralError when duplicate functions