### PR TITLE
Add code-groups

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -11,8 +11,8 @@ Reports an error if the two variables `expected` and `actual` are not equal.
 
 [assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_equals "foo" "foo"
 }
@@ -21,6 +21,7 @@ function test_failure() {
   assert_equals "foo" "bar"
 }
 ```
+:::
 
 ## assert_contains
 > `assert_contains "needle" "haystack"`
@@ -29,8 +30,8 @@ Reports an error if `needle` is not a substring of `haystack`.
 
 [assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_contains "foo" "foobar"
 }
@@ -39,6 +40,7 @@ function test_failure() {
   assert_contains "baz" "foobar"
 }
 ```
+:::
 
 ## assert_empty
 > `assert_empty "actual"`
@@ -47,8 +49,8 @@ Reports an error if `actual` is not empty.
 
 [assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_empty ""
 }
@@ -57,6 +59,7 @@ function test_failure() {
   assert_empty "foo"
 }
 ```
+:::
 
 ## assert_matches
 > `assert_matches "pattern" "value"`
@@ -65,8 +68,8 @@ Reports an error if `value` does not match the regular expression `pattern`.
 
 [assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_matches "^foo" "foobar"
 }
@@ -75,6 +78,7 @@ function test_failure() {
   assert_matches "^bar" "foobar"
 }
 ```
+:::
 
 ## assert_exit_code
 > `assert_exit_code "expected" ["callable"]`
