### PR TITLE
Fix error on count assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,16 @@
 
 ### Unreleased
 
-- Added assertExitCode
-- Improved the readability of the assert by using guard clause
-- Assert that other assertion functions return the right exit code
-- Update functional examples
-- Update documentation
-- Add support for the static analysis on Mac OS
-- Fix bug with watcher for the development of bashunit
+- Added `assertExitCode`
 - Added `assertSuccessfulCode`
 - Added `assertGeneralError`
 - Added `assertCommandNotFound`
+- Improved the readability of the assert by using guard clause
+- Assert that other assertion functions return the right exit code
+- Update documentation
+- Add support for the static analysis on MacOS
+- Fix bug with watcher for the development of bashunit
+- Fix error on count assertions
 
 ### 0.5.0
 ### 2023-09-10

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
 function assertEquals() {
+  local exit_code=$?
+  if [[ $exit_code != "0" ]]; then
+    return $exit_code
+  fi
+
   local expected="$1"
   local actual="$2"
   local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 function assertEquals() {
-  local exit_code=$?
-  if [[ $exit_code != "0" ]]; then
-    return $exit_code
-  fi
-
   local expected="$1"
   local actual="$2"
   local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/test_runner.sh
+++ b/src/test_runner.sh
@@ -25,7 +25,7 @@ function callTestFunctions() {
   if [ "${#functions_to_run[@]}" -gt 0 ]; then
     echo "Running $script"
     for function_name in "${functions_to_run[@]}"; do
-      if [ "$PARALLEL_RUN" = true ] ; then
+      if [ "$PARALLEL_RUN" == true ] ; then
         runTest "$function_name" &
       else
         runTest "$function_name"
@@ -37,11 +37,11 @@ function callTestFunctions() {
 
 function runTest() {
   local function_name="$1"
+  local current_assertions_failed="$_ASSERTIONS_FAILED"
 
   "$function_name"
-  local exit_code=$?
 
-  if [ $exit_code -eq 0 ]; then
+  if [ "$current_assertions_failed" == "$_ASSERTIONS_FAILED" ]; then
     ((_TESTS_PASSED++))
     local label="${3:-$(normalizeTestFunctionName "$function_name")}"
     printSuccessfulTest "${label}"

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -1,127 +1,127 @@
 #!/bin/bash
 
-tests_passed=0
-tests_failed=0
-assertions_passed=0
-assertions_failed=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+ASSERTIONS_PASSED=0
+ASSERTIONS_FAILED=0
 
 function test_not_render_passed_tests_when_no_passed_tests_nor_assertions() {
-  local tests_passed=0
-  local assertions_passed=0
+  local TESTS_PASSED=0
+  local ASSERTIONS_PASSED=0
 
   assertNotMatches\
     "Tests:[^\n]*passed[^\n]*total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_not_render_passed_assertions_when_no_passed_tests_nor_assertions() {
-  local tests_passed=0
-  local assertions_passed=0
+  local TESTS_PASSED=0
+  local ASSERTIONS_PASSED=0
 
   assertNotMatches\
     "Assertions:[^\n]*passed[^\n]*total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_passed_tests_when_passed_tests() {
-  local tests_passed=1
+  local TESTS_PASSED=1
 
   assertMatches\
     $'Tests:[^\n]*\e\[32m1 passed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_passed_tests_when_passed_assertions() {
-  local tests_passed=0
-  local assertions_passed=1
+  local TESTS_PASSED=0
+  local ASSERTIONS_PASSED=1
 
   assertMatches\
     $'Tests:[^\n]*\e\[32m0 passed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_passed_assertions_when_passed_tests() {
-  local tests_passed=1
-  local assertions_passed=0
+  local TESTS_PASSED=1
+  local ASSERTIONS_PASSED=0
 
   assertMatches\
     $'Assertions:[^\n]*\e\[32m0 passed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_passed_assertions_when_passed_assertions() {
-  local assertions_passed=1
+  local ASSERTIONS_PASSED=1
 
   assertMatches\
     $'Assertions:[^\n]*\e\[32m1 passed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_not_render_failed_tests_when_not_failed_tests() {
-  local tests_failed=0
+  local TESTS_FAILED=0
 
   assertNotMatches\
     "Tests:[^\n]*failed[^\n]*total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_not_render_failed_assertions_when_not_failed_tests() {
-  local tests_failed=0
+  local TESTS_FAILED=0
 
   assertNotMatches\
     "Assertions:[^\n]*failed[^\n]*total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_failed_tests_when_failed_tests() {
-  local tests_failed=1
+  local TESTS_FAILED=1
 
   assertMatches\
     $'Tests:[^\n]*\e\[31m1 failed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_failed_assertions_when_failed_tests() {
-  local tests_failed=1
-  local assertions_failed=0
+  local TESTS_FAILED=1
+  local ASSERTIONS_FAILED=0
 
   assertMatches\
     $'Assertions:[^\n]*\e\[31m0 failed\e\[0m[^\n]*total'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_not_render_all_tests_passed_when_failed_tests() {
-  local tests_failed=1
+  local TESTS_FAILED=1
 
   assertNotMatches\
     "All tests passed"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_all_tests_passed_when_not_failed_tests() {
-  local tests_failed=0
+  local TESTS_FAILED=0
 
   assertMatches\
     $'\e\[42mAll tests passed\e\[0m'\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_total_tests_is_the_sum_of_passed_and_failed_tests() {
-  local tests_passed=4
-  local tests_failed=2
+  local TESTS_PASSED=4
+  local TESTS_FAILED=2
 
   assertMatches\
     "Tests:[^\n]*6 total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_total_asserts_is_the_sum_of_passed_and_failed_asserts() {
-  local assertions_passed=1
-  local assertions_failed=3
+  local ASSERTIONS_PASSED=1
+  local ASSERTIONS_FAILED=3
 
   assertMatches\
     "Assertions:[^\n]*4 total"\
-    "$(renderResult $tests_passed $tests_failed $assertions_passed $assertions_failed)"
+    "$(renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_time_of_execution_when_all_assertions_passed() {


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/TypedDevs/bashunit/issues/62

## 🔖 Changes

Instead of considering the last exit code from the function in order to validate if the test was successful or not, we will check the total of failed assertions before and after running a test.