### PR TITLE
Fix simple output with header

### DIFF
--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -11,7 +11,7 @@ function console_header::print_version() {
 EOF
     printf "%s\n\n" "$BASHUNIT_VERSION"
   else
-    printf "${_COLOR_PASSED}bashunit - %s\n" "$BASHUNIT_VERSION"
+    printf "${_COLOR_BOLD}${_COLOR_PASSED}bashunit${_COLOR_DEFAULT} - %s\n" "$BASHUNIT_VERSION"
   fi
 }
 


### PR DESCRIPTION
## 📚 Description

The header didn't reset its color, so in simple mode all points appeared green; bold was also lost.

Introduced on commit 27b72fc1

![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/1e25eb40-1bac-430a-9f4f-9ba020fb1565)

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure you have updated the documentation to reflect the changes or new features
- [x] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