@@ -86,8 +90,8 @@ If `callable` is not provided, it takes the last executed command or function in
 [assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success_with_callable() {
   function foo() {
     return 1
@@ -114,6 +118,7 @@ function test_failure() {
   assert_exit_code "0" "$(foo)"
 }
 ```
+:::
 
 ## assert_array_contains
 > `assert_array_contains "needle" "haystack"`
@@ -122,8 +127,8 @@ Reports an error if `needle` is not an element of `haystack`.
 
 [assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local haystack=(foo bar baz)
 
@@ -136,6 +141,7 @@ function test_failure() {
   assert_array_contains "foobar" "${haystack[@]}"
 }
 ```
+:::
 
 ## assert_successful_code
 > `assert_successful_code ["callable"]`
@@ -146,8 +152,8 @@ If `callable` is not provided, it takes the last executed command or function in
 
 [assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success_with_callable() {
   function foo() {
     return 0
@@ -174,6 +180,7 @@ function test_failure() {
   assert_successful_code "$(foo)"
 }
 ```
+:::
 
 ## assert_general_error
 > `assert_general_error ["callable"]`
@@ -184,8 +191,8 @@ If `callable` is not provided, it takes the last executed command or function in
 
 [assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success_with_callable() {
   function foo() {
     return 1
@@ -212,6 +219,7 @@ function test_failure() {
   assert_general_error "$(foo)"
 }
 ```
+:::
 
 ## assert_command_not_found
 > `assert_general_error ["callable"]`
@@ -223,8 +231,8 @@ If `callable` is not provided, it takes the last executed command or function in
 
 [assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success_with_callable() {
   assert_command_not_found "$(foo > /dev/null 2>&1)"
 }
@@ -239,6 +247,7 @@ function test_failure() {
   assert_command_not_found "$(ls > /dev/null 2>&1)"
 }
 ```
+:::
 
 ## assert_file_exists
 > `assert_file_exists "file"`
@@ -247,8 +256,8 @@ Reports an error if `file` does not exists, or it is a directory.
 
 [assert_file_not_exists](#assert-file-not-exists) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local file_path="foo.txt"
   touch "$file_path"
@@ -264,14 +273,15 @@ function test_failure() {
   assert_file_exists "$file_path"
 }
 ```
+:::
 
 ## assert_is_file
 > `assert_is_file "file"`
 
 Reports an error if `file` is not a file.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local file_path="foo.txt"
   touch "$file_path"
@@ -288,14 +298,15 @@ function test_failure() {
   rmdir "$dir_path"
 }
 ```
+:::
 
 ## assert_is_file_empty
 > `assert_is_file_empty "file"`
 
 Reports an error if `file` is not empty.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local file_path="foo.txt"
   touch "$file_path"
@@ -312,6 +323,7 @@ function test_failure() {
   rm "$file_path"
 }
 ```
+:::
 
 ## assert_directory_exists
 > `assert_directory_exists "directory"`
@@ -320,8 +332,8 @@ Reports an error if `directory` does not exist.
 
 [assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/var"
 
@@ -334,14 +346,15 @@ function test_failure() {
   assert_directory_exists "$directory"
 }
 ```
+:::
 
 ## assert_is_directory
 > `assert_is_directory "directory"`
 
 Reports an error if `directory` is not a directory.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/var"
 
@@ -354,6 +367,7 @@ function test_failure() {
   assert_is_directory "$file"
 }
 ```
+:::
 
 ## assert_is_directory_empty
 > `assert_is_directory_empty "directory"`
@@ -362,8 +376,8 @@ Reports an error if `directory` is not an empty directory.
 
 [assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/home/user/empty_directory"
   mkdir "$directory"
@@ -377,6 +391,7 @@ function test_failure() {
   assert_is_directory_empty "$directory"
 }
 ```
+:::
 
 ## assert_is_directory_readable
 > `assert_is_directory_readable "directory"`
@@ -385,8 +400,8 @@ Reports an error if `directory` is not a readable directory.
 
 [assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/var"
 
@@ -400,6 +415,7 @@ function test_failure() {
   assert_is_directory_readable "$directory"
 }
 ```
+:::
 
 ## assert_is_directory_writable
 > `assert_is_directory_writable "directory"`
@@ -408,8 +424,8 @@ Reports an error if `directory` is not a writable directory.
 
 [assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/tmp"
 
@@ -423,6 +439,7 @@ function test_failure() {
   assert_is_directory_writable "$directory"
 }
 ```
+:::
 
 ## assert_not_equals
 > `assert_not_equals "expected" "actual"`
@@ -431,8 +448,8 @@ Reports an error if the two variables `expected` and `actual` are equal.
 
 [assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_not_equals "foo" "bar"
 }
@@ -441,6 +458,7 @@ function test_failure() {
   assert_not_equals "foo" "foo"
 }
 ```
+:::
 
 ## assert_not_contains
 > `assert_not_contains "needle" "haystack"`
@@ -449,8 +467,8 @@ Reports an error if `needle` is a substring of `haystack`.
 
 [assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_not_contains "baz" "foobar"
 }
@@ -459,6 +477,7 @@ function test_failure() {
   assert_not_contains "foo" "foobar"
 }
 ```
+:::
 
 ## assert_not_empty
 > `assert_not_empty "actual"`
@@ -467,8 +486,8 @@ Reports an error if `actual` is empty.
 
 [assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_not_empty "foo"
 }
@@ -477,6 +496,7 @@ function test_failure() {
   assert_not_empty ""
 }
 ```
+:::
 
 ## assert_not_matches
 > `assert_not_matches "pattern" "value"`
@@ -485,8 +505,8 @@ Reports an error if `value` matches the regular expression `pattern`.
 
 [assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   assert_not_matches "foo$" "foobar"
 }
@@ -495,6 +515,7 @@ function test_failure() {
   assert_not_matches "bar$" "foobar"
 }
 ```
+:::
 
 ## assert_array_not_contains
 > `assert_array_not_contains "needle" "haystack"`
@@ -503,8 +524,8 @@ Reports an error if `needle` is an element of `haystack`.
 
 [assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local haystack=(foo bar baz)
 
@@ -517,6 +538,7 @@ function test_failure() {
   assert_array_not_contains "baz" "${haystack[@]}"
 }
 ```
+:::
 
 ## assert_file_not_exists
 > `assert_file_not_exists "file"`
@@ -525,8 +547,8 @@ Reports an error if `file` does exists.
 
 [assert_file_exists](#assert-file-exists) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local file_path="foo.txt"
   touch "$file_path"
@@ -543,6 +565,7 @@ function test_failed() {
   rm "$file_path"
 }
 ```
+:::
 
 ## assert_directory_not_exists
 > `assert_directory_not_exists "directory"`
@@ -551,8 +574,8 @@ Reports an error if `directory` exists.
 
 [assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/nonexistent_directory"
 
@@ -565,6 +588,7 @@ function test_failure() {
   assert_directory_not_exists "$directory"
 }
 ```
+:::
 
 ## assert_is_directory_not_empty
 > `assert_is_directory_not_empty "directory"`
@@ -573,8 +597,8 @@ Reports an error if `directory` is empty.
 
 [assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/etc"
 
@@ -588,6 +612,7 @@ function test_failure() {
   assert_is_directory_not_empty "$directory"
 }
 ```
+:::
 
 ## assert_is_directory_not_readable
 > `assert_is_directory_not_readable "directory"`
@@ -596,8 +621,8 @@ Reports an error if `directory` is readable.
 
 [assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/home/user/test"
   chmod -r "$directory"
@@ -611,6 +636,7 @@ function test_failure() {
   assert_is_directory_not_readable "$directory"
 }
 ```
+:::
 
 ## assert_is_directory_not_writable
 > `assert_is_directory_not_writable "directory"`
@@ -619,8 +645,8 @@ Reports an error if `directory` is writable.
 
 [assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   local directory="/home/user/test"
   chmod -w "$directory"
@@ -634,3 +660,4 @@ function test_failure() {
   assert_is_directory_not_writable "$directory"
 }
 ```
+:::

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -12,8 +12,8 @@ If a directory is specified, it will execute tests within files ending in `test.
 
 If you use wildcards, **bashunit** will run any tests it finds.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 # all tests inside the tests directory
 ./bashunit ./tests
 
@@ -23,6 +23,7 @@ If you use wildcards, **bashunit** will run any tests it finds.
 # all test matching given wildcard
 ./bashunit ./tests/**/*_test.sh
 ```
+:::
 
 ## Filter
 
@@ -30,11 +31,12 @@ If you use wildcards, **bashunit** will run any tests it finds.
 
 Filters the tests to be run based on the `test name`.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 # run all test functions including "something" in it's name
 ./bashunit ./tests --filter "something"
 ```
+:::
 
 ## Output
 
@@ -48,23 +50,20 @@ Verbose is the default output, but it can be overridden by the environment confi
 
 This command flag will always take precedence over the environment configuration.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 ./bashunit ./tests --simple
 ```
-
-*Output:*
-```text
+```[Output]
 ........
 ```
+:::
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 ./bashunit ./tests --verbose
 ```
-
-*Output:*
-```text
+```[Output]
 Running tests/functional/logic_test.sh
 ✓ Passed: Other way of using the exit code
 ✓ Passed: Should validate a non ok exit code
@@ -75,6 +74,7 @@ Running tests/functional/logic_test.sh
 ✓ Passed: Text should not contain
 ✓ Passed: Text should not match a regular expression
 ```
+:::
 
 ## Version
 
@@ -82,16 +82,14 @@ Running tests/functional/logic_test.sh
 
 Displays the current version of **bashunit**.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 ./bashunit --version
 ```
-
-*Output:*
-```text-vue
+```-vue [Output]
 bashunit - {{ pkg.version }}
 ```
-
+:::
 
 ## Help
 
@@ -99,13 +97,11 @@ bashunit - {{ pkg.version }}
 
 Displays a help message with all allowed arguments and options.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 ./bashunit --help
 ```
-
-*Output:*
-```text-vue
+```-vue [Output]
 bashunit [arguments] [options]
 
 Arguments:
@@ -117,6 +113,7 @@ Options:
 
   [...]
 ```
+:::
 
 <script setup>
 import pkg from '../package.json'

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,13 +28,15 @@ Once **bashunit** is installed, you're ready to get started.
     ```
 
 2.  Next, create your first test file named `example_test.sh` within this folder:
-    ```bash
+    ::: code-group
+    ```bash [tests/example_test.sh]
     #!/bin/bash
 
     function test_bashunit_is_working() {
       assert_equals "bashunit is working" "bashunit is working"
     }
     ```
+    :::
 
 3.  Finally, run the **bashunit** executable:
     ```bash
@@ -42,7 +44,7 @@ Once **bashunit** is installed, you're ready to get started.
     ```
 
 4.  If everything works correctly, you should see an output similar to the following:
-    ```text
+    ```
     Running tests/example_test.sh
     ✓ Passed: Bashunit is working
 

--- a/docs/skipping-incomplete.md
+++ b/docs/skipping-incomplete.md
@@ -13,8 +13,8 @@ It reports that the test has been skipped, including the `[reason]` if one was s
 Skipping tests will not cause **bashunit** to exit with an error code;
 however, it will indicate that some tests were skipped in the final output.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_skipped() {
   if [[ $OS != "GEOS" ]]; then
     skip
@@ -33,9 +33,7 @@ function test_skipped_with_reason() {
   assert_empty "not reached"
 }
 ```
-
-*Output:*
-```text
+```[Output]
 ↷ Skipped: Skipped
 ↷ Skipped: Skipped with reason
     Not running under Commodore
@@ -44,6 +42,7 @@ Tests:      2 skipped, 2 total
 Assertions: 2 skipped, 2 total
 Some tests skipped
 ```
+:::
 
 ## todo
 > `todo "[pending]"`
@@ -56,8 +55,8 @@ Reports that the test is incomplete as it is under development, including any `[
 Incomplete tests will not cause **bashunit** to exit with an error code;
 however, it will indicate that some tests were incomplete in the final output.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_incomplete() {
   todo
 }
@@ -66,9 +65,7 @@ function test_incomplete_with_pending_details() {
   todo "Detailed description of what needs to be done"
 }
 ```
-
-*Output:*
-```text
+```[Output]
 ✒ Incomplete: Incomplete
 ✒ Incomplete: Incomplete with pending details
     Detailed description of what needs to be done
@@ -77,3 +74,4 @@ Tests:      2 incomplete, 2 total
 Assertions: 2 incomplete, 2 total
 Some tests incomplete
 ```
+:::

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -7,21 +7,22 @@ When creating tests, you might need to override existing function to be able to 
 
 Allows you to override the behavior of a callable.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_example() {
   mock ps echo hello world
 
   assert_equals "hello world" "$(ps)"
 }
 ```
+:::
 
 > `mock "function" "output"`
 
 Allows you to override the output of a callable.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_example() {
   function code() {
       ps a | grep bash
@@ -36,13 +37,15 @@ EOF
   assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
 }
 ```
+:::
+
 ## spy
 > `spy "function"`
 
 Overrides the original behavior of a callable to allow you to make various assertions about its calls.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_example() {
   spy ps
 
@@ -52,14 +55,15 @@ function test_example() {
   assert_have_been_called ps
 }
 ```
+:::
 
 ## assert_have_been_called
 > `assert_have_been_called "spy"`
 
 Reports an error if `spy` is not called.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   spy ps
 
@@ -74,14 +78,15 @@ function test_failure() {
   assert_have_been_called ps
 }
 ```
+:::
 
 ## assert_have_been_called_with
 > `assert_have_been_called_with "expected" "spy"`
 
 Reports an error if `callable` is not called with `expected`.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   spy ps
 
@@ -98,14 +103,15 @@ function test_failure() {
   assert_have_been_called_with "foo bar" ps
 }
 ```
+:::
 
 ## assert_have_been_called_times
 > assert_have_been_called_times "expected" "spy"
 
 Reports an error if `spy` is not called exactly `expected` times.
 
-*Example:*
-```bash
+::: code-group
+```bash [Example]
 function test_success() {
   spy ps
 
@@ -124,3 +130,4 @@ function test_failure() {
   assert_have_been_called_times 1 ps
 }
 ```
+:::

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -23,11 +23,13 @@ To distinguish test functions from auxiliary functions, the names must be prefix
 The function names are case-insensitive.
 Below are some example test function names that would work seamlessly:
 
-```bash
+::: code-group
+```bash [Example]
 function test_should_validate_an_ok_exit_code() { ... }
 function testRenderAllTestsPassedWhenNotFailedTests { ... }
 test_getFunctionsToRun_with_filter_should_return_matching_functions() { ... }
 ```
+:::
 
 ::: tip
 You're free to use any of Bash's syntax options to define these functions.
@@ -39,11 +41,13 @@ The `set_up` auxiliary function is called, if it is present in the test file, be
 This provides a hook to prepare the environment or set initial variables specific to each test case.
 For example, you might want to create temporary directories or files that your test will manipulate.
 
-```bash
+::: code-group
+```bash [Example]
 function set_up() {
   touch temp_file.txt
 }
 ```
+:::
 
 ## `tear_down` function
 
@@ -51,22 +55,26 @@ The `tear_down` auxiliary function is called, if it is present in the test file,
 This auxiliary function offers you a place to clean up any resources allocated or changes made during the `set_up` or test function itself.
 This helps to ensure that each test starts with a fresh state.
 
-```bash
+::: code-group
+```bash [Example]
 function tear_down() {
   rm temp_file.txt
 }
 ```
+:::
 
 ## `set_up_before_script` function
 
 The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
 This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
 
-```bash
+::: code-group
+```bash [Example]
 function set_up_before_script() {
   open_database_connection
 }
 ```
+:::
 
 ## `tear_down_after_script` function
 
@@ -74,23 +82,27 @@ The `tear_down_after_script` auxiliary function is called, if it is present in t
 This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
 It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
 
-```bash
+::: code-group
+```bash [Example]
 function tear_down_after_script() {
   close_database_connection
 }
 ```
+:::
 
 ## Data providers
 
 The test function can accept data from a data provider function. The data provider function is specified using a comment before the function declaration.
 The format of this comment will be the following:
 
-```
+::: code-group
+```bash [Example]
 # data_provider provider_function_name
 function test_my_test_case() {
-...
+  ...
 }
 ```
+:::
 
 If **bashunit** find before the test function declaration a comment with the key `data_provider` followed by a provider function name, this provider function
 will be executed before running the test function and the data provided by this provider function will be passed as the first argument to the test function.
@@ -98,9 +110,8 @@ will be executed before running the test function and the data provided by this 
 The provider function can return a list of values like `one two three` or a single value `one`. In case of a list of values, in each iteration of this list,
 the provided data will be the current list value.
 
-Example:
-
-```
+::: code-group
+```bash [Example]
 function provider_directories() {
   local directories=("/usr" "/etc" "/var")
   echo "${directories[@]}"
@@ -113,6 +124,7 @@ function test_should_directory_exists_from_data_provider() {
   assert_directory_exists "$directory"
 }
 ```
+:::
 
 In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of the data provided by this function
 and the test function will be executed passing each time the current iteration value as the first argument.


### PR DESCRIPTION
## 📚 Description

Added code-groups to most of the code boxes in the documentation.

In all examples, the new version is on the left and the old one on the right.

Label more clearly what the box represents (in this case an example):
![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/e13af65e-a8e3-4478-8ba1-43c3a235609f)

Identify which file is being worked on, which aids in skimming:
![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/c1220a5f-fc9a-436a-b45d-bdd7c2d0b327)

Allows grouping examples with their outputs, making the documentation less vertically extensive:
![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/7308db6b-4610-468e-a01b-39a08b855d7a)

## 🔖 Changes

- Add code-groups.
- Remove the text format from the outputs (use none instead, it's more accurate).

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure you have updated the documentation to reflect the changes or new features
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
