### PR TITLE
Output dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
-- Added `--dots` argument for a simpler output
+- Added `--verbose` argument
+  - use a "dotted" simpler version by default
 - `mock`
 - `spy`
 - `assert_have_been_called`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
+- Added `--dots` argument for a simpler output
 - `mock`
 - `spy`
 - `assert_have_been_called`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
 - Added `--verbose` argument
-  - use a "dotted" simpler version by default
-- `mock`
-- `spy`
-- `assert_have_been_called`
-- `assert_have_been_called_with`
-- `assert_have_been_called_times`
+    - use a "dotted" simpler version by default
+- Manage error when test execution fails
+- Added these functions
+    - `mock`
+    - `spy`
+    - `assert_have_been_called`
+    - `assert_have_been_called_with`
+    - `assert_have_been_called_times`
 - Rename assertions from camelCase to snake_case:
     - `assertEquals` -> `assert_equals`
     - `assertNotEquals` -> `assert_not_equals`
@@ -23,8 +25,6 @@
     - `assertCommandNotFound` -> `assert_command_not_found`
     - `assertArrayContains` -> `assert_array_contains`
     - `assertArrayNotContains` -> `assert_array_not_contains`
-
-- Manage error when test execution fails
 
 ## [0.6.0](https://github.com/TypedDevs/bashunit/compare/0.5.0...0.6.0) - 2023-09-19
 

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
+	@./bashunit $(TEST_SCRIPTS) --dots
 
 test/watch: $(TEST_SCRIPTS)
 	@./bashunit $(TEST_SCRIPTS)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS) --dots
+	@./bashunit $(TEST_SCRIPTS)
 
 test/watch: $(TEST_SCRIPTS)
 	@./bashunit $(TEST_SCRIPTS)

--- a/bashunit
+++ b/bashunit
@@ -35,7 +35,7 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --verbose)
+    --verbose|-v)
       _VERBOSE=true
       shift
       shift

--- a/bashunit
+++ b/bashunit
@@ -24,6 +24,7 @@ source "$BASH_UNIT_ROOT_DIR/src/runner.sh"
 ###############
 
 _FILTER=""
+_DOTS=false
 _FILES=()
 
 while [[ $# -gt 0 ]]; do
@@ -32,6 +33,10 @@ while [[ $# -gt 0 ]]; do
     --filter)
       _FILTER="$2"
       shift
+      shift
+      ;;
+    --dots)
+      _DOTS=true
       shift
       ;;
     *)

--- a/bashunit
+++ b/bashunit
@@ -36,7 +36,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --dots)
-      _DOTS=true
+      _DOTS=${2-50}
+      shift
       shift
       ;;
     *)

--- a/bashunit
+++ b/bashunit
@@ -24,7 +24,7 @@ source "$BASH_UNIT_ROOT_DIR/src/runner.sh"
 ###############
 
 _FILTER=""
