### PR TITLE
Assert string ends with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Add data_provider
 - Add `assert_string_not_starts_with`
 - Add `assert_string_starts_with`
+- Add `assert_string_ends_with`
+- Add `assert_string_not_ends_with`
+
 
 ## [0.8.0](https://github.com/TypedDevs/bashunit/compare/0.7.0...0.8.0) - 2023-10-08
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -99,6 +99,25 @@ function test_failure() {
 ```
 :::
 
+## assert_string_ends_with
+> `assert_string_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does not ends with `needle`.
+
+[assert_string_not_ends_with](#assert-string-not-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_ends_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_ends_with "foo" "foobar"
+}
+```
+:::
+
 ## assert_exit_code
 > `assert_exit_code "expected" ["callable"]`
 
@@ -508,11 +527,30 @@ Reports an error if `haystack` does starts with `needle`.
 ::: code-group
 ```bash [Example]
 function test_success() {
-  assert_string_not_starts_with "baz" "foobar"
+  assert_string_not_starts_with "bar" "foobar"
 }
 
 function test_failure() {
   assert_string_not_starts_with "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_ends_with
+> `assert_string_not_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does ends with `needle`.
+
+[assert_string_ends_with](#assert-string-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_ends_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_ends_with "bar" "foobar"
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -208,7 +208,6 @@ function assert_string_ends_with() {
   state::add_assertions_passed
 }
 
-
 function assert_string_not_ends_with() {
   local expected="$1"
   local actual="$2"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -207,3 +207,18 @@ function assert_string_ends_with() {
 
   state::add_assertions_passed
 }
+
+
+function assert_string_not_ends_with() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  if [[ $actual =~ .*"$expected"$ ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${actual}" "to not end with" "${expected}"
+    return
+  fi
+
+  state::add_assertions_passed
+}

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -193,3 +193,17 @@ function assert_string_not_starts_with() {
 
   state::add_assertions_passed
 }
+
+function assert_string_ends_with() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  if ! [[ $actual =~ .*"$expected"$ ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${actual}" "to end with" "${expected}"
+    return
+  fi
+
+  state::add_assertions_passed
+}

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -220,3 +220,14 @@ function test_unsuccessful_assert_string_not_starts_with() {
       "Unsuccessful assert string not starts with" "house" "to not start with" "ho")"\
     "$(assert_string_not_starts_with "ho" "house")"
 }
+
+function test_successful_assert_string_ends_with() {
+  assert_empty "$(assert_string_ends_with "bar" "foobar")"
+}
+
+function test_unsuccessful_assert_string_ends_with() {
+  assert_equals\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert string ends with" "foobar" "to end with" "foo")"\
+    "$(assert_string_ends_with "foo" "foobar")"
+}

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -231,3 +231,15 @@ function test_unsuccessful_assert_string_ends_with() {
       "Unsuccessful assert string ends with" "foobar" "to end with" "foo")"\
     "$(assert_string_ends_with "foo" "foobar")"
 }
+
+
+function test_successful_assert_string_not_ends_with() {
+  assert_empty "$(assert_string_not_ends_with "foo" "foobar")"
+}
+
+function test_unsuccessful_assert_string_not_ends_with() {
+  assert_equals\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert string not ends with" "foobar" "to not end with" "bar")"\
+    "$(assert_string_not_ends_with "bar" "foobar")"
+}


### PR DESCRIPTION
## 📚 Description
- `assert_string_ends_with`
- `assert_string_not_ends_with`

## ✅ To-do list

- [X] Make sure that all the pipeline passes
- [X] Make sure you have updated the documentation to reflect the changes or new features
- [X] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
- [x] Add documentation if need it
