### PR TITLE
Refactor runner functions

### DIFF
--- a/bashunit
+++ b/bashunit
@@ -47,6 +47,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-Runner::loadTestFiles "$_FILTER" "${_FILES[@]}"
+runner::load_test_files "$_FILTER" "${_FILES[@]}"
 
 exit 0

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# shellcheck disable=SC2317
-
 function Runner::loadTestFiles() {
   local filter=$1
   local files=("${@:2}") # Store all arguments starting from the second as an array
@@ -16,8 +14,8 @@ function Runner::loadTestFiles() {
     if [[ ! -f $test_file ]]; then
       continue
     fi
-    # shellcheck disable=SC1090
-    #shellcheck source=/dev/null
+
+    # shellcheck source=/dev/null
     source "$test_file"
 
     Runner::runSetUpBeforeScript

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -18,7 +18,7 @@ function runner::load_test_files() {
     # shellcheck source=/dev/null
     source "$test_file"
 
-    Runner::runSetUpBeforeScript
+    runner::run_set_up_before_script
     runner::call_test_functions "$test_file" "$filter"
     if [ "$PARALLEL_RUN" = true ] ; then
       wait
@@ -92,7 +92,7 @@ function runner::run_test() {
     state::initialize_assertions_count
 
     set -e
-    Runner::runSetUp
+    runner::run_set_up
     "$function_name"
     Runner::runTearDown
 
@@ -117,12 +117,12 @@ function runner::run_test() {
   state::add_tests_passed
 }
 
-function Runner::runSetUp() {
+function runner::run_set_up() {
   Helper::executeFunctionIfExists 'setUp' # Deprecated: please use set_up instead.
   Helper::executeFunctionIfExists 'set_up'
 }
 
-function Runner::runSetUpBeforeScript() {
+function runner::run_set_up_before_script() {
   Helper::executeFunctionIfExists 'setUpBeforeScript' # Deprecated: please use set_up_before_script instead.
   Helper::executeFunctionIfExists 'set_up_before_script'
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -137,13 +137,6 @@ function runner::run_tear_down_after_script() {
   Helper::executeFunctionIfExists 'tear_down_after_script'
 }
 
-function Runner::cleanSetUpAndTearDownAfterTest() {
-  Helper::unsetIfExists 'setUp' # Deprecated: please use set_up instead.
-  Helper::unsetIfExists 'set_up'
-  Helper::unsetIfExists 'tearDown' # Deprecated: please use tear_down instead.
-  Helper::unsetIfExists 'tear_down'
-}
-
 function Runner::cleanSetUpAndTearDownAfterScript() {
   Helper::unsetIfExists 'setUpBeforeScript' # Deprecated: please use set_up_before_script instead.
   Helper::unsetIfExists 'set_up_before_script'

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-function Runner::loadTestFiles() {
+function runner::load_test_files() {
   local filter=$1
   local files=("${@:2}") # Store all arguments starting from the second as an array
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -19,7 +19,7 @@ function runner::load_test_files() {
     source "$test_file"
 
     Runner::runSetUpBeforeScript
-    Runner::callTestFunctions "$test_file" "$filter"
+    runner::call_test_functions "$test_file" "$filter"
     if [ "$PARALLEL_RUN" = true ] ; then
       wait
     fi
@@ -28,7 +28,7 @@ function runner::load_test_files() {
   done
 }
 
-function Runner::callTestFunctions() {
+function runner::call_test_functions() {
   local script="$1"
   local filter="$2"
   local prefix="test"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -54,7 +54,7 @@ function runner::call_test_functions() {
   fi
 }
 
-function Runner::parseExecutionResult() {
+function runner::parse_execution_result() {
   local execution_result=$1
 
   local assertions_failed
@@ -99,7 +99,7 @@ function Runner::runTest() {
     state::export_assertions_count
   )
   local test_result_code=$?
-  Runner::parseExecutionResult "$test_execution_result"
+  runner::parse_execution_result "$test_execution_result"
 
   if [[ "$current_assertions_failed" != "$(state::get_assertions_failed)" ]]; then
     state::add_tests_failed

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -23,7 +23,7 @@ function runner::load_test_files() {
     if [ "$PARALLEL_RUN" = true ] ; then
       wait
     fi
-    Runner::runTearDownAfterScript
+    runner::run_tear_down_after_script
     Runner::cleanSetUpAndTearDownAfterScript
   done
 }
@@ -94,7 +94,7 @@ function runner::run_test() {
     set -e
     runner::run_set_up
     "$function_name"
-    Runner::runTearDown
+    runner::run_tear_down
 
     state::export_assertions_count
   )
@@ -127,12 +127,12 @@ function runner::run_set_up_before_script() {
   Helper::executeFunctionIfExists 'set_up_before_script'
 }
 
-function Runner::runTearDown() {
+function runner::run_tear_down() {
   Helper::executeFunctionIfExists 'tearDown' # Deprecated: please use tear_down instead.
   Helper::executeFunctionIfExists 'tear_down'
 }
 
-function Runner::runTearDownAfterScript() {
+function runner::run_tear_down_after_script() {
   Helper::executeFunctionIfExists 'tearDownAfterScript' # Deprecated: please use tear_down_after_script instead.
   Helper::executeFunctionIfExists 'tear_down_after_script'
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -47,7 +47,7 @@ function runner::call_test_functions() {
     Helper::checkDuplicateFunctions "$script"
 
     for function_name in "${functions_to_run[@]}"; do
-      Runner::runTest "$function_name"
+      runner::run_test "$function_name"
 
       unset "$function_name"
     done
@@ -82,7 +82,7 @@ function runner::parse_execution_result() {
   fi
 }
 
-function Runner::runTest() {
+function runner::run_test() {
   local function_name="$1"
   local current_assertions_failed
   local test_execution_result

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -24,7 +24,7 @@ function runner::load_test_files() {
       wait
     fi
     runner::run_tear_down_after_script
-    Runner::cleanSetUpAndTearDownAfterScript
+    runner::clean_set_up_and_tear_down_after_script
   done
 }
 
@@ -137,7 +137,7 @@ function runner::run_tear_down_after_script() {
   Helper::executeFunctionIfExists 'tear_down_after_script'
 }
 
-function Runner::cleanSetUpAndTearDownAfterScript() {
+function runner::clean_set_up_and_tear_down_after_script() {
   Helper::unsetIfExists 'setUpBeforeScript' # Deprecated: please use set_up_before_script instead.
   Helper::unsetIfExists 'set_up_before_script'
   Helper::unsetIfExists 'tearDownAfterScript' # Deprecated: please use tear_down_after_script instead.


### PR DESCRIPTION
## 📚 Description

Refactor all the state function names to follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)

Removed unused function (Runner::cleanSetUpAndTearDownAfterTest)

It's an internal refactor so I didn't added it to the CHANGELOG.md

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
