### PR TITLE
Use snake_case assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - `assertEmpty` -> `assert_empty`
   - `assertNotEmpty` -> `assert_not_empty`
   - `assertContains` -> `assert_contains`
+  - `assertNotContains` -> `assert_not_contains`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - `assertNotEquals` -> `assert_not_equals`
   - `assertEmpty` -> `assert_empty`
   - `assertNotEmpty` -> `assert_not_empty`
+  - `assertContains` -> `assert_contains`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@
   - `assertMatches` -> `assert_matches`
   - `assertNotMatches` -> `assert_not_matches`
   - `assertExitCode` -> `assert_exit_code`
+  - `assertSuccessfulCode` -> `assert_successful_code`
+  - `assert_general_error` -> `assert_general_error`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
 - Added `assertExitCode`
 - Added `assert_successful_code`
-- Added `assertGeneralError`
+- Added `assert_general_error`
 - Added `assertCommandNotFound`
 - Added `assertArrayContains`
 - Added `assertArrayNotContains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,15 @@
   - `assertNotMatches` -> `assert_not_matches`
   - `assertExitCode` -> `assert_exit_code`
   - `assertSuccessfulCode` -> `assert_successful_code`
-  - `assert_general_error` -> `assert_general_error`
+  - `assertGeneralError` -> `assert_general_error`
+  - `assertCommandNotFound` -> `assert_command_not_found`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
 - Added `assertExitCode`
 - Added `assert_successful_code`
 - Added `assert_general_error`
-- Added `assertCommandNotFound`
+- Added `assert_command_not_found`
 - Added `assertArrayContains`
 - Added `assertArrayNotContains`
 - Added `assertEmpty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   - `assertNotEmpty` -> `assert_not_empty`
   - `assertContains` -> `assert_contains`
   - `assertNotContains` -> `assert_not_contains`
+  - `assertMatches` -> `assert_matches`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Rename assertions from camelCase to snake_case:
   - `assertEquals` -> `assert_equals`
   - `assertEmpty` -> `assert_empty`
+  - `assertNotEmpty` -> `assert_not_empty`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
 - Added `assertExitCode`
-- Added `assertSuccessfulCode`
+- Added `assert_successful_code`
 - Added `assertGeneralError`
 - Added `assertCommandNotFound`
 - Added `assertArrayContains`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - `assertHaveBeenCalledWith`
 - `assertHaveBeenCalled`
 - `assertHaveBeenCalledTimes`
+- Rename assertions from camelCase to snake_case:
+  - `assertEquals` -> `assert_equals`
+  - `assertEmpty` -> `assert_empty`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
 - `mock`
 - `spy`
-- `assertHaveBeenCalledWith`
+- `assert_have_been_called_with`
 - `assertHaveBeenCalled`
 - `assertHaveBeenCalledTimes`
 - Rename assertions from camelCase to snake_case:
@@ -21,6 +21,7 @@
     - `assertCommandNotFound` -> `assert_command_not_found`
     - `assertArrayContains` -> `assert_array_contains`
     - `assertArrayNotContains` -> `assert_array_not_contains`
+    - `assertHaveBeenCalledWith` -> `assert_have_been_called_with`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `assertSuccessfulCode` -> `assert_successful_code`
   - `assertGeneralError` -> `assert_general_error`
   - `assertCommandNotFound` -> `assert_command_not_found`
+  - `assertArrayContains` -> `assert_array_contains`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
@@ -26,7 +27,7 @@
 - Added `assert_successful_code`
 - Added `assert_general_error`
 - Added `assert_command_not_found`
-- Added `assertArrayContains`
+- Added `assert_array_contains`
 - Added `assertArrayNotContains`
 - Added `assertEmpty`
 - Added `assertNotEmpty`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - `assertGeneralError` -> `assert_general_error`
   - `assertCommandNotFound` -> `assert_command_not_found`
   - `assertArrayContains` -> `assert_array_contains`
+  - `assertArrayNotContains` -> `assert_array_not_contains`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
@@ -28,7 +29,7 @@
 - Added `assert_general_error`
 - Added `assert_command_not_found`
 - Added `assert_array_contains`
-- Added `assertArrayNotContains`
+- Added `assert_array_not_contains`
 - Added `assertEmpty`
 - Added `assertNotEmpty`
 - Added `setUp`, `setUpBeforeScript`, `tearDown` and `tearDownAfterScript` function execution before and/or after test and/or script execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   - `assertContains` -> `assert_contains`
   - `assertNotContains` -> `assert_not_contains`
   - `assertMatches` -> `assert_matches`
+  - `assertNotMatches` -> `assert_not_matches`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
 - `mock`
 - `spy`
-- `assert_have_been_called_with`
 - `assert_have_been_called`
+- `assert_have_been_called_with`
 - `assert_have_been_called_times`
 - Rename assertions from camelCase to snake_case:
     - `assertEquals` -> `assert_equals`
@@ -21,18 +21,15 @@
     - `assertCommandNotFound` -> `assert_command_not_found`
     - `assertArrayContains` -> `assert_array_contains`
     - `assertArrayNotContains` -> `assert_array_not_contains`
-    - `assertHaveBeenCalled` -> `assert_have_been_called`
-    - `assertHaveBeenCalledWith` -> `assert_have_been_called_with`
-    - `assertHaveBeenCalledTimes` -> `assert_have_been_called_times`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 
 - Added `assertExitCode`
-- Added `assert_successful_code`
-- Added `assert_general_error`
-- Added `assert_command_not_found`
-- Added `assert_array_contains`
-- Added `assert_array_not_contains`
+- Added `assertSuccessfulCode`
+- Added `assertGeneralError`
+- Added `assertCommandNotFound`
+- Added `assertArrayContains`
+- Added `assertArrayNotContains`
 - Added `assertEmpty`
 - Added `assertNotEmpty`
 - Added `setUp`, `setUpBeforeScript`, `tearDown` and `tearDownAfterScript` function execution before and/or after test and/or script execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,20 +7,20 @@
 - `assertHaveBeenCalled`
 - `assertHaveBeenCalledTimes`
 - Rename assertions from camelCase to snake_case:
-  - `assertEquals` -> `assert_equals`
-  - `assertNotEquals` -> `assert_not_equals`
-  - `assertEmpty` -> `assert_empty`
-  - `assertNotEmpty` -> `assert_not_empty`
-  - `assertContains` -> `assert_contains`
-  - `assertNotContains` -> `assert_not_contains`
-  - `assertMatches` -> `assert_matches`
-  - `assertNotMatches` -> `assert_not_matches`
-  - `assertExitCode` -> `assert_exit_code`
-  - `assertSuccessfulCode` -> `assert_successful_code`
-  - `assertGeneralError` -> `assert_general_error`
-  - `assertCommandNotFound` -> `assert_command_not_found`
-  - `assertArrayContains` -> `assert_array_contains`
-  - `assertArrayNotContains` -> `assert_array_not_contains`
+    - `assertEquals` -> `assert_equals`
+    - `assertNotEquals` -> `assert_not_equals`
+    - `assertEmpty` -> `assert_empty`
+    - `assertNotEmpty` -> `assert_not_empty`
+    - `assertContains` -> `assert_contains`
+    - `assertNotContains` -> `assert_not_contains`
+    - `assertMatches` -> `assert_matches`
+    - `assertNotMatches` -> `assert_not_matches`
+    - `assertExitCode` -> `assert_exit_code`
+    - `assertSuccessfulCode` -> `assert_successful_code`
+    - `assertGeneralError` -> `assert_general_error`
+    - `assertCommandNotFound` -> `assert_command_not_found`
+    - `assertArrayContains` -> `assert_array_contains`
+    - `assertArrayNotContains` -> `assert_array_not_contains`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - `mock`
 - `spy`
 - `assert_have_been_called_with`
-- `assertHaveBeenCalled`
-- `assertHaveBeenCalledTimes`
+- `assert_have_been_called`
+- `assert_have_been_called_times`
 - Rename assertions from camelCase to snake_case:
     - `assertEquals` -> `assert_equals`
     - `assertNotEquals` -> `assert_not_equals`
@@ -21,7 +21,9 @@
     - `assertCommandNotFound` -> `assert_command_not_found`
     - `assertArrayContains` -> `assert_array_contains`
     - `assertArrayNotContains` -> `assert_array_not_contains`
+    - `assertHaveBeenCalled` -> `assert_have_been_called`
     - `assertHaveBeenCalledWith` -> `assert_have_been_called_with`
+    - `assertHaveBeenCalledTimes` -> `assert_have_been_called_times`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - `assertNotContains` -> `assert_not_contains`
   - `assertMatches` -> `assert_matches`
   - `assertNotMatches` -> `assert_not_matches`
+  - `assertExitCode` -> `assert_exit_code`
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `assertHaveBeenCalledTimes`
 - Rename assertions from camelCase to snake_case:
   - `assertEquals` -> `assert_equals`
