### PR TITLE
Manage error when test execution fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
     - `assertArrayContains` -> `assert_array_contains`
     - `assertArrayNotContains` -> `assert_array_not_contains`
 
+- Manage error when test execution fails
+
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
 - Added `assertExitCode`

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -19,8 +19,6 @@ function assert_equals() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_empty instead.
@@ -41,8 +39,6 @@ function assert_empty() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_not_empty instead.
@@ -63,8 +59,6 @@ function assert_not_empty() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_not_equals instead.
@@ -86,8 +80,6 @@ function assert_not_equals() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_contains instead.
@@ -109,8 +101,6 @@ function assert_contains() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_not_contains instead.
@@ -132,8 +122,6 @@ function assert_not_contains() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_matches instead.
@@ -155,8 +143,6 @@ function assert_matches() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_not_matches instead.
@@ -178,8 +164,6 @@ function assert_not_matches() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_exit_code instead.
@@ -202,8 +186,6 @@ function assert_exit_code() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_successful_code instead.
@@ -226,8 +208,6 @@ function assert_successful_code() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_general_error instead.
@@ -250,8 +230,6 @@ function assert_general_error() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_command_not_found instead.
@@ -274,8 +252,6 @@ function assert_command_not_found() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_array_contains instead.
@@ -298,8 +274,6 @@ function assert_array_contains() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 
 # Deprecated: Please use assert_array_not_contains instead.
@@ -320,7 +294,5 @@ function assert_array_not_contains() {
   fi
 
   State::addAssertionsPassed
-
-  return 0
 }
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -19,6 +19,8 @@ function assert_equals() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_empty instead.
@@ -39,6 +41,8 @@ function assert_empty() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_not_empty instead.
@@ -59,6 +63,8 @@ function assert_not_empty() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_not_equals instead.
@@ -80,6 +86,8 @@ function assert_not_equals() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_contains instead.
@@ -101,6 +109,8 @@ function assert_contains() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_not_contains instead.
@@ -122,6 +132,8 @@ function assert_not_contains() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_matches instead.
@@ -143,6 +155,8 @@ function assert_matches() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_not_matches instead.
@@ -164,6 +178,8 @@ function assert_not_matches() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_exit_code instead.
@@ -186,6 +202,8 @@ function assert_exit_code() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_successful_code instead.
@@ -208,6 +226,8 @@ function assert_successful_code() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_general_error instead.
@@ -230,6 +250,8 @@ function assert_general_error() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_command_not_found instead.
@@ -252,6 +274,8 @@ function assert_command_not_found() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_array_contains instead.
@@ -274,6 +298,8 @@ function assert_array_contains() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 
 # Deprecated: Please use assert_array_not_contains instead.
