### PR TITLE
Remove asserts returns

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -8,11 +8,10 @@ function assertEquals() {
   if [[ "$expected" != "$actual" ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${expected}" "but got" "${actual}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertNotEquals() {
@@ -23,11 +22,10 @@ function assertNotEquals() {
   if [[ "$expected" == "$actual" ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${expected}" "but got" "${actual}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertContains() {
@@ -36,13 +34,12 @@ function assertContains() {
   local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if ! [[ $actual == *"$expected"* ]]; then
-      ((_ASSERTIONS_FAILED++))
-      printFailedTest  "${label}" "${actual}" "to contain" "${expected}"
-      return 1
-    fi
+    ((_ASSERTIONS_FAILED++))
+    printFailedTest  "${label}" "${actual}" "to contain" "${expected}"
+    return
+  fi
 
-    ((_ASSERTIONS_PASSED++))
-    return 0
+  ((_ASSERTIONS_PASSED++))
 }
 
 function assertNotContains() {
@@ -53,11 +50,10 @@ function assertNotContains() {
   if [[ $actual == *"$expected"* ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual}" "to not contain" "${expected}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertMatches() {
@@ -68,11 +64,10 @@ function assertMatches() {
   if ! [[ $actual =~ $expected ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual}" "to match" "${expected}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertNotMatches() {
@@ -83,11 +78,10 @@ function assertNotMatches() {
   if [[ $actual =~ $expected ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual}" "to not match" "${expected}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertExitCode() {
@@ -98,11 +92,10 @@ function assertExitCode() {
   if [ $actual_exit_code -ne "$expected_exit_code" ]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual_exit_code}" "to be" "${expected_exit_code}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertSuccessfulCode() {
@@ -113,11 +106,10 @@ function assertSuccessfulCode() {
   if [ $actual_exit_code -ne "$expected_exit_code" ]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertGeneralError() {
@@ -128,11 +120,10 @@ function assertGeneralError() {
   if [ $actual_exit_code -ne "$expected_exit_code" ]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 
@@ -144,11 +135,10 @@ function assertCommandNotFound() {
   if [ $actual_exit_code -ne "$expected_exit_code" ]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertArrayContains() {
@@ -159,11 +149,10 @@ function assertArrayContains() {
   if ! [[ "${actual[*]}" == *"$expected"* ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual[*]}" "to contain" "${expected}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }
 
 function assertArrayNotContains() {
@@ -174,9 +163,8 @@ function assertArrayNotContains() {
   if [[ "${actual[*]}" == *"$expected"* ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual[*]}" "to not contain" "${expected}"
-    return 1
+    return
   fi
 
   ((_ASSERTIONS_PASSED++))
-  return 0
 }

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -146,6 +146,7 @@ function assertArrayContains() {
   label="$(normalizeTestFunctionName "${FUNCNAME[1]}")"
   shift
   local actual=("$@")
+
   if ! [[ "${actual[*]}" == *"$expected"* ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual[*]}" "to contain" "${expected}"
@@ -160,6 +161,7 @@ function assertArrayNotContains() {
   label="$(normalizeTestFunctionName "${FUNCNAME[1]}")"
   shift
   local actual=("$@")
+
   if [[ "${actual[*]}" == *"$expected"* ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual[*]}" "to not contain" "${expected}"

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -28,7 +28,9 @@ function test_should_validate_an_ok_exit_code() {
   function fake_function() {
     return 0
   }
+
   fake_function
+
   assertExitCode "0"
 }
 
@@ -36,14 +38,16 @@ function test_should_validate_a_non_ok_exit_code() {
   function fake_function() {
     return 1
   }
+
   fake_function
+
   assertExitCode "1"
 }
 
 function test_other_way_of_using_the_exit_code() {
   function fake_function() {
-      return 1
-    }
-    assertExitCode "1" "$(fake_function)"
-}
+    return 1
+  }
 
+  assertExitCode "1" "$(fake_function)"
+}

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -150,35 +150,31 @@ function test_unsuccessful_assertCommandNotFound() {
 }
 
 function test_successful_assertArrayContains() {
-  local distros=(Ubuntu 1234 Linux\ Mint)
+  local distros=(Ubuntu 123 Linux\ Mint)
 
-  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertArrayContains "1234" "${distros[@]}")"
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertArrayContains "123" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayContains() {
-  local distros=(Ubuntu 1234 Linux\ Mint)
+  local distros=(Ubuntu 123 Linux\ Mint)
 
   assertEquals\
-    "$(printFailedTest\
-    "Unsuccessful assertArrayContains"\
-    "Ubuntu 1234 Linux Mint"\
-    "to contain"\
-    "a_non_existing_element")"\
-    "$(assertArrayContains "a_non_existing_element" "${distros[@]}")"
+    "$(printFailedTest "Unsuccessful assertArrayContains" "Ubuntu 123 Linux Mint" "to contain" "non_existing_element")"\
+    "$(assertArrayContains "non_existing_element" "${distros[@]}")"
 }
 
-function test_successful_assertArrayContains() {
-  local distros=(Ubuntu 1234 Linux\ Mint)
+function test_successful_assertArrayNotContains() {
+  local distros=(Ubuntu 123 Linux\ Mint)
 
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayNotContains() {
-  local distros=(Ubuntu 1234 Linux\ Mint)
+  local distros=(Ubuntu 123 Linux\ Mint)
 
   assertEquals\
-    "$(printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 1234 Linux Mint" "to not contain" "1234")"\
-    "$(assertArrayNotContains "1234" "${distros[@]}")"
+    "$(printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
+    "$(assertArrayNotContains "123" "${distros[@]}")"
 }
 
 unset SUCCESSFUL_EMPTY_MESSAGE

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -149,7 +149,6 @@ function test_unsuccessful_assertCommandNotFound() {
     "$(assertCommandNotFound "$(fake_function)")"
 }
 
-# shellcheck disable=SC2317
 function test_successful_assertArrayContains() {
   local distros=(Ubuntu 1234 Linux\ Mint)
 

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -3,102 +3,89 @@ SUCCESSFUL_EMPTY_MESSAGE=""
 
 function test_successful_assertEquals() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertEquals "1" "1")"
-  assertSuccessfulCode "$(assertEquals "1" "1")"
 }
 
 function test_unsuccessful_assertEquals() {
-  assertEquals "$(printFailedTest "Unsuccessful assertEquals" "1" "but got" "2")"\
-  "$(assertEquals "1" "2")"
-
-  assertGeneralError "$(assertEquals "1" "2")"
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertEquals" "1" "but got" "2")"\
+    "$(assertEquals "1" "2")"
 }
 
 function test_successful_assertNotEquals() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertNotEquals "1" "2")"
-  assertSuccessfulCode "$(assertNotEquals "1" "2")"
 }
 
 function test_unsuccessful_assertNotEquals() {
-  assertEquals "$(printFailedTest "Unsuccessful assertNotEquals" "1" "but got" "1")"\
-  "$(assertNotEquals "1" "1")"
-
-  assertGeneralError "$(assertNotEquals "1" "1")"
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertNotEquals" "1" "but got" "1")"\
+    "$(assertNotEquals "1" "1")"
 }
 
 function test_successful_assertContains() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertContains "Linux" "GNU/Linux")"
-  assertSuccessfulCode "$(assertContains "Linux" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertContains() {
-  assertEquals "$(printFailedTest "Unsuccessful assertContains" "GNU/Linux" "to contain" "Unix")"\
-  "$(assertContains "Unix" "GNU/Linux")"
-
-  assertGeneralError "$(assertContains "Unix" "GNU/Linux")"
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertContains" "GNU/Linux" "to contain" "Unix")"\
+    "$(assertContains "Unix" "GNU/Linux")"
 }
 
 function test_successful_assertNotContains() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertNotContains "Linus" "GNU/Linux")"
-  assertSuccessfulCode "$(assertNotContains "Linus" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertNotContains() {
-  assertEquals "$(printFailedTest "Unsuccessful assertNotContains" "GNU/Linux" "to not contain" "Linux")"\
-  "$(assertNotContains "Linux" "GNU/Linux")"
-
-  assertGeneralError "$(assertNotContains "Linux" "GNU/Linux")"
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertNotContains" "GNU/Linux" "to not contain" "Linux")"\
+    "$(assertNotContains "Linux" "GNU/Linux")"
 }
 
 function test_successful_assertMatches() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertMatches ".*Linu*" "GNU/Linux")"
-  assertSuccessfulCode "$(assertMatches ".*Linu*" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertMatches() {
-  assertEquals "$(printFailedTest "Unsuccessful assertMatches" "GNU/Linux" "to match" ".*Pinux*")"\
-  "$(assertMatches ".*Pinux*" "GNU/Linux")"
-
-  assertGeneralError "$(assertMatches ".*Pinux*" "GNU/Linux")"
+  assertEquals\
+    "$(printFailedTest "Unsuccessful assertMatches" "GNU/Linux" "to match" ".*Pinux*")"\
+    "$(assertMatches ".*Pinux*" "GNU/Linux")"
 }
 
 function test_successful_assertNotMatches() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
-  assertSuccessfulCode "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertNotMatches() {
   assertEquals\
     "$(printFailedTest "Unsuccessful assertNotMatches" "GNU/Linux" "to not match" ".*Linu*")"\
     "$(assertNotMatches ".*Linu*" "GNU/Linux")"
-
-    assertGeneralError "$(assertNotMatches ".*Linu*" "GNU/Linux")"
 }
 
 function test_successful_assertExitCode() {
   function fake_function() {
     exit 0
   }
-  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertExitCode "0" "$(fake_function)")"
 
-  assertSuccessfulCode "$(fake_function)"
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertExitCode "0" "$(fake_function)")"
 }
 
 function test_unsuccessful_assertExitCode() {
   function fake_function() {
     exit 1
   }
+
   assertEquals\
     "$(printFailedTest "Unsuccessful assertExitCode" "1" "to be" "0")"\
     "$(assertExitCode "0" "$(fake_function)")"
-
-  assertGeneralError "$(assertExitCode "0" "$(fake_function)")"
 }
 
 function test_successful_return_assertExitCode() {
   function fake_function() {
     return 0
   }
+
   fake_function
+
   assertExitCode "0"
 }
 
@@ -106,7 +93,9 @@ function test_unsuccessful_return_assertExitCode() {
   function fake_function() {
     return 1
   }
+
   fake_function
+
   assertExitCode "1"
 }
 
@@ -114,64 +103,57 @@ function test_successful_assertSuccessfulCode() {
   function fake_function() {
     return 0
   }
-  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertSuccessfulCode "$(fake_function)")"
 
-  assertSuccessfulCode "$(fake_function)"
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertSuccessfulCode "$(fake_function)")"
 }
 
 function test_unsuccessful_assertSuccessfulCode() {
   function fake_function() {
     return 2
   }
+
   assertEquals\
     "$(printFailedTest "Unsuccessful assertSuccessfulCode" "2" "to be exactly" "0")"\
     "$(assertSuccessfulCode "$(fake_function)")"
-
-  assertGeneralError "$(assertSuccessfulCode "$(fake_function)")"
 }
 
 function test_successful_assertGeneralError() {
   function fake_function() {
     return 1
   }
-  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertGeneralError "$(fake_function)")"
 
-  assertGeneralError "$(fake_function)"
+  assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertGeneralError "$(fake_function)")"
 }
 
 function test_unsuccessful_assertGeneralError() {
   function fake_function() {
     return 2
   }
+
   assertEquals\
     "$(printFailedTest "Unsuccessful assertGeneralError" "2" "to be exactly" "1")"\
     "$(assertGeneralError "$(fake_function)")"
-
-  assertExitCode "1" "$(assertGeneralError "$(fake_function)")"
 }
 
 function test_successful_assertCommandNotFound() {
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)")"
-
-  assertSuccessfulCode "$(assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)")"
 }
 
 function test_unsuccessful_assertCommandNotFound() {
   function fake_function() {
     return 0
   }
+
   assertEquals\
     "$(printFailedTest "Unsuccessful assertCommandNotFound" "0" "to be exactly" "127")"\
     "$(assertCommandNotFound "$(fake_function)")"
-
-  assertGeneralError "$(assertCommandNotFound "$(fake_function)")"
 }
 
 # shellcheck disable=SC2317
 function test_successful_assertArrayContains() {
   local distros=(Ubuntu 1234 Linux\ Mint)
+
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertArrayContains "1234" "${distros[@]}")"
-  assertSuccessfulCode "$(assertArrayContains "1234" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayContains() {
@@ -184,13 +166,12 @@ function test_unsuccessful_assertArrayContains() {
     "to contain"\
     "a_non_existing_element")"\
     "$(assertArrayContains "a_non_existing_element" "${distros[@]}")"
-  assertGeneralError "$(assertArrayContains "a_non_existing_element" "${distros[@]}")"
 }
 
 function test_successful_assertArrayContains() {
   local distros=(Ubuntu 1234 Linux\ Mint)
+
   assertEquals "$SUCCESSFUL_EMPTY_MESSAGE" "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
-  assertSuccessfulCode "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayNotContains() {
@@ -199,7 +180,6 @@ function test_unsuccessful_assertArrayNotContains() {
   assertEquals\
     "$(printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 1234 Linux Mint" "to not contain" "1234")"\
     "$(assertArrayNotContains "1234" "${distros[@]}")"
-  assertGeneralError "$(assertArrayNotContains "1234" "${distros[@]}")"
 }
 
 unset SUCCESSFUL_EMPTY_MESSAGE

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 SUCCESSFUL_EMPTY_MESSAGE=""
 
 function test_successful_assertEquals() {
@@ -176,5 +177,3 @@ function test_unsuccessful_assertArrayNotContains() {
     "$(printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
     "$(assertArrayNotContains "123" "${distros[@]}")"
 }
-
-unset SUCCESSFUL_EMPTY_MESSAGE

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -19,25 +19,19 @@ function test_normalizeTestFunctionName_camel_case() {
 function test_getFunctionsToRun_no_filter_should_return_all_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  local result1
-  result1=$(getFunctionsToRun "prefix" "" "${functions[*]}")
-  assertEquals "prefix_function1 prefix_function2 prefix_function3" "$result1"
+  assertEquals "prefix_function1 prefix_function2 prefix_function3" "$(getFunctionsToRun "prefix" "" "${functions[*]}")"
 }
 
 function test_getFunctionsToRun_with_filter_should_return_matching_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  local result2
-  result2=$(getFunctionsToRun "prefix" "function1" "${functions[*]}")
-  assertEquals "prefix_function1" "$result2"
+  assertEquals "prefix_function1" "$(getFunctionsToRun "prefix" "function1" "${functions[*]}")"
 }
 
 function test_getFunctionsToRun_filter_no_matching_functions_should_return_empty() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  local result3
-  result3=$(getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")
-  assertEquals "" "$result3"
+  assertEquals "" "$(getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")"
 }
 
 function test_getFunctionsToRun_fail_when_duplicates() {


### PR DESCRIPTION
## 📚 Description

As a result of the fix #66, no part of our code requires assertions to return any kind of status code, so, for simplification, they have been removed.

Assertions from tests checking that the status code was as expected have also been removed. Instead, assertions should be written in the future to ensure that the corresponding counter (passed/failed) is incremented correctly. However, since this is likely to undergo a refactor to address issue #39, I've decided to postpone it.

## 🔖 Changes

- Remove return codes on assertions

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