+  - `assertNotEquals` -> `assert_not_equals`
   - `assertEmpty` -> `assert_empty`
   - `assertNotEmpty` -> `assert_not_empty`
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -83,7 +83,7 @@ Reports an error if the exit code of `callable` is not equal to `expected`.
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_successful_code](#assert_successful_code), [assert_general_error](#assert_general_error) and [assertCommandNotFound](#assertcommandnotfound)
+[assert_successful_code](#assert_successful_code), [assert_general_error](#assert_general_error) and [assert_command_not_found](#assert_command_not_found)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
 *Example:*
@@ -213,7 +213,7 @@ function test_failure() {
 }
 ```
 
-## assertCommandNotFound
+## assert_command_not_found
 > `assert_general_error ["callable"]`
 
 Reports an error if `callable` exists.
@@ -226,17 +226,17 @@ If `callable` is not provided, it takes the last executed command or function in
 *Example:*
 ```bash
 function test_success_with_callable() {
-  assertCommandNotFound "$(foo > /dev/null 2>&1)"
+  assert_command_not_found "$(foo > /dev/null 2>&1)"
 }
 
 function test_success_without_callable() {
   foo > /dev/null 2>&1
 
-  assertCommandNotFound
+  assert_command_not_found
 }
 
 function test_failure() {
-  assertCommandNotFound "$(ls > /dev/null 2>&1)"
+  assert_command_not_found "$(ls > /dev/null 2>&1)"
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -4,8 +4,8 @@ When creating tests, you'll need to verify your commands and functions.
 We provide assertions for these checks.
 Below is their documentation.
 
-## assertEquals
-> `assertEquals "expected" "actual"`
+## assert_equals
+> `assert_equals "expected" "actual"`
 
 Reports an error if the two variables `expected` and `actual` are not equal.
 
@@ -14,11 +14,11 @@ Reports an error if the two variables `expected` and `actual` are not equal.
 *Example:*
 ```bash
 function test_success() {
-  assertEquals "foo" "foo"
+  assert_equals "foo" "foo"
 }
 
 function test_failure() {
-  assertEquals "foo" "bar"
+  assert_equals "foo" "bar"
 }
 ```
 
@@ -245,7 +245,7 @@ function test_failure() {
 
 Reports an error if the two variables `expected` and `actual` are equal.
 
-[assertEquals](#assertequals) is the inverse of this assertion and takes the same arguments.
+[assert_equals](#assert_equals) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -40,8 +40,8 @@ function test_failure() {
 }
 ```
 
-## assertEmpty
-> `assertEmpty "actual"`
+## assert_empty
+> `assert_empty "actual"`
 
 Reports an error if `actual` is not empty.
 
@@ -50,11 +50,11 @@ Reports an error if `actual` is not empty.
 *Example:*
 ```bash
 function test_success() {
-  assertEmpty ""
+  assert_empty ""
 }
 
 function test_failure() {
-  assertEmpty "foo"
+  assert_empty "foo"
 }
 ```
 
@@ -281,7 +281,7 @@ function test_failure() {
 
 Reports an error if `actual` is empty.
 
-[assertEmpty](#assertempty) is the inverse of this assertion and takes the same arguments.
+[assert_empty](#assert_empty) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -76,8 +76,8 @@ function test_failure() {
 }
 ```
 
-## assertExitCode
-> `assertExitCode "expected" ["callable"]`
+## assert_exit_code
+> `assert_exit_code "expected" ["callable"]`
 
 Reports an error if the exit code of `callable` is not equal to `expected`.
 
@@ -93,7 +93,7 @@ function test_success_with_callable() {
     return 1
   }
 
-  assertExitCode "1" "$(foo)"
+  assert_exit_code "1" "$(foo)"
 }
 
 function test_success_without_callable() {
@@ -103,7 +103,7 @@ function test_success_without_callable() {
 
   foo # function took instead `callable`
 
-  assertExitCode "1"
+  assert_exit_code "1"
 }
 
 function test_failure() {
@@ -111,7 +111,7 @@ function test_failure() {
     return 1
   }
 
-  assertExitCode "0" "$(foo)"
+  assert_exit_code "0" "$(foo)"
 }
 ```
 
@@ -144,7 +144,7 @@ Reports an error if the exit code of `callable` is not successful (`0`).
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assertExitCode](#assertexitcode) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash
@@ -182,7 +182,7 @@ Reports an error if the exit code of `callable` is not a general error (`1`).
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assertExitCode](#assertexitcode) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash
@@ -221,7 +221,7 @@ In other words, if executing `callable` does not return a command not found exit
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assertExitCode](#assertexitcode) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -22,8 +22,8 @@ function test_failure() {
 }
 ```
 
-## assertContains
-> `assertContains "needle" "haystack"`
+## assert_contains
+> `assert_contains "needle" "haystack"`
 
 Reports an error if `needle` is not a substring of `haystack`.
 
@@ -32,11 +32,11 @@ Reports an error if `needle` is not a substring of `haystack`.
 *Example:*
 ```bash
 function test_success() {
-  assertContains "foo" "foobar"
+  assert_contains "foo" "foobar"
 }
 
 function test_failure() {
-  assertContains "baz" "foobar"
+  assert_contains "baz" "foobar"
 }
 ```
 
@@ -263,7 +263,7 @@ function test_failure() {
 
 Reports an error if `needle` is a substring of `haystack`.
 
-[assertContains](#assertcontains) is the inverse of this assertion and takes the same arguments.
+[assert_contains](#assert_contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -9,7 +9,7 @@ Below is their documentation.
 
 Reports an error if the two variables `expected` and `actual` are not equal.
 
-[assertNotEquals](#assertnotequals) is the inverse of this assertion and takes the same arguments.
+[assert_not_equals](#assert_not_equals) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -240,8 +240,8 @@ function test_failure() {
 }
 ```
 
-## assertNotEquals
-> `assertNotEquals "expected" "actual"`
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
 
 Reports an error if the two variables `expected` and `actual` are equal.
 
@@ -250,11 +250,11 @@ Reports an error if the two variables `expected` and `actual` are equal.
 *Example:*
 ```bash
 function test_success() {
-  assertNotEquals "foo" "bar"
+  assert_not_equals "foo" "bar"
 }
 
 function test_failure() {
-  assertNotEquals "foo" "foo"
+  assert_not_equals "foo" "foo"
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -9,7 +9,7 @@ Below is their documentation.
 
 Reports an error if the two variables `expected` and `actual` are not equal.
 
-[assert_not_equals](#assert_not_equals) is the inverse of this assertion and takes the same arguments.
+[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -45,7 +45,7 @@ function test_failure() {
 
 Reports an error if `actual` is not empty.
 
-[assert_not_empty](#assert_not_empty) is the inverse of this assertion and takes the same arguments.
+[assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -63,7 +63,7 @@ function test_failure() {
 
 Reports an error if `value` does not match the regular expression `pattern`.
 
-[assert_not_matches](#assert_not_matches) is the inverse of this assertion and takes the same arguments.
+[assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -83,7 +83,7 @@ Reports an error if the exit code of `callable` is not equal to `expected`.
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_successful_code](#assert_successful_code), [assert_general_error](#assert_general_error) and [assert_command_not_found](#assert_command_not_found)
+[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
 *Example:*
@@ -120,7 +120,7 @@ function test_failure() {
 
 Reports an error if `needle` is not an element of `haystack`.
 
-[assert_array_not_contains](#assert_array_not_contains) is the inverse of this assertion and takes the same arguments.
+[assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -144,7 +144,7 @@ Reports an error if the exit code of `callable` is not successful (`0`).
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash
@@ -182,7 +182,7 @@ Reports an error if the exit code of `callable` is not a general error (`1`).
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash
@@ -221,7 +221,7 @@ In other words, if executing `callable` does not return a command not found exit
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_exit_code](#assert_exit_code) is the full version of this assertion where you can specify the expected exit code.
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
 *Example:*
 ```bash
@@ -245,7 +245,7 @@ function test_failure() {
 
 Reports an error if the two variables `expected` and `actual` are equal.
 
-[assert_equals](#assert_equals) is the inverse of this assertion and takes the same arguments.
+[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -263,7 +263,7 @@ function test_failure() {
 
 Reports an error if `needle` is a substring of `haystack`.
 
-[assert_contains](#assert_contains) is the inverse of this assertion and takes the same arguments.
+[assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -281,7 +281,7 @@ function test_failure() {
 
 Reports an error if `actual` is empty.
 
-[assert_empty](#assert_empty) is the inverse of this assertion and takes the same arguments.
+[assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -299,7 +299,7 @@ function test_failure() {
 
 Reports an error if `value` matches the regular expression `pattern`.
 
-[assert_matches](#assert_matches) is the inverse of this assertion and takes the same arguments.
+[assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -317,7 +317,7 @@ function test_failure() {
 
 Reports an error if `needle` is an element of `haystack`.
 
-[assert_array_contains](#assert_array_contains) is the inverse of this assertion and takes the same arguments.
+[assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -27,7 +27,7 @@ function test_failure() {
 
 Reports an error if `needle` is not a substring of `haystack`.
 
-[assertNotContains](#assertnotcontains) is the inverse of this assertion and takes the same arguments.
+[assert_not_contains](#assert_not_contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -258,8 +258,8 @@ function test_failure() {
 }
 ```
 
-## assertNotContains
-> `assertNotContains "needle" "haystack"`
+## assert_not_contains
+> `assert_not_contains "needle" "haystack"`
 
 Reports an error if `needle` is a substring of `haystack`.
 
@@ -268,11 +268,11 @@ Reports an error if `needle` is a substring of `haystack`.
 *Example:*
 ```bash
 function test_success() {
-  assertNotContains "baz" "foobar"
+  assert_not_contains "baz" "foobar"
 }
 
 function test_failure() {
-  assertNotContains "foo" "foobar"
+  assert_not_contains "foo" "foobar"
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -27,7 +27,7 @@ function test_failure() {
 
 Reports an error if `needle` is not a substring of `haystack`.
 
-[assert_not_contains](#assert_not_contains) is the inverse of this assertion and takes the same arguments.
+[assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -45,7 +45,7 @@ function test_failure() {
 
 Reports an error if `actual` is not empty.
 
-[assertNotEmpty](#assertnotempty) is the inverse of this assertion and takes the same arguments.
+[assert_not_empty](#assert_not_empty) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -276,8 +276,8 @@ function test_failure() {
 }
 ```
 
-## assertNotEmpty
-> `assertNotEmpty "actual"`
+## assert_not_empty
+> `assert_not_empty "actual"`
 
 Reports an error if `actual` is empty.
 
@@ -286,11 +286,11 @@ Reports an error if `actual` is empty.
 *Example:*
 ```bash
 function test_success() {
-  assertNotEmpty "foo"
+  assert_not_empty "foo"
 }
 
 function test_failure() {
-  assertNotEmpty ""
+  assert_not_empty ""
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -83,7 +83,7 @@ Reports an error if the exit code of `callable` is not equal to `expected`.
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_successful_code](#assert_successful_code), [assertGeneralError](#assertgeneralerror) and [assertCommandNotFound](#assertcommandnotfound)
+[assert_successful_code](#assert_successful_code), [assert_general_error](#assert_general_error) and [assertCommandNotFound](#assertcommandnotfound)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
 *Example:*
@@ -175,8 +175,8 @@ function test_failure() {
 }
 ```
 
-## assertGeneralError
-> `assertGeneralError ["callable"]`
+## assert_general_error
+> `assert_general_error ["callable"]`
 
 Reports an error if the exit code of `callable` is not a general error (`1`).
 
@@ -191,7 +191,7 @@ function test_success_with_callable() {
     return 1
   }
 
-  assertGeneralError "$(foo)"
+  assert_general_error "$(foo)"
 }
 
 function test_success_without_callable() {
@@ -201,7 +201,7 @@ function test_success_without_callable() {
 
   foo # function took instead `callable`
 
-  assertGeneralError
+  assert_general_error
 }
 
 function test_failure() {
@@ -209,12 +209,12 @@ function test_failure() {
     return 0
   }
 
-  assertGeneralError "$(foo)"
+  assert_general_error "$(foo)"
 }
 ```
 
 ## assertCommandNotFound
-> `assertGeneralError ["callable"]`
+> `assert_general_error ["callable"]`
 
 Reports an error if `callable` exists.
 In other words, if executing `callable` does not return a command not found exit code (`127`).

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -120,7 +120,7 @@ function test_failure() {
 
 Reports an error if `needle` is not an element of `haystack`.
 
-[assertArrayNotContains](#assertarraynotcontains) is the inverse of this assertion and takes the same arguments.
+[assert_array_not_contains](#assert_array_not_contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -312,8 +312,8 @@ function test_failure() {
 }
 ```
 
-## assertArrayNotContains
-> `assertArrayNotContains "needle" "haystack"`
+## assert_array_not_contains
+> `assert_array_not_contains "needle" "haystack"`
 
 Reports an error if `needle` is an element of `haystack`.
 
@@ -324,12 +324,12 @@ Reports an error if `needle` is an element of `haystack`.
 function test_success() {
   local haystack=(foo bar baz)
 
-  assertArrayNotContains "foobar" "${haystack[@]}"
+  assert_array_not_contains "foobar" "${haystack[@]}"
 }
 
 function test_failure() {
   local haystack=(foo bar baz)
 
-  assertArrayNotContains "baz" "${haystack[@]}"
+  assert_array_not_contains "baz" "${haystack[@]}"
 }
 ```

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -83,7 +83,7 @@ Reports an error if the exit code of `callable` is not equal to `expected`.
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assertSuccessfulCode](#assertsuccessfulcode), [assertGeneralError](#assertgeneralerror) and [assertCommandNotFound](#assertcommandnotfound)
+[assert_successful_code](#assert_successful_code), [assertGeneralError](#assertgeneralerror) and [assertCommandNotFound](#assertcommandnotfound)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
 *Example:*
@@ -137,8 +137,8 @@ function test_failure() {
 }
 ```
 
-## assertSuccessfulCode
-> `assertSuccessfulCode ["callable"]`
+## assert_successful_code
+> `assert_successful_code ["callable"]`
 
 Reports an error if the exit code of `callable` is not successful (`0`).
 
@@ -153,7 +153,7 @@ function test_success_with_callable() {
     return 0
   }
 
-  assertSuccessfulCode "$(foo)"
+  assert_successful_code "$(foo)"
 }
 
 function test_success_without_callable() {
@@ -163,7 +163,7 @@ function test_success_without_callable() {
 
   foo # function took instead `callable`
 
-  assertSuccessfulCode
+  assert_successful_code
 }
 
 function test_failure() {
@@ -171,7 +171,7 @@ function test_failure() {
     return 1
   }
 
-  assertSuccessfulCode "$(foo)"
+  assert_successful_code "$(foo)"
 }
 ```
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -58,8 +58,8 @@ function test_failure() {
 }
 ```
 
-## assertMatches
-> `assertMatches "pattern" "value"`
+## assert_matches
+> `assert_matches "pattern" "value"`
 
 Reports an error if `value` does not match the regular expression `pattern`.
 
@@ -68,11 +68,11 @@ Reports an error if `value` does not match the regular expression `pattern`.
 *Example:*
 ```bash
 function test_success() {
-  assertMatches "^foo" "foobar"
+  assert_matches "^foo" "foobar"
 }
 
 function test_failure() {
-  assertMatches "^bar" "foobar"
+  assert_matches "^bar" "foobar"
 }
 ```
 
@@ -299,7 +299,7 @@ function test_failure() {
 
 Reports an error if `value` matches the regular expression `pattern`.
 
-[assertMatches](#assertmatches) is the inverse of this assertion and takes the same arguments.
+[assert_matches](#assert_matches) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -115,8 +115,8 @@ function test_failure() {
 }
 ```
 
-## assertArrayContains
-> `assertArrayContains "needle" "haystack"`
+## assert_array_contains
+> `assert_array_contains "needle" "haystack"`
 
 Reports an error if `needle` is not an element of `haystack`.
 
@@ -127,13 +127,13 @@ Reports an error if `needle` is not an element of `haystack`.
 function test_success() {
   local haystack=(foo bar baz)
 
-  assertArrayContains "bar" "${haystack[@]}"
+  assert_array_contains "bar" "${haystack[@]}"
 }
 
 function test_failure() {
   local haystack=(foo bar baz)
 
-  assertArrayContains "foobar" "${haystack[@]}"
+  assert_array_contains "foobar" "${haystack[@]}"
 }
 ```
 
@@ -317,7 +317,7 @@ function test_failure() {
 
 Reports an error if `needle` is an element of `haystack`.
 
-[assertArrayContains](#assertarraycontains) is the inverse of this assertion and takes the same arguments.
+[assert_array_contains](#assert_array_contains) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -63,7 +63,7 @@ function test_failure() {
 
 Reports an error if `value` does not match the regular expression `pattern`.
 
-[assertNotMatches](#assertnotmatches) is the inverse of this assertion and takes the same arguments.
+[assert_not_matches](#assert_not_matches) is the inverse of this assertion and takes the same arguments.
 
 *Example:*
 ```bash
@@ -294,8 +294,8 @@ function test_failure() {
 }
 ```
 
-## assertNotMatches
-> `assertNotMatches "pattern" "value"`
+## assert_not_matches
+> `assert_not_matches "pattern" "value"`
 
 Reports an error if `value` matches the regular expression `pattern`.
 
@@ -304,11 +304,11 @@ Reports an error if `value` matches the regular expression `pattern`.
 *Example:*
 ```bash
 function test_success() {
-  assertNotMatches "foo$" "foobar"
+  assert_not_matches "foo$" "foobar"
 }
 
 function test_failure() {
-  assertNotMatches "bar$" "foobar"
+  assert_not_matches "bar$" "foobar"
 }
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,7 +61,7 @@ Once **bashunit** is installed, you're ready to get started.
     #!/bin/bash
 
     function test_bashunit_is_working() {
-      assertEquals "bashunit is working" "bashunit is working"
+      assert_equals "bashunit is working" "bashunit is working"
     }
     ```
     ::: tip

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -12,7 +12,7 @@ function test_text_should_contain() {
 }
 
 function test_text_should_not_contain() {
-  assertNotContains "expecs" "$($SCRIPT "123")"
+  assert_not_contains "expecs" "$($SCRIPT "123")"
 }
 
 function test_text_should_match_a_regular_expression() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -57,7 +57,7 @@ function test_successful_exit_code() {
     return 0
   }
 
-  assertSuccessfulCode "$(fake_function)"
+  assert_successful_code "$(fake_function)"
 }
 
 function test_other_way_of_using_the_successful_exit_code() {
@@ -67,7 +67,7 @@ function test_other_way_of_using_the_successful_exit_code() {
 
   fake_function
 
-  assertSuccessfulCode
+  assert_successful_code
 }
 
 function test_general_error() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -95,7 +95,7 @@ function test_should_assert_exit_code_of_a_non_existing_command() {
 function test_should_assert_that_an_array_contains_1234() {
   local distros=(Ubuntu 1234 Linux\ Mint)
 
-  assertArrayContains "1234" "${distros[@]}"
+  assert_array_contains "1234" "${distros[@]}"
 }
 
 function test_should_assert_that_an_array_not_contains_1234() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -30,7 +30,7 @@ function test_should_validate_an_ok_exit_code() {
 
   fake_function
 
-  assertExitCode "0"
+  assert_exit_code "0"
 }
 
 
@@ -41,7 +41,7 @@ function test_should_validate_a_non_ok_exit_code() {
 
   fake_function
 
-  assertExitCode "1"
+  assert_exit_code "1"
 }
 
 function test_other_way_of_using_the_exit_code() {
@@ -49,7 +49,7 @@ function test_other_way_of_using_the_exit_code() {
     return 1
   }
 
-  assertExitCode "1" "$(fake_function)"
+  assert_exit_code "1" "$(fake_function)"
 }
 
 function test_successful_exit_code() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -20,7 +20,7 @@ function test_text_should_match_a_regular_expression() {
 }
 
 function test_text_should_not_match_a_regular_expression() {
-  assertNotMatches ".*xpes.*" "$($SCRIPT "123")"
+  assert_not_matches ".*xpes.*" "$($SCRIPT "123")"
 }
 
 function test_should_validate_an_ok_exit_code() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -75,7 +75,7 @@ function test_general_error() {
     return 1
   }
 
-  assertGeneralError "$(fake_function)"
+  assert_general_error "$(fake_function)"
 }
 
 function test_other_way_of_using_the_general_error() {
@@ -85,7 +85,7 @@ function test_other_way_of_using_the_general_error() {
 
   fake_function
 
-  assertGeneralError
+  assert_general_error
 }
 
 function test_should_assert_exit_code_of_a_non_existing_command() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -8,7 +8,7 @@ function test_text_should_be_equal() {
 }
 
 function test_text_should_contain() {
-  assertContains "expect" "$($SCRIPT "123")"
+  assert_contains "expect" "$($SCRIPT "123")"
 }
 
 function test_text_should_not_contain() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -16,7 +16,7 @@ function test_text_should_not_contain() {
 }
 
 function test_text_should_match_a_regular_expression() {
-  assertMatches ".*xpec*" "$($SCRIPT "123")"
+  assert_matches ".*xpec*" "$($SCRIPT "123")"
 }
 
 function test_text_should_not_match_a_regular_expression() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -101,5 +101,5 @@ function test_should_assert_that_an_array_contains_1234() {
 function test_should_assert_that_an_array_not_contains_1234() {
   local distros=(Ubuntu 1234 Linux\ Mint)
 
-  assertArrayNotContains "a_non_existing_element" "${distros[@]}"
+  assert_array_not_contains "a_non_existing_element" "${distros[@]}"
 }

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -89,7 +89,7 @@ function test_other_way_of_using_the_general_error() {
 }
 
 function test_should_assert_exit_code_of_a_non_existing_command() {
-  assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)"
+  assert_command_not_found "$(a_non_existing_function > /dev/null 2>&1)"
 }
 
 function test_should_assert_that_an_array_contains_1234() {

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -4,7 +4,7 @@ ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."
 SCRIPT="$ROOT_DIR/example/logic.sh"
 
 function test_text_should_be_equal() {
-  assertEquals "expected 123" "$($SCRIPT "123")"
+  assert_equals "expected 123" "$($SCRIPT "123")"
 }
 
 function test_text_should_contain() {

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -256,9 +256,7 @@ function assert_command_not_found() {
 
 # Deprecated: Please use assert_array_contains instead.
 function assertArrayContains() {
-  local expected="$1"
-
-  assert_array_contains "$expected" "${@:2}"
+  assert_array_contains "$1" "${@:2}"
 }
 
 function assert_array_contains() {
@@ -277,8 +275,12 @@ function assert_array_contains() {
   State::addAssertionsPassed
 }
 
-
+# Deprecated: Please use assert_array_not_contains instead.
 function assertArrayNotContains() {
+  assert_array_not_contains "$1" "${@:1}"
+}
+
+function assert_array_not_contains() {
   local expected="$1"
   label="$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")"
   shift

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -41,9 +41,16 @@ function assert_empty() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_not_empty instead.
 function assertNotEmpty() {
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_not_empty "$1" "$label"
+}
+
+function assert_not_empty() {
   local expected="$1"
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if [[ "$expected" == "" ]]; then
     State::addAssertionsFailed

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -145,7 +145,14 @@ function assert_matches() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_not_matches instead.
 function assertNotMatches() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_not_matches "$1" "$2" "$label"
+}
+
+function assert_not_matches() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -103,7 +103,14 @@ function assert_contains() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_not_contains instead.
 function assertNotContains() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_not_contains "$1" "$2" "$label"
+}
+
+function assert_not_contains() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -124,7 +124,14 @@ function assert_not_contains() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_matches instead.
 function assertMatches() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_matches "$1" "$2" "$label"
+}
+
+function assert_matches() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -232,11 +232,18 @@ function assert_general_error() {
   State::addAssertionsPassed
 }
 
-
+# Deprecated: Please use assert_command_not_found instead.
 function assertCommandNotFound() {
   local actual_exit_code=$?
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_command_not_found "{command}" "$label" "$actual_exit_code"
+}
+
+function assert_command_not_found() {
+  local actual_exit_code=${3-"$?"}
   local expected_exit_code=127
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -61,7 +61,14 @@ function assert_not_empty() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_not_equals instead.
 function assertNotEquals() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_not_equals "$1" "$2" "$label"
+}
+
+function assert_not_equals() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -166,12 +166,20 @@ function assert_not_matches() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_exit_code instead.
 function assertExitCode() {
   local actual_exit_code=$?
-  local expected_exit_code="$1"
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
-  if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
+  assert_exit_code "$1" "$label" "$actual_exit_code"
+}
+
+function assert_exit_code() {
+  local actual_exit_code=${3-"$?"}
+  local expected_exit_code="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ "$actual_exit_code" -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be" "${expected_exit_code}"
     return

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -21,9 +21,16 @@ function assert_equals() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_empty instead.
 function assertEmpty() {
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_empty "$1" "$label"
+}
+
+function assert_empty() {
   local expected="$1"
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if [[ "$expected" != "" ]]; then
     State::addAssertionsFailed

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -82,7 +82,14 @@ function assert_not_equals() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_contains instead.
 function assertContains() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_contains "$1" "$2" "$label"
+}
+
+function assert_contains() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -210,10 +210,18 @@ function assert_successful_code() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_general_error instead.
 function assertGeneralError() {
   local actual_exit_code=$?
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_general_error "$1" "$label" "$actual_exit_code"
+}
+
+function assert_general_error() {
+  local actual_exit_code=${3-"$?"}
   local expected_exit_code=1
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -188,12 +188,20 @@ function assert_exit_code() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_successful_code instead.
 function assertSuccessfulCode() {
   local actual_exit_code=$?
-  local expected_exit_code=0
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
-  if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
+  assert_successful_code "$1" "$label" "$actual_exit_code"
+}
+
+function assert_successful_code() {
+  local actual_exit_code=${3-"$?"}
+  local expected_exit_code=0
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ "$actual_exit_code" -ne "$expected_exit_code" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${actual_exit_code}" "to be exactly" "${expected_exit_code}"
     return

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+# Deprecated: Please use assert_equals instead.
 function assertEquals() {
+  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  assert_equals "$1" "$2" "$label"
+}
+
+function assert_equals() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -254,11 +254,19 @@ function assert_command_not_found() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_array_contains instead.
 function assertArrayContains() {
   local expected="$1"
-  label="$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")"
+
+  assert_array_contains "$expected" "${@:2}"
+}
+
+function assert_array_contains() {
+  local expected="$1"
+  local label="$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")"
   shift
-  local actual=("$@")
+
+  local actual=("${@}")
 
   if ! [[ "${actual[*]}" == *"$expected"* ]]; then
     State::addAssertionsFailed
@@ -268,6 +276,7 @@ function assertArrayContains() {
 
   State::addAssertionsPassed
 }
+
 
 function assertArrayNotContains() {
   local expected="$1"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -261,7 +261,8 @@ function assertArrayContains() {
 
 function assert_array_contains() {
   local expected="$1"
-  local label="$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")"
+  local label
+  label="$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")"
   shift
 
   local actual=("${@}")

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -23,6 +23,26 @@ function spy() {
   export -f "${command?}"
 }
 
+# Deprecated: Please use assert_have_been_called instead.
+function assertHaveBeenCalled() {
+  assert_have_been_called "$1" "$2"
+}
+
+function assert_have_been_called() {
+  local command=$1
+  local actual
+  actual="${command}_times"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ${!actual} -eq 0 ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${command}" "has not been called at least" "once"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
 # Deprecated: Please use assert_have_been_called_with instead.
 function assertHaveBeenCalledWith() {
   assert_have_been_called_with "$1" "$2" "$3"
@@ -38,26 +58,6 @@ function assert_have_been_called_with() {
   if [[ "$expected" != "${!actual}" ]]; then
     State::addAssertionsFailed
     Console::printFailedTest "${label}" "${expected}" "but got" "${!actual}"
-    return
-  fi
-
-  State::addAssertionsPassed
-}
-
-# Deprecated: Please use assert_have_been_called instead.
-function assertHaveBeenCalled() {
-  assert_have_been_called "$1" "$2"
-}
-
-function assert_have_been_called() {
-  local command=$1
-  local actual
-  actual="${command}_times"
-  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
-
-  if [[ ${!actual} -eq 0 ]]; then
-    State::addAssertionsFailed
-    Console::printFailedTest "${label}" "${command}" "has not been called at least" "once"
     return
   fi
 

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -23,11 +23,6 @@ function spy() {
   export -f "${command?}"
 }
 
-# Deprecated: Please use assert_have_been_called instead.
-function assertHaveBeenCalled() {
-  assert_have_been_called "$1" "$2"
-}
-
 function assert_have_been_called() {
   local command=$1
   local actual
@@ -41,11 +36,6 @@ function assert_have_been_called() {
   fi
 
   State::addAssertionsPassed
-}
-
-# Deprecated: Please use assert_have_been_called_with instead.
-function assertHaveBeenCalledWith() {
-  assert_have_been_called_with "$1" "$2" "$3"
 }
 
 function assert_have_been_called_with() {
@@ -62,11 +52,6 @@ function assert_have_been_called_with() {
   fi
 
   State::addAssertionsPassed
-}
-
-# Deprecated: Please use assert_have_been_called_times instead.
-function assertHaveBeenCalledTimes() {
-  assert_have_been_called_times "$1" "$2" "$3"
 }
 
 function assert_have_been_called_times() {

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -23,7 +23,12 @@ function spy() {
   export -f "${command?}"
 }
 
+# Deprecated: Please use assert_have_been_called_with instead.
 function assertHaveBeenCalledWith() {
+  assert_have_been_called_with "$1" "$2" "$3"
+}
+
+function assert_have_been_called_with() {
   local expected=$1
   local command=$2
   local actual

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -44,11 +44,16 @@ function assert_have_been_called_with() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_have_been_called instead.
 function assertHaveBeenCalled() {
+  assert_have_been_called "$1" "$2"
+}
+
+function assert_have_been_called() {
   local command=$1
   local actual
   actual="${command}_times"
-  local label="${3:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
 
   if [[ ${!actual} -eq 0 ]]; then
     State::addAssertionsFailed
@@ -59,7 +64,12 @@ function assertHaveBeenCalled() {
   State::addAssertionsPassed
 }
 
+# Deprecated: Please use assert_have_been_called_times instead.
 function assertHaveBeenCalledTimes() {
+  assert_have_been_called_times "$1" "$2" "$3"
+}
+
+function assert_have_been_called_times() {
   local expected=$1
   local command=$2
   local actual

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -17,7 +17,7 @@ function test_succeed() { assert_equals \"1\" \"1\" ; }" > $test_file
    "$fixture"\
     "$(./bashunit "$test_file")"
 
-  assertSuccessfulCode "$(./bashunit "$test_file")"
+  assert_successful_code "$(./bashunit "$test_file")"
 
   rm $test_file
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -11,7 +11,7 @@ function test_bash_unit_when_a_test_passes() {
 
   echo "
 #!/bin/bash
-function test_succeed() { assertEquals \"1\" \"1\" ; }" > $test_file
+function test_succeed() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assertContains\
    "$fixture"\
@@ -34,7 +34,7 @@ function test_bash_unit_when_a_test_fail() {
 
   echo "
 #!/bin/bash
-function test_fail() { assertEquals \"1\" \"0\" ; }" > $test_file
+function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
   assertContains\
    "$fixture"\

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -40,7 +40,7 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
    "$fixture"\
     "$(./bashunit "$test_file")"
 
-  assertGeneralError "$(./bashunit "$test_file")"
+  assert_general_error "$(./bashunit "$test_file")"
 
   rm $test_file
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -13,7 +13,7 @@ function test_bash_unit_when_a_test_passes() {
 #!/bin/bash
 function test_succeed() { assert_equals \"1\" \"1\" ; }" > $test_file
 
-  assertContains\
+  assert_contains\
    "$fixture"\
     "$(./bashunit "$test_file")"
 
@@ -36,7 +36,7 @@ function test_bash_unit_when_a_test_fail() {
 #!/bin/bash
 function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
-  assertContains\
+  assert_contains\
    "$fixture"\
     "$(./bashunit "$test_file")"
 

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -13,15 +13,15 @@ function test_text_should_contain() {
 }
 
 function test_text_should_not_contain() {
-  assertNotContains "expecs" "$($SCRIPT "123")"
+  assert_not_contains "expecs" "$($SCRIPT "123")"
 }
 
 function test_text_should_match_a_regular_expression() {
-  assertNotContains ".*xpec*" "$($SCRIPT "123")"
+  assert_not_contains ".*xpec*" "$($SCRIPT "123")"
 }
 
 function test_text_should_not_match_a_regular_expression() {
-  assertNotContains ".*xpes*" "$($SCRIPT "123")"
+  assert_not_contains ".*xpes*" "$($SCRIPT "123")"
 }
 
 function test_should_validate_an_ok_exit_code() {

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -31,7 +31,7 @@ function test_should_validate_an_ok_exit_code() {
 
   fake_function
 
-  assertExitCode "0"
+  assert_exit_code "0"
 }
 
 function test_should_validate_a_non_ok_exit_code() {
@@ -41,7 +41,7 @@ function test_should_validate_a_non_ok_exit_code() {
 
   fake_function
 
-  assertExitCode "1"
+  assert_exit_code "1"
 }
 
 function test_other_way_of_using_the_exit_code() {
@@ -49,5 +49,5 @@ function test_other_way_of_using_the_exit_code() {
     return 1
   }
 
-  assertExitCode "1" "$(fake_function)"
+  assert_exit_code "1" "$(fake_function)"
 }

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT="$ROOT_DIR/logic.sh"
 
 function test_text_should_be_equal() {
-  assertEquals "expected 123" "$($SCRIPT "123")"
+  assert_equals "expected 123" "$($SCRIPT "123")"
 }
 
 function test_text_should_contain() {

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -9,7 +9,7 @@ function test_text_should_be_equal() {
 }
 
 function test_text_should_contain() {
-  assertContains "expect" "$($SCRIPT "123")"
+  assert_contains "expect" "$($SCRIPT "123")"
 }
 
 function test_text_should_not_contain() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -154,18 +154,18 @@ function test_unsuccessful_assert_general_error() {
     "$(assert_general_error "$(fake_function)")"
 }
 
-function test_successful_assertCommandNotFound() {
-  assert_empty "$(assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)")"
+function test_successful_assert_command_not_found() {
+  assert_empty "$(assert_command_not_found "$(a_non_existing_function > /dev/null 2>&1)")"
 }
 
-function test_unsuccessful_assertCommandNotFound() {
+function test_unsuccessful_assert_command_not_found() {
   function fake_function() {
     return 0
   }
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertCommandNotFound" "0" "to be exactly" "127")"\
-    "$(assertCommandNotFound "$(fake_function)")"
+    "$(Console::printFailedTest "Unsuccessful assert command not found" "0" "to be exactly" "127")"\
+    "$(assert_command_not_found "$(fake_function)")"
 }
 
 function test_successful_assertArrayContains() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -118,22 +118,22 @@ function test_unsuccessful_return_assert_exit_code() {
   assert_exit_code "1"
 }
 
-function test_successful_assertSuccessfulCode() {
+function test_successful_assert_successful_code() {
   function fake_function() {
     return 0
   }
 
-  assert_empty "$(assertSuccessfulCode "$(fake_function)")"
+  assert_empty "$(assert_successful_code "$(fake_function)")"
 }
 
-function test_unsuccessful_assertSuccessfulCode() {
+function test_unsuccessful_assert_successful_code() {
   function fake_function() {
     return 2
   }
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertSuccessfulCode" "2" "to be exactly" "0")"\
-    "$(assertSuccessfulCode "$(fake_function)")"
+    "$(Console::printFailedTest "Unsuccessful assert successful code" "2" "to be exactly" "0")"\
+    "$(assert_successful_code "$(fake_function)")"
 }
 
 function test_successful_assertGeneralError() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -30,14 +30,14 @@ function test_unsuccessful_assert_not_empty() {
     "$(assert_not_empty "")"
 }
 
-function test_successful_assertNotEquals() {
-  assert_empty "$(assertNotEquals "1" "2")"
+function test_successful_assert_not_equals() {
+  assert_empty "$(assert_not_equals "1" "2")"
 }
 
-function test_unsuccessful_assertNotEquals() {
+function test_unsuccessful_assert_not_equals() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertNotEquals" "1" "but got" "1")"\
-    "$(assertNotEquals "1" "1")"
+    "$(Console::printFailedTest "Unsuccessful assert not equals" "1" "but got" "1")"\
+    "$(assert_not_equals "1" "1")"
 }
 
 function test_successful_assertContains() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-function test_successful_assertEquals() {
-  assertEmpty "$(assertEquals "1" "1")"
+function test_successful_assert_equals() {
+  assertEmpty "$(assert_equals "1" "1")"
 }
 
-function test_unsuccessful_assertEquals() {
-  assertEquals\
-    "$(Console::printFailedTest "Unsuccessful assertEquals" "1" "but got" "2")"\
-    "$(assertEquals "1" "2")"
+function test_unsuccessful_assert_equals() {
+  assert_equals\
+    "$(Console::printFailedTest "Unsuccessful assert equals" "1" "but got" "2")"\
+    "$(assert_equals "1" "2")"
 }
 
 function test_successful_assertEmpty() {
@@ -15,7 +15,7 @@ function test_successful_assertEmpty() {
 }
 
 function test_unsuccessful_assertEmpty() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertEmpty" "to be empty" "but got" "1")"\
     "$(assertEmpty "1")"
 }
@@ -25,7 +25,7 @@ function test_successful_assertNotEmpty() {
 }
 
 function test_unsuccessful_assertNotEmpty() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertNotEmpty" "to not be empty" "but got" "")"\
     "$(assertNotEmpty "")"
 }
@@ -35,7 +35,7 @@ function test_successful_assertNotEquals() {
 }
 
 function test_unsuccessful_assertNotEquals() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertNotEquals" "1" "but got" "1")"\
     "$(assertNotEquals "1" "1")"
 }
@@ -45,7 +45,7 @@ function test_successful_assertContains() {
 }
 
 function test_unsuccessful_assertContains() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertContains" "GNU/Linux" "to contain" "Unix")"\
     "$(assertContains "Unix" "GNU/Linux")"
 }
@@ -55,7 +55,7 @@ function test_successful_assertNotContains() {
 }
 
 function test_unsuccessful_assertNotContains() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertNotContains" "GNU/Linux" "to not contain" "Linux")"\
     "$(assertNotContains "Linux" "GNU/Linux")"
 }
@@ -65,7 +65,7 @@ function test_successful_assertMatches() {
 }
 
 function test_unsuccessful_assertMatches() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertMatches" "GNU/Linux" "to match" ".*Pinux*")"\
     "$(assertMatches ".*Pinux*" "GNU/Linux")"
 }
@@ -75,7 +75,7 @@ function test_successful_assertNotMatches() {
 }
 
 function test_unsuccessful_assertNotMatches() {
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertNotMatches" "GNU/Linux" "to not match" ".*Linu*")"\
     "$(assertNotMatches ".*Linu*" "GNU/Linux")"
 }
@@ -93,7 +93,7 @@ function test_unsuccessful_assertExitCode() {
     exit 1
   }
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertExitCode" "1" "to be" "0")"\
     "$(assertExitCode "0" "$(fake_function)")"
 }
@@ -131,7 +131,7 @@ function test_unsuccessful_assertSuccessfulCode() {
     return 2
   }
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertSuccessfulCode" "2" "to be exactly" "0")"\
     "$(assertSuccessfulCode "$(fake_function)")"
 }
@@ -149,7 +149,7 @@ function test_unsuccessful_assertGeneralError() {
     return 2
   }
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertGeneralError" "2" "to be exactly" "1")"\
     "$(assertGeneralError "$(fake_function)")"
 }
@@ -163,7 +163,7 @@ function test_unsuccessful_assertCommandNotFound() {
     return 0
   }
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertCommandNotFound" "0" "to be exactly" "127")"\
     "$(assertCommandNotFound "$(fake_function)")"
 }
@@ -177,7 +177,7 @@ function test_successful_assertArrayContains() {
 function test_unsuccessful_assertArrayContains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest \
       "Unsuccessful assertArrayContains"\
       "Ubuntu 123 Linux Mint"\
@@ -195,7 +195,7 @@ function test_successful_assertArrayNotContains() {
 function test_unsuccessful_assertArrayNotContains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
     "$(assertArrayNotContains "123" "${distros[@]}")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -70,14 +70,14 @@ function test_unsuccessful_assert_matches() {
     "$(assert_matches ".*Pinux*" "GNU/Linux")"
 }
 
-function test_successful_assertNotMatches() {
-  assert_empty "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
+function test_successful_assert_not_matches() {
+  assert_empty "$(assert_not_matches ".*Pinux*" "GNU/Linux")"
 }
 
-function test_unsuccessful_assertNotMatches() {
+function test_unsuccessful_assert_not_matches() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertNotMatches" "GNU/Linux" "to not match" ".*Linu*")"\
-    "$(assertNotMatches ".*Linu*" "GNU/Linux")"
+    "$(Console::printFailedTest "Unsuccessful assert not matches" "GNU/Linux" "to not match" ".*Linu*")"\
+    "$(assert_not_matches ".*Linu*" "GNU/Linux")"
 }
 
 function test_successful_assertExitCode() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -136,22 +136,22 @@ function test_unsuccessful_assert_successful_code() {
     "$(assert_successful_code "$(fake_function)")"
 }
 
-function test_successful_assertGeneralError() {
+function test_successful_assert_general_error() {
   function fake_function() {
     return 1
   }
 
-  assert_empty "$(assertGeneralError "$(fake_function)")"
+  assert_empty "$(assert_general_error "$(fake_function)")"
 }
 
-function test_unsuccessful_assertGeneralError() {
+function test_unsuccessful_assert_general_error() {
   function fake_function() {
     return 2
   }
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertGeneralError" "2" "to be exactly" "1")"\
-    "$(assertGeneralError "$(fake_function)")"
+    "$(Console::printFailedTest "Unsuccessful assert general error" "2" "to be exactly" "1")"\
+    "$(assert_general_error "$(fake_function)")"
 }
 
 function test_successful_assertCommandNotFound() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -196,6 +196,7 @@ function test_unsuccessful_assert_array_not_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assert array not contains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
+    "$(Console::printFailedTest\
+      "Unsuccessful assert array not contains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
     "$(assert_array_not_contains "123" "${distros[@]}")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -80,42 +80,42 @@ function test_unsuccessful_assert_not_matches() {
     "$(assert_not_matches ".*Linu*" "GNU/Linux")"
 }
 
-function test_successful_assertExitCode() {
+function test_successful_assert_exit_code() {
   function fake_function() {
     exit 0
   }
 
-  assert_empty "$(assertExitCode "0" "$(fake_function)")"
+  assert_empty "$(assert_exit_code "0" "$(fake_function)")"
 }
 
-function test_unsuccessful_assertExitCode() {
+function test_unsuccessful_assert_exit_code() {
   function fake_function() {
     exit 1
   }
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertExitCode" "1" "to be" "0")"\
-    "$(assertExitCode "0" "$(fake_function)")"
+    "$(Console::printFailedTest "Unsuccessful assert exit code" "1" "to be" "0")"\
+    "$(assert_exit_code "0" "$(fake_function)")"
 }
 
-function test_successful_return_assertExitCode() {
+function test_successful_return_assert_exit_code() {
   function fake_function() {
     return 0
   }
 
   fake_function
 
-  assertExitCode "0"
+  assert_exit_code "0"
 }
 
-function test_unsuccessful_return_assertExitCode() {
+function test_unsuccessful_return_assert_exit_code() {
   function fake_function() {
     return 1
   }
 
   fake_function
 
-  assertExitCode "1"
+  assert_exit_code "1"
 }
 
 function test_successful_assertSuccessfulCode() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -186,16 +186,16 @@ function test_unsuccessful_assert_array_contains() {
     "$(assert_array_contains "non_existing_element" "${distros[@]}")"
 }
 
-function test_successful_assertArrayNotContains() {
+function test_successful_assert_array_not_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assert_empty "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
+  assert_empty "$(assert_array_not_contains "a_non_existing_element" "${distros[@]}")"
 }
 
-function test_unsuccessful_assertArrayNotContains() {
+function test_unsuccessful_assert_array_not_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertArrayNotContains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
-    "$(assertArrayNotContains "123" "${distros[@]}")"
+    "$(Console::printFailedTest "Unsuccessful assert array not contains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
+    "$(assert_array_not_contains "123" "${distros[@]}")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -40,14 +40,14 @@ function test_unsuccessful_assert_not_equals() {
     "$(assert_not_equals "1" "1")"
 }
 
-function test_successful_assertContains() {
-  assert_empty "$(assertContains "Linux" "GNU/Linux")"
+function test_successful_assert_contains() {
+  assert_empty "$(assert_contains "Linux" "GNU/Linux")"
 }
 
-function test_unsuccessful_assertContains() {
+function test_unsuccessful_assert_contains() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertContains" "GNU/Linux" "to contain" "Unix")"\
-    "$(assertContains "Unix" "GNU/Linux")"
+    "$(Console::printFailedTest "Unsuccessful assert contains" "GNU/Linux" "to contain" "Unix")"\
+    "$(assert_contains "Unix" "GNU/Linux")"
 }
 
 function test_successful_assertNotContains() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -20,14 +20,14 @@ function test_unsuccessful_assert_empty() {
     "$(assert_empty "1")"
 }
 
-function test_successful_assertNotEmpty() {
-  assert_empty "$(assertNotEmpty "a_random_string")"
+function test_successful_assert_not_empty() {
+  assert_empty "$(assert_not_empty "a_random_string")"
 }
 
-function test_unsuccessful_assertNotEmpty() {
+function test_unsuccessful_assert_not_empty() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertNotEmpty" "to not be empty" "but got" "")"\
-    "$(assertNotEmpty "")"
+    "$(Console::printFailedTest "Unsuccessful assert not empty" "to not be empty" "but got" "")"\
+    "$(assert_not_empty "")"
 }
 
 function test_successful_assertNotEquals() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function test_successful_assert_equals() {
-  assertEmpty "$(assert_equals "1" "1")"
+  assert_empty "$(assert_equals "1" "1")"
 }
 
 function test_unsuccessful_assert_equals() {
@@ -10,18 +10,18 @@ function test_unsuccessful_assert_equals() {
     "$(assert_equals "1" "2")"
 }
 
-function test_successful_assertEmpty() {
-  assertEmpty "$(assertEmpty "")"
+function test_successful_assert_empty() {
+  assert_empty "$(assert_empty "")"
 }
 
-function test_unsuccessful_assertEmpty() {
+function test_unsuccessful_assert_empty() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertEmpty" "to be empty" "but got" "1")"\
-    "$(assertEmpty "1")"
+    "$(Console::printFailedTest "Unsuccessful assert empty" "to be empty" "but got" "1")"\
+    "$(assert_empty "1")"
 }
 
 function test_successful_assertNotEmpty() {
-  assertEmpty "$(assertNotEmpty "a_random_string")"
+  assert_empty "$(assertNotEmpty "a_random_string")"
 }
 
 function test_unsuccessful_assertNotEmpty() {
@@ -31,7 +31,7 @@ function test_unsuccessful_assertNotEmpty() {
 }
 
 function test_successful_assertNotEquals() {
-  assertEmpty "$(assertNotEquals "1" "2")"
+  assert_empty "$(assertNotEquals "1" "2")"
 }
 
 function test_unsuccessful_assertNotEquals() {
@@ -41,7 +41,7 @@ function test_unsuccessful_assertNotEquals() {
 }
 
 function test_successful_assertContains() {
-  assertEmpty "$(assertContains "Linux" "GNU/Linux")"
+  assert_empty "$(assertContains "Linux" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertContains() {
@@ -51,7 +51,7 @@ function test_unsuccessful_assertContains() {
 }
 
 function test_successful_assertNotContains() {
-  assertEmpty "$(assertNotContains "Linus" "GNU/Linux")"
+  assert_empty "$(assertNotContains "Linus" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertNotContains() {
@@ -61,7 +61,7 @@ function test_unsuccessful_assertNotContains() {
 }
 
 function test_successful_assertMatches() {
-  assertEmpty "$(assertMatches ".*Linu*" "GNU/Linux")"
+  assert_empty "$(assertMatches ".*Linu*" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertMatches() {
@@ -71,7 +71,7 @@ function test_unsuccessful_assertMatches() {
 }
 
 function test_successful_assertNotMatches() {
-  assertEmpty "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
+  assert_empty "$(assertNotMatches ".*Pinux*" "GNU/Linux")"
 }
 
 function test_unsuccessful_assertNotMatches() {
@@ -85,7 +85,7 @@ function test_successful_assertExitCode() {
     exit 0
   }
 
-  assertEmpty "$(assertExitCode "0" "$(fake_function)")"
+  assert_empty "$(assertExitCode "0" "$(fake_function)")"
 }
 
 function test_unsuccessful_assertExitCode() {
@@ -123,7 +123,7 @@ function test_successful_assertSuccessfulCode() {
     return 0
   }
 
-  assertEmpty "$(assertSuccessfulCode "$(fake_function)")"
+  assert_empty "$(assertSuccessfulCode "$(fake_function)")"
 }
 
 function test_unsuccessful_assertSuccessfulCode() {
@@ -141,7 +141,7 @@ function test_successful_assertGeneralError() {
     return 1
   }
 
-  assertEmpty "$(assertGeneralError "$(fake_function)")"
+  assert_empty "$(assertGeneralError "$(fake_function)")"
 }
 
 function test_unsuccessful_assertGeneralError() {
@@ -155,7 +155,7 @@ function test_unsuccessful_assertGeneralError() {
 }
 
 function test_successful_assertCommandNotFound() {
-  assertEmpty "$(assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)")"
+  assert_empty "$(assertCommandNotFound "$(a_non_existing_function > /dev/null 2>&1)")"
 }
 
 function test_unsuccessful_assertCommandNotFound() {
@@ -171,7 +171,7 @@ function test_unsuccessful_assertCommandNotFound() {
 function test_successful_assertArrayContains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assertEmpty "$(assertArrayContains "123" "${distros[@]}")"
+  assert_empty "$(assertArrayContains "123" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayContains() {
@@ -189,7 +189,7 @@ function test_unsuccessful_assertArrayContains() {
 function test_successful_assertArrayNotContains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assertEmpty "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
+  assert_empty "$(assertArrayNotContains "a_non_existing_element" "${distros[@]}")"
 }
 
 function test_unsuccessful_assertArrayNotContains() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -60,14 +60,14 @@ function test_unsuccessful_assert_not_contains() {
     "$(assert_not_contains "Linux" "GNU/Linux")"
 }
 
-function test_successful_assertMatches() {
-  assert_empty "$(assertMatches ".*Linu*" "GNU/Linux")"
+function test_successful_assert_matches() {
+  assert_empty "$(assert_matches ".*Linu*" "GNU/Linux")"
 }
 
-function test_unsuccessful_assertMatches() {
+function test_unsuccessful_assert_matches() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertMatches" "GNU/Linux" "to match" ".*Pinux*")"\
-    "$(assertMatches ".*Pinux*" "GNU/Linux")"
+    "$(Console::printFailedTest "Unsuccessful assert matches" "GNU/Linux" "to match" ".*Pinux*")"\
+    "$(assert_matches ".*Pinux*" "GNU/Linux")"
 }
 
 function test_successful_assertNotMatches() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -50,14 +50,14 @@ function test_unsuccessful_assert_contains() {
     "$(assert_contains "Unix" "GNU/Linux")"
 }
 
-function test_successful_assertNotContains() {
-  assert_empty "$(assertNotContains "Linus" "GNU/Linux")"
+function test_successful_assert_not_contains() {
+  assert_empty "$(assert_not_contains "Linus" "GNU/Linux")"
 }
 
-function test_unsuccessful_assertNotContains() {
+function test_unsuccessful_assert_not_contains() {
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful assertNotContains" "GNU/Linux" "to not contain" "Linux")"\
-    "$(assertNotContains "Linux" "GNU/Linux")"
+    "$(Console::printFailedTest "Unsuccessful assert not contains" "GNU/Linux" "to not contain" "Linux")"\
+    "$(assert_not_contains "Linux" "GNU/Linux")"
 }
 
 function test_successful_assertMatches() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -168,22 +168,22 @@ function test_unsuccessful_assert_command_not_found() {
     "$(assert_command_not_found "$(fake_function)")"
 }
 
-function test_successful_assertArrayContains() {
+function test_successful_assert_array_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assert_empty "$(assertArrayContains "123" "${distros[@]}")"
+  assert_empty "$(assert_array_contains "123" "${distros[@]}")"
 }
 
-function test_unsuccessful_assertArrayContains() {
+function test_unsuccessful_assert_array_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
   assert_equals\
     "$(Console::printFailedTest \
-      "Unsuccessful assertArrayContains"\
+      "Unsuccessful assert array contains"\
       "Ubuntu 123 Linux Mint"\
       "to contain"\
       "non_existing_element")"\
-    "$(assertArrayContains "non_existing_element" "${distros[@]}")"
+    "$(assert_array_contains "non_existing_element" "${distros[@]}")"
 }
 
 function test_successful_assertArrayNotContains() {

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -26,7 +26,7 @@ function test_not_render_passed_assertions_when_no_passed_tests_nor_assertions()
 function test_render_passed_tests_when_passed_tests() {
   local TESTS_PASSED=1
 
-  assertMatches\
+  assert_matches\
     $'Tests:[^\n]*\e\[32m1 passed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -35,7 +35,7 @@ function test_render_passed_tests_when_passed_assertions() {
   local TESTS_PASSED=0
   local ASSERTIONS_PASSED=1
 
-  assertMatches\
+  assert_matches\
     $'Tests:[^\n]*\e\[32m0 passed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -44,7 +44,7 @@ function test_render_passed_assertions_when_passed_tests() {
   local TESTS_PASSED=1
   local ASSERTIONS_PASSED=0
 
-  assertMatches\
+  assert_matches\
     $'Assertions:[^\n]*\e\[32m0 passed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -52,7 +52,7 @@ function test_render_passed_assertions_when_passed_tests() {
 function test_render_passed_assertions_when_passed_assertions() {
   local ASSERTIONS_PASSED=1
 
-  assertMatches\
+  assert_matches\
     $'Assertions:[^\n]*\e\[32m1 passed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -76,7 +76,7 @@ function test_not_render_failed_assertions_when_not_failed_tests() {
 function test_render_failed_tests_when_failed_tests() {
   local TESTS_FAILED=1
 
-  assertMatches\
+  assert_matches\
     $'Tests:[^\n]*\e\[31m1 failed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -85,7 +85,7 @@ function test_render_failed_assertions_when_failed_tests() {
   local TESTS_FAILED=1
   local ASSERTIONS_FAILED=0
 
-  assertMatches\
+  assert_matches\
     $'Assertions:[^\n]*\e\[31m0 failed\e\[0m[^\n]*total'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -101,7 +101,7 @@ function test_not_render_all_tests_passed_when_failed_tests() {
 function test_render_all_tests_passed_when_not_failed_tests() {
   local TESTS_FAILED=0
 
-  assertMatches\
+  assert_matches\
     $'\e\[42mAll tests passed\e\[0m'\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -110,7 +110,7 @@ function test_total_tests_is_the_sum_of_passed_and_failed_tests() {
   local TESTS_PASSED=4
   local TESTS_FAILED=2
 
-  assertMatches\
+  assert_matches\
     "Tests:[^\n]*6 total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -119,14 +119,14 @@ function test_total_asserts_is_the_sum_of_passed_and_failed_asserts() {
   local ASSERTIONS_PASSED=1
   local ASSERTIONS_FAILED=3
 
-  assertMatches\
+  assert_matches\
     "Assertions:[^\n]*4 total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
 
 function test_render_time_of_execution_when_all_assertions_passed() {
   if [[ $_OS != "OSX" ]]; then
-    assertMatches\
+    assert_matches\
       "Time taken: [[:digit:]]+ ms"\
       "$(Console::renderResult)"
   fi
@@ -134,7 +134,7 @@ function test_render_time_of_execution_when_all_assertions_passed() {
 
 function test_render_time_of_execution_when_not_all_assertions_passed() {
   if [[ $_OS != "OSX" ]]; then
-    assertMatches\
+    assert_matches\
       "Time taken: [[:digit:]]+ ms"\
       "$(Console::renderResult)"
   fi

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -9,7 +9,7 @@ function test_not_render_passed_tests_when_no_passed_tests_nor_assertions() {
   local TESTS_PASSED=0
   local ASSERTIONS_PASSED=0
 
-  assertNotMatches\
+  assert_not_matches\
     "Tests:[^\n]*passed[^\n]*total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -18,7 +18,7 @@ function test_not_render_passed_assertions_when_no_passed_tests_nor_assertions()
   local TESTS_PASSED=0
   local ASSERTIONS_PASSED=0
 
-  assertNotMatches\
+  assert_not_matches\
     "Assertions:[^\n]*passed[^\n]*total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -60,7 +60,7 @@ function test_render_passed_assertions_when_passed_assertions() {
 function test_not_render_failed_tests_when_not_failed_tests() {
   local TESTS_FAILED=0
 
-  assertNotMatches\
+  assert_not_matches\
     "Tests:[^\n]*failed[^\n]*total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -68,7 +68,7 @@ function test_not_render_failed_tests_when_not_failed_tests() {
 function test_not_render_failed_assertions_when_not_failed_tests() {
   local TESTS_FAILED=0
 
-  assertNotMatches\
+  assert_not_matches\
     "Assertions:[^\n]*failed[^\n]*total"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -93,7 +93,7 @@ function test_render_failed_assertions_when_failed_tests() {
 function test_not_render_all_tests_passed_when_failed_tests() {
   local TESTS_FAILED=1
 
-  assertNotMatches\
+  assert_not_matches\
     "All tests passed"\
     "$(Console::renderResult $TESTS_PASSED $TESTS_FAILED $ASSERTIONS_PASSED $ASSERTIONS_FAILED)"
 }
@@ -142,7 +142,7 @@ function test_render_time_of_execution_when_not_all_assertions_passed() {
 
 function test_should_not_render_time_of_execution_when_all_assertions_passed_on_mac() {
   if [[ $_OS == "OSX" ]]; then
-    assertNotMatches\
+    assert_not_matches\
       "Time taken: [[:digit:]]+ ms"\
       "$(Console::renderResult)"
   fi
@@ -150,7 +150,7 @@ function test_should_not_render_time_of_execution_when_all_assertions_passed_on_
 
 function test_should_not_render_time_of_execution_when_not_all_assertions_passed_on_mac() {
   if [[ $_OS == "OSX" ]]; then
-    assertNotMatches\
+    assert_not_matches\
       "Time taken: [[:digit:]]+ ms"\
       "$(Console::renderResult)"
   fi

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -13,25 +13,25 @@ function dummyFunction() {
 }
 
 function test_normalizeTestFunctionName_empty() {
-  assertEquals "" "$(Helper::normalizeTestFunctionName)"
+  assert_equals "" "$(Helper::normalizeTestFunctionName)"
 }
 
 function test_normalizeTestFunctionName_one_word() {
-  assertEquals "Word" "$(Helper::normalizeTestFunctionName "word")"
+  assert_equals "Word" "$(Helper::normalizeTestFunctionName "word")"
 }
 
 function test_normalizeTestFunctionName_snake_case() {
-  assertEquals "Some logic" "$(Helper::normalizeTestFunctionName "test_some_logic")"
+  assert_equals "Some logic" "$(Helper::normalizeTestFunctionName "test_some_logic")"
 }
 
 function test_normalizeTestFunctionName_camel_case() {
-  assertEquals "SomeLogic" "$(Helper::normalizeTestFunctionName "testSomeLogic")"
+  assert_equals "SomeLogic" "$(Helper::normalizeTestFunctionName "testSomeLogic")"
 }
 
 function test_getFunctionsToRun_no_filter_should_return_all_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assertEquals\
+  assert_equals\
     "prefix_function1 prefix_function2 prefix_function3"\
     "$(Helper::getFunctionsToRun "prefix" "" "${functions[*]}")"
 }
@@ -39,13 +39,13 @@ function test_getFunctionsToRun_no_filter_should_return_all_functions() {
 function test_getFunctionsToRun_with_filter_should_return_matching_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assertEquals "prefix_function1" "$(Helper::getFunctionsToRun "prefix" "function1" "${functions[*]}")"
+  assert_equals "prefix_function1" "$(Helper::getFunctionsToRun "prefix" "function1" "${functions[*]}")"
 }
 
 function test_getFunctionsToRun_filter_no_matching_functions_should_return_empty() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assertEquals "" "$(Helper::getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")"
+  assert_equals "" "$(Helper::getFunctionsToRun "prefix" "nonexistent" "${functions[*]}")"
 }
 
 function test_getFunctionsToRun_fail_when_duplicates() {
@@ -57,7 +57,7 @@ function test_getFunctionsToRun_fail_when_duplicates() {
 function test_dummyFunction_is_executed_with_execute_function_if_exists() {
   local function_name='dummyFunction'
 
-  assertEquals "dummyFunction executed" "$(Helper::executeFunctionIfExists "$function_name")"
+  assert_equals "dummyFunction executed" "$(Helper::executeFunctionIfExists "$function_name")"
 }
 
 function test_no_function_is_executed_with_execute_function_if_exists() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -63,7 +63,7 @@ function test_dummyFunction_is_executed_with_execute_function_if_exists() {
 function test_no_function_is_executed_with_execute_function_if_exists() {
   local function_name='notExistingFunction'
 
-  assertEmpty "$(Helper::executeFunctionIfExists "$function_name")"
+  assert_empty "$(Helper::executeFunctionIfExists "$function_name")"
 }
 
 function test_unsuccessful_unsetIfExists() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -76,7 +76,7 @@ function test_successful_unsetIfExists() {
     return 0
   }
 
-  assertSuccessfulCode "$(Helper::unsetIfExists "fake_function")"
+  assert_successful_code "$(Helper::unsetIfExists "fake_function")"
 }
 
 function test_checkDuplicateFunctions_with_duplicates() {
@@ -90,5 +90,5 @@ function test_checkDuplicateFunctions_without_duplicates() {
   local file
   file="$(dirname "${BASH_SOURCE[0]}")/fixtures/no_duplicate_functions.sh"
 
-  assertSuccessfulCode "$(Helper::checkDuplicateFunctions "$file")"
+  assert_successful_code "$(Helper::checkDuplicateFunctions "$file")"
 }

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -51,7 +51,7 @@ function test_getFunctionsToRun_filter_no_matching_functions_should_return_empty
 function test_getFunctionsToRun_fail_when_duplicates() {
   local functions=("prefix_function1" "prefix_function1")
 
-  assertGeneralError "$(Helper::getFunctionsToRun "prefix" "" "${functions[*]}")"
+  assert_general_error "$(Helper::getFunctionsToRun "prefix" "" "${functions[*]}")"
 }
 
 function test_dummyFunction_is_executed_with_execute_function_if_exists() {
@@ -67,7 +67,7 @@ function test_no_function_is_executed_with_execute_function_if_exists() {
 }
 
 function test_unsuccessful_unsetIfExists() {
-  assertGeneralError "$(Helper::unsetIfExists "fake_function")"
+  assert_general_error "$(Helper::unsetIfExists "fake_function")"
 }
 
 function test_successful_unsetIfExists() {
@@ -83,7 +83,7 @@ function test_checkDuplicateFunctions_with_duplicates() {
   local file
   file="$(dirname "${BASH_SOURCE[0]}")/fixtures/duplicate_functions.sh"
 
-  assertGeneralError "$(Helper::checkDuplicateFunctions "$file")"
+  assert_general_error "$(Helper::checkDuplicateFunctions "$file")"
 }
 
 function test_checkDuplicateFunctions_without_duplicates() {

--- a/tests/unit/setup_teardown_test.sh
+++ b/tests/unit/setup_teardown_test.sh
@@ -19,9 +19,9 @@ function tearDownAfterScript() {
 }
 
 function test_counter_is_incremented_after_setup_before_script_and_setup() {
-  assertEquals "3" "$TEST_COUNTER"
+  assert_equals "3" "$TEST_COUNTER"
 }
 
 function test_counter_is_decremented_and_incremented_after_teardown_and_setup() {
-  assertEquals "3" "$TEST_COUNTER"
+  assert_equals "3" "$TEST_COUNTER"
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -33,7 +33,7 @@ function test_successful_spy() {
   spy ps
   ps a_random_parameter_1 a_random_parameter_2
 
-  assertHaveBeenCalledWith "a_random_parameter_1 a_random_parameter_2" ps
+  assert_have_been_called_with "a_random_parameter_1 a_random_parameter_2" ps
   assertHaveBeenCalled ps
 }
 

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -21,7 +21,7 @@ PID TTY          TIME CMD
 8387  ?        00:00:00 /usr/sbin/apache2 -k start
 EOF
 
-  assert_empty "$(assertSuccessfulCode "$(code)")"
+  assert_empty "$(assert_successful_code "$(code)")"
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -21,7 +21,7 @@ PID TTY          TIME CMD
 8387  ?        00:00:00 /usr/sbin/apache2 -k start
 EOF
 
-  assertEmpty "$(assertSuccessfulCode "$(code)")"
+  assert_empty "$(assertSuccessfulCode "$(code)")"
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -34,7 +34,7 @@ function test_successful_spy() {
   ps a_random_parameter_1 a_random_parameter_2
 
   assert_have_been_called_with "a_random_parameter_1 a_random_parameter_2" ps
-  assertHaveBeenCalled ps
+  assert_have_been_called ps
 }
 
 function test_unsuccessful_spy_called() {
@@ -42,7 +42,7 @@ function test_unsuccessful_spy_called() {
 
   assert_equals\
     "$(Console::printFailedTest "Unsuccessful spy called" "ps" "has not been called at least" "once")"\
-    "$(assertHaveBeenCalled ps)"
+    "$(assert_have_been_called ps)"
 }
 
 
@@ -52,6 +52,6 @@ function test_successful_spy_called_times() {
   ps
   ps
 
-  assertHaveBeenCalledTimes 2 ps
+  assert_have_been_called_times 2 ps
 }
 

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -26,7 +26,7 @@ EOF
 
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
-  assertEquals "hello world" "$(ps)"
+  assert_equals "hello world" "$(ps)"
 }
 
 function test_successful_spy() {
@@ -40,7 +40,7 @@ function test_successful_spy() {
 function test_unsuccessful_spy_called() {
   spy ps
 
-  assertEquals\
+  assert_equals\
     "$(Console::printFailedTest "Unsuccessful spy called" "ps" "has not been called at least" "once")"\
     "$(assertHaveBeenCalled ps)"
 }


### PR DESCRIPTION
## 📚 Description

In bash, is common to use snake_case instead of camelCase. 
Therefore, the bash community will appreciate this.

## 🔖 Changes

- Create all assertions using snake_case
- Deprecate all assertions using camelCase; they will be remove in a future version

