### PR TITLE
Use verbose output by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
-- Added `--dots` argument for a simpler output
+- Added `--simple` argument for a simpler output
 - Manage error when test execution fails
 - Split install and build scripts
 - Added these functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.6.0...main)
-- Added `--verbose` argument
-    - use a "dotted" simpler version by default
+- Added `--dots` argument for a simpler output
 - Manage error when test execution fails
 - Split install and build scripts
 - Added these functions

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS) --dots
+	@./bashunit $(TEST_SCRIPTS) --simple
 
 test/watch: $(TEST_SCRIPTS)
 	@./bashunit $(TEST_SCRIPTS)

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
+	@./bashunit $(TEST_SCRIPTS) --dots
 
 test/watch: $(TEST_SCRIPTS)
 	@./bashunit $(TEST_SCRIPTS)

--- a/bashunit
+++ b/bashunit
@@ -24,7 +24,7 @@ source "$BASH_UNIT_ROOT_DIR/src/runner.sh"
 ###############
 
 _FILTER=""
-_DOTS=false
+_SIMPLE_OUTPUT=false
 _FILES=()
 
 while [[ $# -gt 0 ]]; do
@@ -35,9 +35,8 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --dots)
-      _DOTS=${2-50}
-      shift
+    --simple)
+      _SIMPLE_OUTPUT=true
       shift
       ;;
     *)

--- a/bashunit
+++ b/bashunit
@@ -24,7 +24,7 @@ source "$BASH_UNIT_ROOT_DIR/src/runner.sh"
 ###############
 
 _FILTER=""
-_VERBOSE=false
+_DOTS=false
 _FILES=()
 
 while [[ $# -gt 0 ]]; do
@@ -35,8 +35,8 @@ while [[ $# -gt 0 ]]; do
       shift
       shift
       ;;
-    --verbose|-v)
-      _VERBOSE=true
+    --dots)
+      _DOTS=${2-50}
       shift
       shift
       ;;

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -58,8 +58,8 @@ _SUCCESSFUL_TEST_COUNT=0
 function Console::printSuccessfulTest() {
   ((_SUCCESSFUL_TEST_COUNT++))
 
-  if [[ "$_DOTS" != false ]]; then
-    if (( _SUCCESSFUL_TEST_COUNT % _DOTS != 0 )); then
+  if [[ "$_SIMPLE_OUTPUT" == true ]]; then
+    if (( _SUCCESSFUL_TEST_COUNT % 50 != 0 )); then
       printf "."
     else
       echo "."

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -58,8 +58,8 @@ _SUCCESSFUL_TEST_COUNT=0
 function Console::printSuccessfulTest() {
   ((_SUCCESSFUL_TEST_COUNT++))
 
-  if [[ "$_VERBOSE" == false ]]; then
-    if (( _SUCCESSFUL_TEST_COUNT % 50 != 0 )); then
+  if [[ "$_DOTS" != false ]]; then
+    if (( _SUCCESSFUL_TEST_COUNT % _DOTS != 0 )); then
       printf "."
     else
       echo "."

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -42,7 +42,7 @@ function Runner::callTestFunctions() {
   functions_to_run=($(Helper::getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [[ "${#functions_to_run[@]}" -gt 0 ]]; then
-    if [[ "$_VERBOSE" == true ]]; then
+    if [[ "$_DOTS" == false ]]; then
       echo "Running $script"
     fi
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -42,7 +42,7 @@ function Runner::callTestFunctions() {
   functions_to_run=($(Helper::getFunctionsToRun "$prefix" "$filter" "$function_names"))
 
   if [[ "${#functions_to_run[@]}" -gt 0 ]]; then
-    if [[ "$_DOTS" == false ]]; then
+    if [[ "$_SIMPLE_OUTPUT" == false ]]; then
       echo "Running $script"
     fi
 

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -71,7 +71,7 @@ function test_error() {
   rm $test_file
 }
 
-function test_bash_unit_output_dots() {
+function test_bash_unit_simple_output() {
   local test_file=./tests/acceptance/fake_dots_test.sh
   local fixture
   fixture=$(printf "....
@@ -88,7 +88,7 @@ function test_4() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file" --dots)"
+    "$(./bashunit "$test_file" --simple)"
 
   assert_successful_code "$(./bashunit "$test_file")"
 

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -15,7 +15,7 @@ function test_succeed() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file" --verbose)"
+    "$(./bashunit "$test_file")"
 
   assert_successful_code "$(./bashunit "$test_file")"
 
@@ -38,7 +38,7 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file" --verbose)"
+    "$(./bashunit "$test_file")"
 
   assert_general_error "$(./bashunit "$test_file")"
 
@@ -64,7 +64,7 @@ function test_error() {
 
   assertContains\
    "$fixture"\
-    "$(./bashunit "$test_file" --verbose)"
+    "$(./bashunit "$test_file")"
 
   assertGeneralError "$(./bashunit "$test_file")"
 
@@ -88,7 +88,7 @@ function test_4() { assert_equals \"1\" \"1\" ; }" > $test_file
 
   assert_contains\
    "$fixture"\
-    "$(./bashunit "$test_file")"
+    "$(./bashunit "$test_file" --dots)"
 
   assert_successful_code "$(./bashunit "$test_file")"
 


### PR DESCRIPTION
## 📚 Description

This reverts commit dc89a22014d52025729f7f88ac8145a263118f95.

## 🔖 Changes

Use "verbose output" by default, and allow using `--simple` to display a simplified output using a dot per passed test.

## 🖼️  Screenshots

<img width="699" alt="Screenshot 2023-09-30 at 21 54 33" src="https://github.com/TypedDevs/bashunit/assets/5256287/64116224-c17c-4dda-a385-91497c7c60a6">