-_DOTS=false
+_VERBOSE=false
 _FILES=()
 
 while [[ $# -gt 0 ]]; do
@@ -35,8 +35,8 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --dots)
-      _DOTS=${2-50}
+    --verbose)
+      _VERBOSE=true
       shift
       shift
       ;;

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Running pre-commit checks..."
+echo "Running pre-commit checks"
 
 make pre_commit/run
 EXIT_CODE=$?

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -58,8 +58,8 @@ _SUCCESSFUL_TEST_COUNT=0
 function Console::printSuccessfulTest() {
   ((_SUCCESSFUL_TEST_COUNT++))
 
-  if [[ "$_DOTS" != false ]]; then
-    if (( _SUCCESSFUL_TEST_COUNT % _DOTS != 0 )); then
+  if [[ "$_VERBOSE" == false ]]; then
+    if (( _SUCCESSFUL_TEST_COUNT % 50 != 0 )); then
       printf "."
     else
       echo "."

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -54,9 +54,20 @@ function Console::printExecutionTime() {
   fi
 }
 
+_SUCCESSFUL_TEST_COUNT=0
 function Console::printSuccessfulTest() {
-  local test_name=$1
-  printf "%s✓ Passed%s: %s\n" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "${test_name}"
+  ((_SUCCESSFUL_TEST_COUNT++))
+
+  if [[ "$_DOTS" == true ]]; then
+    if (( _SUCCESSFUL_TEST_COUNT % 50 != 0 )); then
+      printf "."
+    else
+      echo "."
+    fi
+  else
+    local test_name=$1
+    printf "%s✓ Passed%s: %s\n" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "${test_name}"
+  fi
 }
 
 function Console::printFailedTest() {

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -58,8 +58,8 @@ _SUCCESSFUL_TEST_COUNT=0
 function Console::printSuccessfulTest() {
   ((_SUCCESSFUL_TEST_COUNT++))
 
-  if [[ "$_DOTS" == true ]]; then
-    if (( _SUCCESSFUL_TEST_COUNT % 50 != 0 )); then
+  if [[ "$_DOTS" != false ]]; then
+    if (( _SUCCESSFUL_TEST_COUNT % _DOTS != 0 )); then
       printf "."
     else
       echo "."

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -42,7 +42,7 @@ function Runner::callTestFunctions() {
   functions_to_run=($(Helper::getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [[ "${#functions_to_run[@]}" -gt 0 ]]; then
-    if [[ "$_DOTS" != true ]]; then
+    if [[ "$_DOTS" == false ]]; then
       echo "Running $script"
     fi
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -42,7 +42,10 @@ function Runner::callTestFunctions() {
   functions_to_run=($(Helper::getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [[ "${#functions_to_run[@]}" -gt 0 ]]; then
-    echo "Running $script"
+    if [[ "$_DOTS" != true ]]; then
+      echo "Running $script"
+    fi
+
     Helper::checkDuplicateFunctions "$script"
 
     for function_name in "${functions_to_run[@]}"; do

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -42,7 +42,7 @@ function Runner::callTestFunctions() {
   functions_to_run=($(Helper::getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [[ "${#functions_to_run[@]}" -gt 0 ]]; then
-    if [[ "$_DOTS" == false ]]; then
+    if [[ "$_VERBOSE" == true ]]; then
       echo "Running $script"
     fi
 

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -74,24 +74,23 @@ function test_error() {
 function test_bash_unit_output_dots() {
   local test_file=./tests/acceptance/fake_dots_test.sh
   local fixture
-  fixture=$(printf "Running ./tests/acceptance/fake_fail_test.sh
-...
-
-\e[2mTests:     \e[0m \e[32m1 passed\e[0m, 1 total
-\e[2mAssertions:\e[0m \e[32m1 passed\e[0m, 1 total
+  fixture=$(printf "....
+\e[2mTests:     \e[0m \e[32m4 passed\e[0m, 4 total
+\e[2mAssertions:\e[0m \e[32m6 passed\e[0m, 6 total
 \e[42mAll tests passed\e[0m")
 
   echo "
 #!/bin/bash
 function test_1() { assert_equals \"1\" \"1\" ; }
-function test_2() { assert_equals \"1\" \"1\" ; }
-function test_3() { assert_equals \"1\" \"1\" ; }" > $test_file
+function test_2() { assert_equals \"1\" \"1\" ; assert_equals \"1\" \"1\" ;}
+function test_3() { assert_equals \"1\" \"1\" ; assert_equals \"1\" \"1\" ; }
+function test_4() { assert_equals \"1\" \"1\" ; }" > $test_file
 
-  assert_contains\
+  assert_equals\
    "$fixture"\
     "$(./bashunit "$test_file" --dots)"
 
-  assert_general_error "$(./bashunit "$test_file")"
+  assert_successful_code "$(./bashunit "$test_file")"
 
   rm $test_file
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -70,3 +70,28 @@ function test_error() {
 
   rm $test_file
 }
+
+function test_bash_unit_output_dots() {
+  local test_file=./tests/acceptance/fake_dots_test.sh
+  local fixture
+  fixture=$(printf "Running ./tests/acceptance/fake_fail_test.sh
+...
+
+\e[2mTests:     \e[0m \e[32m1 passed\e[0m, 1 total
+\e[2mAssertions:\e[0m \e[32m1 passed\e[0m, 1 total
+\e[42mAll tests passed\e[0m")
+
+  echo "
+#!/bin/bash
+function test_1() { assert_equals \"1\" \"1\" ; }
+function test_2() { assert_equals \"1\" \"1\" ; }
+function test_3() { assert_equals \"1\" \"1\" ; }" > $test_file
+
+  assert_contains\
+   "$fixture"\
+    "$(./bashunit "$test_file" --dots)"
+
+  assert_general_error "$(./bashunit "$test_file")"
+
+  rm $test_file
+}

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -86,7 +86,7 @@ function test_2() { assert_equals \"1\" \"1\" ; assert_equals \"1\" \"1\" ;}
 function test_3() { assert_equals \"1\" \"1\" ; assert_equals \"1\" \"1\" ; }
 function test_4() { assert_equals \"1\" \"1\" ; }" > $test_file
 
-  assert_equals\
+  assert_contains\
    "$fixture"\
     "$(./bashunit "$test_file" --dots)"
 

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -15,7 +15,7 @@ function test_succeed() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file")"
+    "$(./bashunit "$test_file" --verbose)"
 
   assert_successful_code "$(./bashunit "$test_file")"
 
@@ -38,7 +38,7 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file")"
+    "$(./bashunit "$test_file" --verbose)"
 
   assert_general_error "$(./bashunit "$test_file")"
 
@@ -64,7 +64,7 @@ function test_error() {
 
   assertContains\
    "$fixture"\
-    "$(./bashunit "$test_file")"
+    "$(./bashunit "$test_file" --verbose)"
 
   assertGeneralError "$(./bashunit "$test_file")"
 
@@ -88,7 +88,7 @@ function test_4() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file" --dots)"
+    "$(./bashunit "$test_file")"
 
   assert_successful_code "$(./bashunit "$test_file")"
 


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/TypedDevs/bashunit/issues/59: Display dots instead of tests names

Currently, the only output from bashunit is the test names in a `prettify way`. 
We want to allow rendering dots (a dot per test). 

## 🔖 Changes

- Render dots (per test) by default
- Render the scripts and test names using the new flag `--verbose`

<img width="701" alt="Screenshot 2023-09-30 at 13 58 46" src="https://github.com/TypedDevs/bashunit/assets/5256287/e06d23d0-af5e-4953-9506-5ce3b65fb2bf">
