### PR TITLE
Make boxes slightly less dark for the bashunit webpage

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -141,7 +141,7 @@ h1, h2, h3, h4, h5, h6 {
   --vp-c-bg: #232729;
   --vp-c-bg-alt: #171a1b;
   --vp-c-bg-elv: #0c0d0e;
-  --vp-c-bg-soft: #0c0d0e;
+  --vp-c-bg-soft: #1a1a1a;
 }
 
 /**
@@ -176,8 +176,4 @@ h1, h2, h3, h4, h5, h6 {
   height: 2rem;
   object-fit: contain;
   object-position: center;
-}
-
-.box {
-  background-color: #3b3c392e;
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -177,3 +177,7 @@ h1, h2, h3, h4, h5, h6 {
   object-fit: contain;
   object-position: center;
 }
+
+.box {
+  background-color: #3b3c392e;
+}


### PR DESCRIPTION
## 📚 Description

Make boxes slightly less dark for bashunit webpage


## Ⓜ️ Difference
Left is before, right is after with the new change. 

![image](https://github.com/TypedDevs/bashunit/assets/80126839/5b5d29ff-e935-4eea-b8c0-c5fae1c7350f)
## 🔖 Changes

Add in style.css:
```css
.box {
  background-color: #3b3c392e;
}
```

