### PR TITLE
fixing test, creating assertSuccessfulCode assertGeneralError assertCommandNotFound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Update documentation
 - Add support for the static analysis on Mac OS
 - Fix bug with watcher for the development of bashunit
+- Added `assertSuccessfulCode`
+- Added `assertGeneralError`
+- Added `assertCommandNotFound`
 
 ### 0.5.0
 ### 2023-09-10

--- a/Makefile
+++ b/Makefile
@@ -57,10 +57,11 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	./bashunit $(TEST_SCRIPTS)
+	@./bashunit $(TEST_SCRIPTS)
 
 test/watch: $(TEST_SCRIPTS)
-	fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 -I{} ./bashunit $(TEST_SCRIPTS)
+	@./bashunit $(TEST_SCRIPTS)
+	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit $(TEST_SCRIPTS)
 
 env/example:
 	@echo "Copy the .env into the .env.example file without the values"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -82,7 +82,53 @@ function assertExitCode() {
 
   if [ $actual_exit_code -ne "$expected_exit_code" ]; then
     ((_ASSERTIONS_FAILED++))
-    printFailedTest  "${label}" "${actual_exit_code}" "to not match" "${expected_exit_code}"
+    printFailedTest  "${label}" "${actual_exit_code}" "to be" "${expected_exit_code}"
+    return 1
+  fi
+
+  ((_ASSERTIONS_PASSED++))
+  return 0
+}
+
+function assertSuccessfulCode() {
+  local actual_exit_code=$?
+  local expected_exit_code=0
+  local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [ $actual_exit_code -ne "$expected_exit_code" ]; then
+    ((_ASSERTIONS_FAILED++))
+    printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
+    return 1
+  fi
+
+  ((_ASSERTIONS_PASSED++))
+  return 0
+}
+
+function assertGeneralError() {
+  local actual_exit_code=$?
+  local expected_exit_code=1
+  local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [ $actual_exit_code -ne "$expected_exit_code" ]; then
+    ((_ASSERTIONS_FAILED++))
+    printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
+    return 1
+  fi
+
+  ((_ASSERTIONS_PASSED++))
+  return 0
+}
+
+
+function assertCommandNotFound() {
+  local actual_exit_code=$?
+  local expected_exit_code=127
+  local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [ $actual_exit_code -ne "$expected_exit_code" ]; then
+    ((_ASSERTIONS_FAILED++))
+    printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
     return 1
   fi
 

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -68,7 +68,7 @@ function test_successful_assertExitCode() {
   }
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertExitCode "0" "$(fake_function)")"
 
-  assertExitCode "0" "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
+  assertExitCode "0" "$(fake_function)"
 }
 
 function test_unsuccessful_assertExitCode() {
@@ -76,7 +76,7 @@ function test_unsuccessful_assertExitCode() {
     exit 1
   }
   assertEquals\
-    "$(printFailedTest "Unsuccessful assertExitCode" "1" "to not match" "0")"\
+    "$(printFailedTest "Unsuccessful assertExitCode" "1" "to be" "0")"\
     "$(assertExitCode "0" "$(fake_function)")"
 
   assertExitCode "1" "$(assertExitCode "0" "$(fake_function)")"
@@ -96,6 +96,63 @@ function test_unsuccessful_return_assertExitCode() {
   }
   fake_function
   assertExitCode "1"
+}
+
+function test_successful_assertSuccessfulCode() {
+  function fake_function() {
+    return 0
+  }
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertSuccessfulCode "$(fake_function)")"
+
+  assertSuccessfulCode "$(fake_function)"
+}
+
+function test_unsuccessful_assertSuccessfulCode() {
+  function fake_function() {
+    return 2
+  }
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertSuccessfulCode" "2" "to be exactly" "0")"\
+    "$(assertSuccessfulCode "$(fake_function)")"
+
+  assertExitCode "1" "$(assertSuccessfulCode "$(fake_function)")"
+}
+
+function test_successful_assertGeneralError() {
+  function fake_function() {
+    return 1
+  }
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertGeneralError "$(fake_function)")"
+
+  assertGeneralError "$(fake_function)"
+}
+
+function test_unsuccessful_assertGeneralError() {
+  function fake_function() {
+    return 2
+  }
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertGeneralError" "2" "to be exactly" "1")"\
+    "$(assertGeneralError "$(fake_function)")"
+
+  assertExitCode "1" "$(assertGeneralError "$(fake_function)")"
+}
+
+function test_successful_assertCommandNotFound() {
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertCommandNotFound "$(a_non_existing_function)")"
+
+  assertExitCode "0" "$(assertCommandNotFound "$(a_non_existing_function)")"
+}
+
+function test_unsuccessful_assertCommandNotFound() {
+  function fake_function() {
+    return 0
+  }
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertCommandNotFound" "0" "to be exactly" "127")"\
+    "$(assertCommandNotFound "$(fake_function)")"
+
+  assertExitCode "1" "$(assertCommandNotFound "$(fake_function)")"
 }
 
 unset SUCCESSFUL_EMPTY_MESSAGE


### PR DESCRIPTION


## 📚 Description

Implemented 3 assertions more related to the exit code on the bash standards

https://www.cyberciti.biz/faq/bash-get-exit-code-of-command/

![image](https://github.com/TypedDevs/bashunit/assets/6353105/5320a15b-92d9-465a-bff1-5515927b69b6)


## 🔖 Changes

- implemented `assertSuccessfulCode`
- implemented `assertGeneralError`
- implemented `assertCommandNotFound`

## ✅ To-do list
- [X] Make sure that all the pipeline passes
- [X] Make sure to update the need it documentation files for example: CHANGELOG.md of CONTRIBUTING.md