### PR TITLE
Catch errors when test execution fails

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -8,10 +8,12 @@ function assertEquals() {
   if [[ "$expected" != "$actual" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${expected}" "but got" "${actual}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertEmpty() {
@@ -21,10 +23,12 @@ function assertEmpty() {
   if [[ "$expected" != "" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "to be empty" "but got" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertNotEmpty() {
@@ -34,10 +38,12 @@ function assertNotEmpty() {
   if [[ "$expected" == "" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "to not be empty" "but got" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertNotEquals() {
@@ -48,10 +54,12 @@ function assertNotEquals() {
   if [[ "$expected" == "$actual" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${expected}" "but got" "${actual}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertContains() {
@@ -62,10 +70,12 @@ function assertContains() {
   if ! [[ $actual == *"$expected"* ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual}" "to contain" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertNotContains() {
@@ -76,10 +86,12 @@ function assertNotContains() {
   if [[ $actual == *"$expected"* ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual}" "to not contain" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertMatches() {
@@ -90,10 +102,12 @@ function assertMatches() {
   if ! [[ $actual =~ $expected ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual}" "to match" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertNotMatches() {
@@ -104,10 +118,12 @@ function assertNotMatches() {
   if [[ $actual =~ $expected ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual}" "to not match" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertExitCode() {
@@ -118,10 +134,12 @@ function assertExitCode() {
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be" "${expected_exit_code}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertSuccessfulCode() {
@@ -132,10 +150,12 @@ function assertSuccessfulCode() {
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertGeneralError() {
@@ -146,10 +166,12 @@ function assertGeneralError() {
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 
@@ -161,10 +183,12 @@ function assertCommandNotFound() {
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertArrayContains() {
@@ -176,10 +200,12 @@ function assertArrayContains() {
   if ! [[ "${actual[*]}" == *"$expected"* ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual[*]}" "to contain" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 function assertArrayNotContains() {
@@ -191,8 +217,10 @@ function assertArrayNotContains() {
   if [[ "${actual[*]}" == *"$expected"* ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual[*]}" "to not contain" "${expected}"
-    return
+    return 1
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -71,3 +71,10 @@ ${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
     ${_COLOR_FAINT}%s${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
     "${test_name}" "${expected}" "${failure_condition_message}" "${actual}"
 }
+
+function Console::printErrorTest() {
+  local test_name=$1
+  local error_code=$2
+
+  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s with error code %s\n" "${test_name}" "${error_code}"
+}

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -44,3 +44,24 @@ function test_fail() { assertEquals \"1\" \"0\" ; }" > $test_file
 
   rm $test_file
 }
+
+function test_bash_unit_when_a_test_execution_error() {
+  local test_file=./tests/acceptance/fake_error_test.sh
+  fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
+\e[31m✗ Failed\e[0m: test_error with error code 127
+
+\e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
+\e[2mAssertions:\e[0m \e[31m0 failed\e[0m, 0 total")
+
+  echo "
+#!/bin/bash
+function test_error() { invalidFunctionName 2>/dev/null ; }" > $test_file
+
+  assertContains\
+   "$fixture"\
+    "$(./bashunit "$test_file")"
+
+  assertGeneralError "$(./bashunit "$test_file")"
+
+  rm $test_file
+}


### PR DESCRIPTION
## 📚 Description

In case a test fails because an error inside, it will be marked as failed and it will show the result code error:

![imagen](https://github.com/TypedDevs/bashunit/assets/109357/f71a0399-3c95-4359-8eb1-0c172257c2ed)

![imagen](https://github.com/TypedDevs/bashunit/assets/109357/1c62f734-4f92-43a5-9756-b00bada2f61a)


## ✅ To-do list

- [ ] Make sure that all the pipeline passes
- [ ] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
