### PR TITLE
Create --help option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Optimised docs Fonts (Serving directly from origin instead of Google Fonts _proxy_)
 - Add Brew installation to docs
+- Add `--help` option
 
 ## [0.8.0](https://github.com/TypedDevs/bashunit/compare/0.7.0...0.8.0) - 2023-10-08
 

--- a/bashunit
+++ b/bashunit
@@ -46,6 +46,10 @@ while [[ $# -gt 0 ]]; do
       console_header::print_version
       trap '' EXIT && exit 0
       ;;
+    --help)
+      console_header::print_help
+      trap '' EXIT && exit 0
+      ;;
     *)
       while IFS='' read -r line; do
         _FILES+=("$line");

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -92,6 +92,33 @@ Displays the current version of **bashunit**.
 bashunit - {{ pkg.version }}
 ```
 
+
+## Help
+
+> `bashunit --help`
+
+Displays a help message with all allowed arguments and options.
+
+*Example:*
+```bash
+./bashunit --help
+```
+
+*Output:*
+```text-vue
+bashunit [arguments] [options]
+
+Arguments:
+  Specifies the directory or file containing [...]
+
+Options:
+    -f|--filer
+    Filters the tests to run based on the test name.
+
+  -s|simple || -v|verbose
+    [...]
+```
+
 <script setup>
 import pkg from '../package.json'
 </script>

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -112,11 +112,10 @@ Arguments:
   Specifies the directory or file containing [...]
 
 Options:
-    -f|--filer
+  -f|--filer
     Filters the tests to run based on the test name.
 
-  -s|simple || -v|verbose
-    [...]
+  [...]
 ```
 
 <script setup>

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -11,7 +11,7 @@ function console_header::print_version() {
 EOF
     printf "%s\n\n" "$BASHUNIT_VERSION"
   else
-    printf "${_COLOR_BOLD}${_COLOR_PASSED}bashunit${_COLOR_DEFAULT} - %s\n" "$BASHUNIT_VERSION"
+    printf "${_COLOR_PASSED}bashunit - %s\n" "$BASHUNIT_VERSION"
   fi
 }
 
@@ -27,23 +27,24 @@ function console_header::print_help() {
     cat <<EOF
 bashunit [arguments] [options]
 
-${_COLOR_BOLD}Arguments:${_COLOR_DEFAULT}
-  ${_COLOR_FAINT}bashunit "directory|file"${_COLOR_DEFAULT}
+Arguments:
+  Specifies the directory or file containing the tests to run.
+  If a directory is specified, it will execute the tests within files ending with test.sh.
+  If you use wildcards, bashunit will run any tests it finds.
 
-Specifies the directory or file containing the tests to be run.
-If a directory is specified, it will execute tests within files ending in test.sh.
-If you use wildcards, bashunit will run any tests it finds.
+Options:
+  -f|--filer
+    Filters the tests to run based on the test name.
 
-${_COLOR_BOLD}Options:${_COLOR_DEFAULT}
-${_COLOR_BOLD}-f|--filer${_COLOR_DEFAULT} Filters the tests to be run based on the test name.
-  ${_COLOR_FAINT}bashunit -f|--filter "test name"${_COLOR_DEFAULT}
+  -s|simple || -v|verbose
+    Enables simplified or verbose output to the console.
 
-${_COLOR_BOLD}-s|simple || -v|verbose${_COLOR_DEFAULT} Enables simplified or verbose output to the console.
-  ${_COLOR_FAINT}bashunit -s "test name"${_COLOR_DEFAULT}
+  --version
+    Displays the current version of bashunit.
 
-${_COLOR_BOLD}--version${_COLOR_DEFAULT} Displays the current version of bashunit.
-  ${_COLOR_FAINT}bashunit --version${_COLOR_DEFAULT}
+  --help
+    This message.
 
-${_COLOR_BOLD}--help${_COLOR_DEFAULT} This message.
+See more: https://bashunit.typeddevs.com/command-line
 EOF
 }

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -15,11 +15,35 @@ EOF
   fi
 }
 
-
 function console_header::print_version_with_env() {
     local should_print_ascii="true"
     if [[ "$SHOW_HEADER" != "$should_print_ascii" ]]; then
       return
     fi
     console_header::print_version
+}
+
+function console_header::print_help() {
+    cat <<EOF
+bashunit [arguments] [options]
+
+${_COLOR_BOLD}Arguments:${_COLOR_DEFAULT}
+  ${_COLOR_FAINT}bashunit "directory|file"${_COLOR_DEFAULT}
+
+Specifies the directory or file containing the tests to be run.
+If a directory is specified, it will execute tests within files ending in test.sh.
+If you use wildcards, bashunit will run any tests it finds.
+
+${_COLOR_BOLD}Options:${_COLOR_DEFAULT}
+${_COLOR_BOLD}-f|--filer${_COLOR_DEFAULT} Filters the tests to be run based on the test name.
+  ${_COLOR_FAINT}bashunit -f|--filter "test name"${_COLOR_DEFAULT}
+
+${_COLOR_BOLD}-s|simple || -v|verbose${_COLOR_DEFAULT} Enables simplified or verbose output to the console.
+  ${_COLOR_FAINT}bashunit -s "test name"${_COLOR_DEFAULT}
+
+${_COLOR_BOLD}--version${_COLOR_DEFAULT} Displays the current version of bashunit.
+  ${_COLOR_FAINT}bashunit --version${_COLOR_DEFAULT}
+
+${_COLOR_BOLD}--help${_COLOR_DEFAULT} This message
+EOF
 }

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -44,6 +44,6 @@ ${_COLOR_BOLD}-s|simple || -v|verbose${_COLOR_DEFAULT} Enables simplified or ver
 ${_COLOR_BOLD}--version${_COLOR_DEFAULT} Displays the current version of bashunit.
   ${_COLOR_FAINT}bashunit --version${_COLOR_DEFAULT}
 
-${_COLOR_BOLD}--help${_COLOR_DEFAULT} This message
+${_COLOR_BOLD}--help${_COLOR_DEFAULT} This message.
 EOF
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -6,7 +6,7 @@ function runner::load_test_files() {
 
   if [[ ${#files[@]} == 0 ]]; then
     printf "%sError: At least one file path is required.%s\n" "${_COLOR_FAILED}" "${_COLOR_DEFAULT}"
-    printf "%sUsage: %s <test_file.sh>%s\n" "${_COLOR_DEFAULT}" "$0" "${_COLOR_DEFAULT}"
+    console_header::print_help
     exit 1
   fi
 


### PR DESCRIPTION
## 🔖 Changes

- Add `--help` option
- Display the help text if no argument is provided

## 🖼️ Screenshots

### --help 
<img width="831" alt="Screenshot 2023-10-11 at 09 52 54" src="https://github.com/TypedDevs/bashunit/assets/5256287/cbf59849-9f01-4d76-8d76-68648fff6f5c">

### no arguments

<img width="510" alt="Screenshot 2023-10-11 at 09 53 19" src="https://github.com/TypedDevs/bashunit/assets/5256287/7812f36d-2675-4c4b-95f9-8d7375aa3eca">

### Docs/Website

![Screenshot 2023-10-11 at 09 53 49](https://github.com/TypedDevs/bashunit/assets/5256287/00b5d919-b195-46ab-a824-b96a0766c50c)
