### PR TITLE
Refactor loadTestFiles to receive args instead of using globals

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -43,10 +43,9 @@ function Runner::runTest() {
   Console::printSuccessfulTest "${label}"
   State::addTestsPassed
 }
-
 function Runner::loadTestFiles() {
   local filter=$1
-  local files=$2
+  local files=("${@:2}") # Store all arguments starting from the second as an array
 
   if [[ ${#files[@]} == 0 ]]; then
     printf "%sError: At least one file path is required.%s\n" "${_COLOR_FAILED}" "${_COLOR_DEFAULT}"
@@ -54,7 +53,7 @@ function Runner::loadTestFiles() {
     exit 1
   fi
 
-  for test_file in "${_FILES[@]}"; do
+  for test_file in "${files[@]}"; do
     if [[ ! -f $test_file ]]; then
       continue
     fi
@@ -121,3 +120,4 @@ while [[ $# -gt 0 ]]; do
 done
 
 Runner::loadTestFiles "$_FILTER" "${_FILES[@]}"
+

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -45,7 +45,10 @@ function Runner::runTest() {
 }
 
 function Runner::loadTestFiles() {
-  if [[ ${#_FILES[@]} == 0 ]]; then
+  local filter=$1
+  local files=$2
+
+  if [[ ${#files[@]} == 0 ]]; then
     printf "%sError: At least one file path is required.%s\n" "${_COLOR_FAILED}" "${_COLOR_DEFAULT}"
     printf "%sUsage: %s <test_file.sh>%s\n" "${_COLOR_DEFAULT}" "$0" "${_COLOR_DEFAULT}"
     exit 1
@@ -60,7 +63,7 @@ function Runner::loadTestFiles() {
     source "$test_file"
 
     Runner::runSetUpBeforeScript
-    Runner::callTestFunctions "$test_file" "$_FILTER"
+    Runner::callTestFunctions "$test_file" "$filter"
     if [ "$PARALLEL_RUN" = true ] ; then
       wait
     fi
@@ -99,8 +102,8 @@ function Runner::cleanSetUpAndTearDownAfterScript() {
 #### MAIN #####
 ###############
 
-_FILES=()
 _FILTER=""
+_FILES=()
 
 while [[ $# -gt 0 ]]; do
   argument="$1"
@@ -117,4 +120,4 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-Runner::loadTestFiles
+Runner::loadTestFiles "$_FILTER" "${_FILES[@]}"


### PR DESCRIPTION
## 🔖 Changes

- Avoid using globals from `Runner::loadTestFiles`, instead use local arguments.
