### PR TITLE
Add assert for directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@
     - `assert_file_not_exists`
     - `assert_is_file_empty`
     - `assert_is_file`
+    - `assert_directory_exists`
+    - `assert_directory_not_exists`
+    - `assert_is_directory`
+    - `assert_is_directory_empty`
+    - `assert_is_directory_not_empty`
+    - `assert_is_directory_readable`
+    - `assert_is_directory_not_readable`
+    - `assert_is_directory_writable`
+    - `assert_is_directory_not_writable`
 - Rename assertions from camelCase to snake_case:
     - `assertEquals` -> `assert_equals`
     - `assertNotEquals` -> `assert_not_equals`

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -313,6 +313,117 @@ function test_failure() {
 }
 ```
 
+## assert_directory_exists
+> `assert_directory_exists "directory"`
+
+Reports an error if `directory` does not exist.
+
+[assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/var"
+
+  assert_directory_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_exists "$directory"
+}
+```
+
+## assert_is_directory
+> `assert_is_directory "directory"`
+
+Reports an error if `directory` is not a directory.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory "$directory"
+}
+
+function test_failure() {
+  local file="/etc/hosts"
+
+  assert_is_directory "$file"
+}
+```
+
+## assert_is_directory_empty
+> `assert_is_directory_empty "directory"`
+
+Reports an error if `directory` is not an empty directory.
+
+[assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/etc"
+
+  assert_is_directory_empty "$directory"
+}
+```
+
+## assert_is_directory_readable
+> `assert_is_directory_readable "directory"`
+
+Reports an error if `directory` is not a readable directory.
+
+[assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_readable "$directory"
+}
+```
+
+## assert_is_directory_writable
+> `assert_is_directory_writable "directory"`
+
+Reports an error if `directory` is not a writable directory.
+
+[assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/tmp"
+
+  assert_is_directory_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_writable "$directory"
+}
+```
+
 ## assert_not_equals
 > `assert_not_equals "expected" "actual"`
 
