### PR TITLE
Little test doubles changes

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -49,11 +49,11 @@ export default defineConfig({
           link: '/test-files#test-function-names',
         }]
       }, {
-        text: 'Assertions',
-        link: '/assertions'
-      },{
         text: 'Test doubles',
         link: '/test-doubles'
+      }, {
+        text: 'Assertions',
+        link: '/assertions'
       }, {
         text: 'Examples',
         link: '/examples'

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -5,11 +5,11 @@ When creating tests, you might need to override existing function to be able to 
 ## mock
 > `mock "function" "body"`
 
-Override the behaviour of a function.
+Allows you to override the behavior of a callable.
 
 *Example:*
 ```bash
-function test_success() {
+function test_example() {
   mock ps echo hello world
 
   assert_equals "hello world" "$(ps)"
@@ -19,27 +19,36 @@ function test_success() {
 ## spy
 > `spy "function"`
 
-Spies are mocks that record some information based on how they were called.
+Overrides the original behavior of a callable to allow you to make various assertions about its calls.
 
 *Example:*
 ```bash
-function test_success_spy_call_with() {
+function test_example() {
   spy ps
-  ps a_random_parameter_1 a_random_parameter_2
 
-  assert_have_been_called_with "a_random_parameter_1 a_random_parameter_2" ps
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
   assert_have_been_called ps
 }
 ```
 
 ### assert_have_been_called
-> `assert_have_been_called ["a spy"]`
+> `assert_have_been_called "spy"`
 
-Informs you if the `spy` has been called at least once.
+Reports an error if `spy` is not called.
 
 *Example:*
 ```bash
-function test_that_spy_has_been_called() {
+function test_success() {
+  spy ps
+
+  ps
+
+  assert_have_been_called ps
+}
+
+function test_failure() {
   spy ps
 
   assert_have_been_called ps
@@ -47,33 +56,51 @@ function test_that_spy_has_been_called() {
 ```
 
 ### assert_have_been_called_with
-> `assert_have_been_called_with ["arguments"] ["a spy"]`
+> `assert_have_been_called_with "expected" "spy"`
 
-Informs you if the `spy` has been called with the arguments passed.
+Reports an error if `callable` is not called with `expected`.
 
 *Example:*
 ```bash
-function test_that_spy_has_been_called_with() {
+function test_success() {
   spy ps
+
   ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps bar foo
 
   assert_have_been_called_with "foo bar" ps
 }
 ```
 
 ### assert_have_been_called_times
-> assert_have_been_called_times [a spy]
+> assert_have_been_called_times "expected" "spy"
 
-Informs you if the `spy` has been called a certain amount of times.
+Reports an error if `spy` is not called exactly `expected` times.
 
 *Example:*
 ```bash
-function test_that_spy_has_been_called_times() {
+function test_success() {
   spy ps
 
   ps
   ps
 
   assert_have_been_called_times 2 ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 1 ps
 }
 ```

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -31,7 +31,7 @@ function assert_have_been_called() {
 
   if [[ ${!actual} -eq 0 ]]; then
     State::addAssertionsFailed
-    Console::printFailedTest "${label}" "${command}" "has not been called at least" "once"
+    Console::printFailedTest "${label}" "${command}" "to has been called" "once"
     return
   fi
 
@@ -63,7 +63,7 @@ function assert_have_been_called_times() {
 
   if [[ ${!actual} -ne $expected ]]; then
     State::addAssertionsFailed
-    Console::printFailedTest "${label}" "${command}" "has not been called" "${expected} times"
+    Console::printFailedTest "${label}" "${command}" "to has been called" "${expected} times"
     return
   fi
 

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -8,6 +8,7 @@ function tearDown() {
 function setUp() {
   function code() {
     # shellcheck disable=SC2009
+    # shellcheck disable=SC2317
     ps a | grep apache
   }
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -2,15 +2,14 @@
 
 function tearDown() {
   unset code
-  unset _ps
+  unset ps
 }
 
 function setUp() {
   function code() {
-      # shellcheck disable=SC2009
-      # shellcheck disable=SC2317
-      ps a | grep apache
-    }
+    # shellcheck disable=SC2009
+    ps a | grep apache
+  }
 }
 
 function test_successful_mock() {
@@ -41,10 +40,9 @@ function test_unsuccessful_spy_called() {
   spy ps
 
   assert_equals\
-    "$(Console::printFailedTest "Unsuccessful spy called" "ps" "has not been called at least" "once")"\
+    "$(Console::printFailedTest "Unsuccessful spy called" "ps" "to has been called" "once")"\
     "$(assert_have_been_called ps)"
 }
-
 
 function test_successful_spy_called_times() {
   spy ps
@@ -55,3 +53,14 @@ function test_successful_spy_called_times() {
   assert_have_been_called_times 2 ps
 }
 
+
+function test_unsuccessful_spy_called_times() {
+  spy ps
+
+  ps
+  ps
+
+  assert_equals\
+    "$(Console::printFailedTest "Unsuccessful spy called times" "ps" "to has been called" "1 times")"\
+    "$(assert_have_been_called_times 1 ps)"
+}


### PR DESCRIPTION
## 🔖 Changes

- On docs, i moved test doubles before assertions (similar order in PHPUnit and Jest).
- Changed docs/test-doubles.md general descriptions/examples to fit more with the other sections.
- Changed the fail output of assert_have_been_called and assert_have_been_called_times to be more developer-friendly
- Test assert_have_been_called_times fail output

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
