### PR TITLE
Create one single bin executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ node_modules
 yarn-error.log
 docs/.vitepress/cache
 docs/.vitepress/dist
+
+# installation
+bin/bashunit

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+mkdir -p bin
+
+cat src/*.sh > bin/temp.sh
+cat bashunit >> bin/temp.sh
+grep -v '^source' bin/temp.sh > bin/bashunit
+rm bin/temp.sh
+
+chmod +x bin/bashunit
+
+echo "Build complete. bashunit has been generated in the bin folder."


### PR DESCRIPTION
## 📚 Description

The current `./bashunit` file depends on multiple other files to manage better the complexity of the project, spliting by responsibility, scope and context. However, it might be useful to be able to have the whole tool in one single file for installation purposes as third-party dependency.

## 🔖 Changes

- Create an `install.sh` script, which will create an executable of `bashunit` in one single file inside the `bin/` folder

>  I thought about this originally because of this issue: https://github.com/bpkg/bpkg/issues/168#issuecomment-1738304446 
This installer could help us solving this "missing deps files" when installing bashunit.
