### PR TITLE
Unset setup functions

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -129,7 +129,7 @@ function assertSuccessfulCode() {
   local expected_exit_code=0
   local label="${3:-$(normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
-  if [ $actual_exit_code -ne "$expected_exit_code" ]; then
+  if [[ $actual_exit_code != "$expected_exit_code" ]]; then
     ((_ASSERTIONS_FAILED++))
     printFailedTest  "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
     return

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -59,3 +59,14 @@ function executeFunctionIfExists() {
     "$function_name"
   fi
 }
+
+function unsetIfExists() {
+  local function_name=$1
+
+  if declare -F | awk '{print $3}' | grep -Eq "^${function_name}$"; then
+    unset "$function_name"
+    return 0
+  fi
+
+  return 1
+}

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -57,6 +57,16 @@ function runTearDownAfterScript() {
   executeFunctionIfExists 'tearDownAfterScript'
 }
 
+function cleanSetUpAndTearDownAfterTest() {
+  unsetIfExists 'setUp'
+  unsetIfExists 'tearDown'
+}
+
+function cleanSetUpAndTearDownAfterScript() {
+  unsetIfExists 'setUpBeforeScript'
+  unsetIfExists 'tearDownAfterScript'
+}
+
 ###############
 #### MAIN #####
 ###############
@@ -101,6 +111,8 @@ function loadTestFiles() {
       wait
     fi
     runTearDownAfterScript
+
+    cleanSetUpAndTearDownAfterScript
   done
 }
 

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -57,7 +57,7 @@ function test_no_function_is_executed_with_execute_function_if_exists() {
 }
 
 function test_unsuccessful_unsetIfExists() {
-   assertGeneralError "$(unsetIfExists "fake_function")"
+  assertGeneralError "$(unsetIfExists "fake_function")"
 }
 
 function test_successful_unsetIfExists() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -61,6 +61,7 @@ function test_unsuccessful_unsetIfExists() {
 }
 
 function test_successful_unsetIfExists() {
+  # shellcheck disable=SC2317
   function fake_function() {
     return 0
   }

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -55,3 +55,19 @@ function test_no_function_is_executed_with_execute_function_if_exists() {
 
   assertEmpty "$(executeFunctionIfExists "$function_name")"
 }
+
+function test_unsuccessful_unsetIfExists() {
+   assertGeneralError "$(unsetIfExists "fake_function")"
+}
+
+function test_successful_unsetIfExists() {
+  function fake_function() {
+    return 0
+  }
+
+  assertSuccessfulCode "$(unsetIfExists "fake_function")"
+}
+
+function tearDown() {
+  unset fake_function
+}


### PR DESCRIPTION
## 📚 Description

Discovered after merging https://github.com/TypedDevs/bashunit/pull/92 CC: @cmayo

## 🔖 Changes

- Unset the setup/tearDown functions after each test/script

> TODO: Missing tests for `cleanSetUpAndTearDownAfterScript()` and `cleanSetUpAndTearDownAfterTest()` in a follow up. Anybody can pick this up! ;)