### PR TITLE
Data provider for test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Optimised docs Fonts (Serving directly from origin instead of Google Fonts _proxy_)
 - Add Brew installation to docs
 - Add `--help` option
+- Add data_provider
 
 ## [0.8.0](https://github.com/TypedDevs/bashunit/compare/0.7.0...0.8.0) - 2023-10-08
 

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -79,3 +79,40 @@ function tear_down_after_script() {
   close_database_connection
 }
 ```
+
+## Data providers
+
+The test function can accept data from a data provider function. The data provider function is specified using a comment before the function declaration.
+The format of this comment will be the following:
+
+```
+# data_provider provider_function_name
+function test_my_test_case() {
+...
+}
+```
+
+If **bashunit** find before the test function declaration a comment with the key `data_provider` followed by a provider function name, this provider function
+will be executed before running the test function and the data provided by this provider function will be passed as the first argument to the test function.
+
+The provider function can return a list of values like `one two three` or a single value `one`. In case of a list of values, in each iteration of this list,
+the provided data will be the current list value.
+
+Example:
+
+```
+function provider_directories() {
+  local directories=("/usr" "/etc" "/var")
+  echo "${directories[@]}"
+}
+
+# data_provider provider_directories
+function test_should_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}
+```
+
+In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of the data provided by this function
+and the test function will be executed passing each time the current iteration value as the first argument.

--- a/example/logic_test.sh
+++ b/example/logic_test.sh
@@ -103,3 +103,15 @@ function test_should_assert_that_an_array_not_contains_1234() {
 
   assert_array_not_contains "a_non_existing_element" "${distros[@]}"
 }
+
+function provider_existing_directories() {
+  local directories=(/*)
+  echo "${directories[@]}"
+}
+
+# data_provider provider_existing_directories
+function test_should_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -124,3 +124,22 @@ helper::normalize_variable_name() {
   echo "$normalized_string"
 }
 
+function helper::get_provider_data() {
+  local function_name="$1"
+  local script="$2"
+  local data_provider_function
+
+  if [[ ! -f "$script" ]]; then
+    return
+  fi
+
+  data_provider_function=$(\
+    grep -B 1 "function $function_name()" "$script" |\
+    grep "# data_provider " |\
+    sed -E -e 's/\ *# data_provider (.*)$/\1/g'\
+  )
+
+  if [[ -n "$data_provider_function" ]]; then
+    helper::execute_function_if_exists "$data_provider_function"
+  fi
+}

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE=""
+
+function set_up_before_script() {
+  _TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE=$(mktemp)
+  echo 0 > "$_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE"
+}
+
+function tear_down_after_script() {
+  rm "$_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE"
+}
+
+# data_provider provider_test_data_array
+function test_get_data_from_provider_as_array() {
+  local current_data="$1"
+  local current_iteration=0
+
+  echo "$(awk 'BEGIN{FS=OFS=""} {$1++} {print $1}' "$_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE")"\
+    > "$_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE"
+  current_iteration=$(cat "$_TEST_GET_DATA_FROM_PROVIDER_ITERATION_FILE")
+
+  case $current_iteration in
+    1)
+      assert_equals "one" "$current_data"
+      ;;
+    2)
+      assert_equals "two" "$current_data"
+      ;;
+    3)
+      assert_equals "three" "$current_data"
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+}
+
+# data_provider provider_test_data_single_value
+function test_get_data_from_provider_as_single_value() {
+  local current_data="$1"
+
+  assert_equals "one" "$current_data"
+}
+
+function provider_test_data_array() {
+  local data=("one" "two" "three")
+  echo "${data[@]}"
+}
+
+function provider_test_data_single_value() {
+  echo "one"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -105,3 +105,44 @@ function test_normalize_variable_name() {
   assert_equals "_variable" "$(helper::normalize_variable_name "_variable")"
   assert_equals "__________" "$(helper::normalize_variable_name "!@#$%^&*()")"
 }
+
+function fake_provider_data_string() {
+  echo "data_provided"
+}
+
+function test_get_provider_data() {
+  # shellcheck disable=SC2317
+  # data_provider fake_provider_data_string
+  function fake_function_get_provider_data() {
+    return 0
+  }
+
+  assert_equals "data_provided" "$(helper::get_provider_data "fake_function_get_provider_data" "${BASH_SOURCE[0]}")"
+}
+
+function fake_provider_data_array() {
+  local data=("one" "two" "three")
+  echo "${data[@]}"
+}
+
+function test_get_provider_data_array() {
+  # shellcheck disable=SC2317
+  # data_provider fake_provider_data_array
+  function fake_function_get_provider_data_array() {
+    return 0
+  }
+
+  assert_equals \
+    "one two three" \
+    "$(helper::get_provider_data "fake_function_get_provider_data_array" "${BASH_SOURCE[0]}")"
+}
+
+function test_get_provider_data_should_returns_empty_when_not_exists_provider_function() {
+  # shellcheck disable=SC2317
+  # data_provider not_existing_provider
+  function fake_function_get_not_existing_provider_data() {
+    return 0
+  }
+
+  assert_equals "" "$(helper::get_provider_data "fake_function_get_not_existing_provider_data" "${BASH_SOURCE[0]}")"
+}


### PR DESCRIPTION
## 📚 Description

This is a **proof of concept** PR of a simple data provider for test functions.

The main idea is having an "annotation" just before the test function where we can specify the data provider function as this:

```
# data_provider function_data_provider
function test_my_function_test() {
  ...
}
```

This function_data_provider can return a single or a list of values. Those are two examples of data provider:

```
function provider_test_data_array() {
  local data=("one" "two" "three")  
  echo "${data[@]}" 
}

function provider_test_data_single_value() {
  echo "one" 
}
```

The test function will receive the data provided in the $1 parameter.

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure you have updated the documentation to reflect the changes or new features
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