@@ -430,5 +541,96 @@ function test_failed() {
 
   assert_file_not_exists "$file_path"
   rm "$file_path"
+}
+```
+
+## assert_directory_not_exists
+> `assert_directory_not_exists "directory"`
+
+Reports an error if `directory` exists.
+
+[assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_not_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_directory_not_exists "$directory"
+}
+```
+
+## assert_is_directory_not_empty
+> `assert_is_directory_not_empty "directory"`
+
+Reports an error if `directory` is empty.
+
+[assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/etc"
+
+  assert_is_directory_not_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_not_empty "$directory"
+}
+```
+
+## assert_is_directory_not_readable
+> `assert_is_directory_not_readable "directory"`
+
+Reports an error if `directory` is readable.
+
+[assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_not_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_is_directory_not_readable "$directory"
+}
+```
+
+## assert_is_directory_not_writable
+> `assert_is_directory_not_writable "directory"`
+
+Reports an error if `directory` is writable.
+
+[assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
+
+*Example:*
+```bash
+function test_success() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_not_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/tmp"
+
+  assert_is_directory_not_writable "$directory"
 }
 ```

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -249,3 +249,120 @@ function assert_is_file_empty() {
 
   State::addAssertionsPassed
 }
+
+function assert_directory_exists() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to exist but" "do not exist"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_directory_not_exists() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ -d "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to not exist but" "the directory exists"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be a directory" "but is not a directory"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_empty() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" || -n "$(ls -A "$expected")" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be empty" "but is not empty"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_not_empty() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" || -z "$(ls -A "$expected")" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to not be empty" "but is empty"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_readable() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" || ! -r "$expected" || ! -x "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be readable" "but is not readable"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_not_readable() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" ]] || [[ -r "$expected" && -x "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be not readable" "but is readable"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_writable() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" || ! -w "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be writable" "but is not writable"
+    return
+  fi
+
+  State::addAssertionsPassed
+}
+
+function assert_is_directory_not_writable() {
+  local expected="$1"
+  local label="${2:-$(Helper::normalizeTestFunctionName "${FUNCNAME[1]}")}"
+
+  if [[ ! -d "$expected" || -w "$expected" ]]; then
+    State::addAssertionsFailed
+    Console::printFailedTest "${label}" "${expected}" "to be not writable" "but is writable"
+    return
+  fi
+
+  State::addAssertionsPassed
+}

--- a/tests/unit/directory_test.sh
+++ b/tests/unit/directory_test.sh
@@ -1,0 +1,266 @@
+#!/bin/bash
+
+function test_successful_assert_directory_exists() {
+  local a_directory
+  a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  assert_empty "$(assert_directory_exists "$a_directory")"
+}
+
+function test_unsuccessful_assert_directory_exists() {
+  local a_directory="a_random_directory_that_will_not_exist"
+
+  assert_equals\
+    "$(Console::printFailedTest "Unsuccessful assert directory exists" "$a_directory" "to exist but" "do not exist")"\
+    "$(assert_directory_exists "$a_directory")"
+}
+
+function test_assert_directory_exists_should_not_work_with_files() {
+  local a_file
+  a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Assert directory exists should not work with files" "$a_file" "to exist but" "do not exist")"\
+    "$(assert_directory_exists "$a_file")"
+}
+
+function test_successful_assert_directory_not_exists() {
+  local a_directory="a_random_directory_that_will_not_exist"
+
+  assert_empty "$(assert_directory_not_exists "$a_directory")"
+}
+
+function test_unsuccessful_assert_directory_not_exists() {
+  local a_directory
+  a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert directory not exists" "$a_directory" "to not exist but" "the directory exists")"\
+    "$(assert_directory_not_exists "$a_directory")"
+}
+
+function test_successful_assert_is_directory() {
+  local a_directory
+  a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  assert_empty "$(assert_is_directory "$a_directory")"
+}
+
+function test_unsuccessful_assert_is_directory() {
+  local a_directory="a_random_directory_that_will_not_exist"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory" "$a_directory" "to be a directory" "but is not a directory")"\
+    "$(assert_is_directory "$a_directory")"
+}
+
+function test_unsuccessful_assert_is_directory_when_a_file_is_given() {
+  local a_file
+  a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  assert_equals\
+    "$(Console::printFailedTest\
+      "Unsuccessful assert is directory when a file is given" "$a_file" "to be a directory" "but is not a directory")"\
+    "$(assert_is_directory "$a_file")"
+}
+
+function test_successful_assert_is_directory_empty() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_empty "$(assert_is_directory_empty "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_empty() {
+  local a_directory
+  a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory empty" "$a_directory" "to be empty" "but is not empty")"\
+    "$(assert_is_directory_empty "$a_directory")"
+}
+
+function test_successful_assert_is_directory_not_empty() {
+  local a_directory
+  a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+  assert_empty "$(assert_is_directory_not_empty "$a_directory")"
+}
+
+function test_unsuccessful_assert_is_directory_not_empty() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory not empty" "$a_directory" "to not be empty" "but is empty")"\
+    "$(assert_is_directory_not_empty "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_successful_assert_is_directory_readable() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_empty "$(assert_is_directory_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_readable_when_a_file_is_given() {
+  local a_file
+  a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  assert_equals\
+    "$(Console::printFailedTest\
+      "Unsuccessful assert is directory readable when a file is given" \
+      "$a_file" "to be readable" "but is not readable")"\
+    "$(assert_is_directory_readable "$a_file")"
+}
+
+function test_unsuccessful_assert_is_directory_readable_without_execution_permission() {
+  if [[ "$_OS" == "Windows" ]]; then
+    return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-x "$a_directory"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory readable without execution permission" \
+      "$a_directory" "to be readable" "but is not readable")"\
+    "$(assert_is_directory_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_readable_without_read_permission() {
+  if [[ "$_OS" == "Windows" ]]; then
+      return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-r "$a_directory"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory readable without read permission" \
+      "$a_directory" "to be readable" "but is not readable")"\
+    "$(assert_is_directory_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_successful_assert_is_directory_not_readable_without_read_permission() {
+  if [[ "$_OS" == "Windows" ]]; then
+      return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-r "$a_directory"
+
+  assert_empty "$(assert_is_directory_not_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_successful_assert_is_directory_not_readable_without_execution_permission() {
+  if [[ "$_OS" == "Windows" ]]; then
+      return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-x "$a_directory"
+
+  assert_empty "$(assert_is_directory_not_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_not_readable() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory not readable" "$a_directory" "to be not readable" "but is readable")"\
+    "$(assert_is_directory_not_readable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_successful_assert_is_directory_writable() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_empty "$(assert_is_directory_writable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_writable() {
+  if [[ "$_OS" == "Windows" ]]; then
+      return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-w "$a_directory"
+
+  assert_equals\
+    "$(Console::printFailedTest \
+      "Unsuccessful assert is directory writable" "$a_directory" "to be writable" "but is not writable")"\
+    "$(assert_is_directory_writable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_writable_when_a_file_is_given() {
+  local a_file
+  a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+  assert_equals\
+    "$(Console::printFailedTest\
+      "Unsuccessful assert is directory writable when a file is given" \
+      "$a_file" "to be writable" "but is not writable")"\
+    "$(assert_is_directory_writable "$a_file")"
+}
+
+function test_successful_assert_is_directory_not_writable() {
+  if [[ "$_OS" == "Windows" ]]; then
+      return
+  fi
+
+  local a_directory
+  a_directory=$(mktemp -d)
+  chmod a-w "$a_directory"
+
+  assert_empty "$(assert_is_directory_not_writable "$a_directory")"
+
+  rmdir "$a_directory"
+}
+
+function test_unsuccessful_assert_is_directory_not_writable() {
+  local a_directory
+  a_directory=$(mktemp -d)
+
+  assert_equals\
+    "$(Console::printFailedTest\
+      "Unsuccessful assert is directory not writable" \
+      "$a_file" "to be not writable" "but is writable")"\
+    "$(assert_is_directory_not_writable "$a_file")"
+
+  rmdir "$a_directory"
+}


### PR DESCRIPTION
## 📚 Description

Based on the new assert for files (https://github.com/TypedDevs/bashunit/pull/128), I have added new assert for directory:

  - `assert_directory_exists`
  - `assert_directory_not_exists`
  - `assert_is_directory`
  - `assert_is_directory_empty`
  - `assert_is_directory_not_empty`
  - `assert_is_directory_readable`
  - `assert_is_directory_not_readable`
  - `assert_is_directory_writable`
  - `assert_is_directory_not_writable`

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