@@ -294,5 +320,7 @@ function assert_array_not_contains() {
   fi
 
   State::addAssertionsPassed
+
+  return 0
 }
 

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -71,3 +71,10 @@ ${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
     ${_COLOR_FAINT}%s${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
     "${test_name}" "${expected}" "${failure_condition_message}" "${actual}"
 }
+
+function Console::printErrorTest() {
+  local test_name=$1
+  local error_code=$2
+
+  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s with error code %s\n" "${test_name}" "${error_code}"
+}

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -39,6 +39,8 @@ function Helper::checkDuplicateFunctions() {
     State::setDuplicatedTestFunctionsFound
     return 1
   fi
+
+  return 0
 }
 
 #
@@ -98,8 +100,5 @@ function Helper::unsetIfExists() {
 
   if declare -F | awk '{print $3}' | grep -Eq "^${function_name}$"; then
     unset "$function_name"
-    return 0
   fi
-
-  return 1
 }

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -39,8 +39,6 @@ function Helper::checkDuplicateFunctions() {
     State::setDuplicatedTestFunctionsFound
     return 1
   fi
-
-  return 0
 }
 
 #

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -56,12 +56,15 @@ function Runner::callTestFunctions() {
 function Runner::parseExecutionResult() {
   local execution_result=$1
 
-  local assertions_failed=$(\
+  local assertions_failed
+  assertions_failed=$(\
     echo "$execution_result" |\
     tail -n 1 |\
     sed -E -e 's/.*##ASSERTIONS_FAILED=([0-9]*)##.*/\1/g'\
   )
-  local assertions_passed=$(\
+
+  local assertions_passed
+  assertions_passed=$(\
     echo "$execution_result" |\
     tail -n 1 |\
     sed -E -e 's/.*##ASSERTIONS_PASSED=([0-9]*)##.*/\1/g'\
@@ -70,7 +73,8 @@ function Runner::parseExecutionResult() {
   _ASSERTIONS_PASSED=$((_ASSERTIONS_PASSED + assertions_passed))
   _ASSERTIONS_FAILED=$((_ASSERTIONS_FAILED + assertions_failed))
 
-  local print_execution_result="$(echo "$execution_result" | sed '$ d')"
+  local print_execution_result
+  print_execution_result="$(echo "$execution_result" | sed '$ d')"
 
   if [ -n "$print_execution_result" ]; then
     echo "$print_execution_result"

--- a/src/state.sh
+++ b/src/state.sh
@@ -12,6 +12,7 @@ function State::getTestsPassed() {
 
 function State::addTestsPassed() {
   ((_TESTS_PASSED++))
+  return 0
 }
 
 function State::getTestsFailed() {
@@ -20,6 +21,7 @@ function State::getTestsFailed() {
 
 function State::addTestsFailed() {
   ((_TESTS_FAILED++))
+  return 0
 }
 
 function State::getAssertionsPassed() {
@@ -27,7 +29,8 @@ function State::getAssertionsPassed() {
 }
 
 function State::addAssertionsPassed() {
-  ((_ASSERTIONS_PASSED++))
+  ((_ASSERTIONS_PASSED++)) || true
+  return 0
 }
 
 function State::getAssertionsFailed() {
@@ -35,7 +38,8 @@ function State::getAssertionsFailed() {
 }
 
 function State::addAssertionsFailed() {
-  ((_ASSERTIONS_FAILED++))
+  ((_ASSERTIONS_FAILED++)) || true
+  return 0
 }
 
 function State::isDuplicatedTestFunctionsFound() {
@@ -44,4 +48,14 @@ function State::isDuplicatedTestFunctionsFound() {
 
 function State::setDuplicatedTestFunctionsFound() {
   _DUPLICATED_TEST_FUNCTIONS_FOUND=true
+  return 0
+}
+
+function State::initializeAssertionsCount() {
+    _ASSERTIONS_PASSED=0
+    _ASSERTIONS_FAILED=0
+}
+
+function State::exportAssertionsCount() {
+  echo "##ASSERTIONS_FAILED=$_ASSERTIONS_FAILED##ASSERTIONS_PASSED=$_ASSERTIONS_PASSED##"
 }

--- a/src/state.sh
+++ b/src/state.sh
@@ -11,8 +11,7 @@ function State::getTestsPassed() {
 }
 
 function State::addTestsPassed() {
-  ((_TESTS_PASSED++))
-  return 0
+  ((_TESTS_PASSED++)) || true
 }
 
 function State::getTestsFailed() {
@@ -20,8 +19,7 @@ function State::getTestsFailed() {
 }
 
 function State::addTestsFailed() {
-  ((_TESTS_FAILED++))
-  return 0
+  ((_TESTS_FAILED++)) || true
 }
 
 function State::getAssertionsPassed() {
@@ -30,7 +28,6 @@ function State::getAssertionsPassed() {
 
 function State::addAssertionsPassed() {
   ((_ASSERTIONS_PASSED++)) || true
-  return 0
 }
 
 function State::getAssertionsFailed() {
@@ -39,7 +36,6 @@ function State::getAssertionsFailed() {
 
 function State::addAssertionsFailed() {
   ((_ASSERTIONS_FAILED++)) || true
-  return 0
 }
 
 function State::isDuplicatedTestFunctionsFound() {
@@ -48,7 +44,6 @@ function State::isDuplicatedTestFunctionsFound() {
 
 function State::setDuplicatedTestFunctionsFound() {
   _DUPLICATED_TEST_FUNCTIONS_FOUND=true
-  return 0
 }
 
 function State::initializeAssertionsCount() {

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -18,7 +18,7 @@ function spy() {
   export "${command}_times"=0
   export "${command}_params"
 
-  eval "function $command() { ${command}_params=(\"\$*\"); ((${command}_times++)); }"
+  eval "function $command() { ${command}_params=(\"\$*\"); ((${command}_times++)) || true; }"
 
   export -f "${command?}"
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -44,3 +44,29 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
   rm $test_file
 }
+
+function test_bash_unit_when_a_test_execution_error() {
+  local test_file=./tests/acceptance/fake_error_test.sh
+  fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
+\e[31m✗ Failed\e[0m: test_error with error code 127
+
+\e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
+\e[2mAssertions:\e[0m \e[31m0 failed\e[0m, 0 total")
+
+  echo "
+#!/bin/bash
+function test_error() {
+  invalidFunctionName 2>/dev/null
+  assertGeneralError
+}" > $test_file
+
+  set +e
+
+  assertContains\
+   "$fixture"\
+    "$(./bashunit "$test_file")"
+
+  assertGeneralError "$(./bashunit "$test_file")"
+
+  rm $test_file
+}

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -39,6 +39,8 @@ function test_should_validate_a_non_ok_exit_code() {
     return 1
   }
 
+  set +e
+
   fake_function
 
   assert_exit_code "1"

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -113,11 +113,7 @@ function test_unsuccessful_return_assert_exit_code() {
     return 1
   }
 
-  (
-    set +e
-    fake_function
-    assert_exit_code "1"
-  )
+  assert_exit_code "1" "$(fake_function)"
 }
 
 function test_successful_assert_successful_code() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -113,9 +113,11 @@ function test_unsuccessful_return_assert_exit_code() {
     return 1
   }
 
-  fake_function
-
-  assert_exit_code "1"
+  (
+    set +e
+    fake_function
+    assert_exit_code "1"
+  )
 }
 
 function test_successful_assert_successful_code() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -66,7 +66,7 @@ function test_no_function_is_executed_with_execute_function_if_exists() {
   assert_empty "$(Helper::executeFunctionIfExists "$function_name")"
 }
 
-function test_unsuccessful_unsetIfExists() {
+function test_successful_unsetIfExists_non_existent_function() {
   assert_successful_code "$(Helper::unsetIfExists "fake_function")"
 }
 

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -67,7 +67,7 @@ function test_no_function_is_executed_with_execute_function_if_exists() {
 }
 
 function test_unsuccessful_unsetIfExists() {
-  assert_general_error "$(Helper::unsetIfExists "fake_function")"
+  assert_successful_code "$(Helper::unsetIfExists "fake_function")"
 }
 
 function test_successful_unsetIfExists() {

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+function test_add_and_get_tests_passed() {
+    local tests_passed=$(
+        _TESTS_PASSED=0
+
+        State::addTestsPassed
+        State::getTestsPassed
+    )
+
+    assertEquals "1" "$tests_passed"
+}
+
+function test_add_and_get_tests_failed() {
+    local tests_failed=$(
+        _TESTS_FAILED=0
+
+        State::addTestsFailed
+        State::getTestsFailed
+    )
+
+    assertEquals "1" "$tests_failed"
+}
+
+function test_add_and_get_assertions_passed() {
+    local assertions_passed=$(
+        _ASSERTIONS_PASSED=0
+
+        State::addAssertionsPassed
+        State::getAssertionsPassed
+    )
+
+    assertEquals "1" "$assertions_passed"
+}
+
+function test_add_and_get_assertions_failed() {
+    local assertions_failed=$(
+        _ASSERTIONS_FAILED=0
+
+        State::addAssertionsFailed
+        State::getAssertionsFailed
+    )
+
+    assertEquals "1" "$assertions_failed"
+}
+
+function test_set_and_is_duplicated_test_functions_found() {
+    local duplicated_test_functions_found=$(
+        _DUPLICATED_TEST_FUNCTIONS_FOUND=false
+
+        State::setDuplicatedTestFunctionsFound
+        State::isDuplicatedTestFunctionsFound
+    )
+
+    assertEquals "true" "$duplicated_test_functions_found"
+}
+
+function test_initialize_assertions_count() {
+    local export_assertions_count=$(
+        _ASSERTIONS_PASSED=10
+        _ASSERTIONS_FAILED=5
+
+        State::initializeAssertionsCount
+        State::exportAssertionsCount
+    )
+
+    assertEquals "##ASSERTIONS_FAILED=0##ASSERTIONS_PASSED=0##" "$export_assertions_count"
+}
+
+function test_export_assertions_count() {
+    local export_assertions_count=$(
+        _ASSERTIONS_PASSED=10
+        _ASSERTIONS_FAILED=5
+
+        State::exportAssertionsCount
+    )
+
+    assertEquals "##ASSERTIONS_FAILED=5##ASSERTIONS_PASSED=10##" "$export_assertions_count"
+}


### PR DESCRIPTION
## 📚 Description

I have created a new PR (coming from https://github.com/TypedDevs/bashunit/pull/105) from a new branch in this repository so now we can work together on it.

In case a test fails because an error inside, it will be marked as failed and it will show the result code error:

![imagen](https://github.com/TypedDevs/bashunit/assets/109357/bb3572e3-4854-4ef0-a3bc-c37c4462b4fc)

![imagen](https://github.com/TypedDevs/bashunit/assets/109357/e946875b-493b-4f23-b2ab-a32c57fe2a26)

The main objective is execute the tests in a subshell with the `set -e`. The problem with this is that in the subshell we don't have access to the same state variables of the parent shell so we can't increase the assertion count from the subshell.

To avoid this problem, the idea is return (printing) the total of assertions failed and passed in the subshell and then in the main runner shell we have to parse this output and get the assertions failed and passed so we can increase them now in the main shell. 

There are some side effects I have changed too:
- Assert and helper functions should return 0 to prevent being stopped
- Test files for testing errors (like tests/acceptance/bashunit_test.sh) need to be executed in a subhell with `set +e` to prevent being catch by the main shell.