### PR TITLE
docs: add tooltip in installation page

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Although there's no Bash script dependency manager <sup style="cursor:default; font-size:x-small" title="Like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP">ⓘ</sup>;
+Although there's no Bash script dependency manager[<sup style="font-size:x-small">ⓘ</sup>](## "Like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP");
 you can add **bashunit** as a dependency in your repository according to your preferences.
 
 Here, we provide different options that you can use to install **bashunit** in your application.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
+Although there's no Bash script dependency manager <sup style="cursor:default; font-size:x-small" title="Like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP">ⓘ</sup>;
 you can add **bashunit** as a dependency in your repository according to your preferences.
 
 Here, we provide different options that you can use to install **bashunit** in your application.


### PR DESCRIPTION
## 📚 Description

Move `like npm for Javascript ...` text to a tooltip.

![image](https://github.com/TypedDevs/bashunit/assets/6381924/989b8d12-aa78-4d10-9132-93c1dce10e72)
