### PR TITLE
Allow using main or latest when using install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Find all test on a directory
 - Add skip and todo functions
 - Add SIMPLE_OUTPUT to `.env`
+- Allow using `main` or `latest` when using install.sh
 
 ## [0.7.0](https://github.com/TypedDevs/bashunit/compare/0.6.0...0.7.0) - 2023-10-02
 

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,9 @@ rm -f "$DIR"/bashunit
 [ -d "$DIR" ] || mkdir "$DIR"
 cd "$DIR"
 
-if [[ $TAG == latest ]]; then
-  echo "> Using latest version"
-  git clone -b latest https://github.com/TypedDevs/bashunit temp_bashunit
+if [[ "$TAG" == "latest" || "$TAG" == "main" ]]; then
+  echo "> Using $TAG version"
+  git clone -b "$TAG" https://github.com/TypedDevs/bashunit temp_bashunit
   cd temp_bashunit
   ./build.sh
   cd ..


### PR DESCRIPTION
## 📚 Description

Currently, the installer accepts a concrete TAG or latest branch, but there is no possibility to install the `main` branch.

## 🔖 Changes

- Allow passing `main` to install the main branch similarly as with the `latest` branch
