### PR TITLE
assert_string_not_starts_with & assert_string_starts_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Add Brew installation to docs
 - Add `--help` option
 - Add data_provider
+- Add `assert_string_not_starts_with`
+- Add `assert_string_starts_with`
 
 ## [0.8.0](https://github.com/TypedDevs/bashunit/compare/0.7.0...0.8.0) - 2023-10-08
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -80,6 +80,25 @@ function test_failure() {
 ```
 :::
 
+## assert_string_starts_with
+> `assert_string_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does not starts with `needle`.
+
+[assert_string_not_starts_with](#assert-string-not-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_starts_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_starts_with "baz" "foobar"
+}
+```
+:::
+
 ## assert_exit_code
 > `assert_exit_code "expected" ["callable"]`
 
@@ -475,6 +494,25 @@ function test_success() {
 
 function test_failure() {
   assert_not_contains "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_starts_with
+> `assert_string_not_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does starts with `needle`.
+
+[assert_string_starts_with](#assert-string-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_starts_with "baz" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_starts_with "foo" "foobar"
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -166,6 +166,34 @@ function assert_command_not_found() {
   state::add_assertions_passed
 }
 
+function assert_string_starts_with() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  if ! [[ $actual =~ ^"$expected"* ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${actual}" "to start with" "${expected}"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
+function assert_string_not_starts_with() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  if [[ $actual =~ ^"$expected"* ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${actual}" "to not start with" "${expected}"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
 function assert_array_contains() {
   local expected="$1"
   local label

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -198,3 +198,25 @@ function test_unsuccessful_assert_array_not_contains() {
       "Unsuccessful assert array not contains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
     "$(assert_array_not_contains "123" "${distros[@]}")"
 }
+
+function test_successful_assert_string_starts_with() {
+  assert_empty "$(assert_string_starts_with "ho" "house")"
+}
+
+function test_unsuccessful_assert_string_starts_with() {
+  assert_equals\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert string starts with" "pause" "to start with" "hou")"\
+    "$(assert_string_starts_with "hou" "pause")"
+}
+
+function test_successful_assert_string_not_starts_with() {
+  assert_empty "$(assert_string_not_starts_with "hou" "pause")"
+}
+
+function test_unsuccessful_assert_string_not_starts_with() {
+  assert_equals\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert string not starts with" "house" "to not start with" "ho")"\
+    "$(assert_string_not_starts_with "ho" "house")"
+}


### PR DESCRIPTION
## 📚 Description

- `assert_string_not_starts_with`
- `assert_string_starts_with`

## 🔖 Changes

- [X] Code
- [x] Documentation

## ✅ To-do list

- [X] Make sure that all the pipeline passes
- [X] Make sure you have updated the documentation to reflect the changes or new features
- [X] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
