### PR TITLE
feat: alternative to set -e

### DIFF
--- a/adrs/TEMPLATE.md
+++ b/adrs/TEMPLATE.md
@@ -1,0 +1,72 @@
+# [short title of solved problem and solution]
+
+* Status: [proposed | rejected | accepted | deprecated | … | superseded by [ADR-0005](0005-example.md)] <!-- optional -->
+* Deciders: [list everyone involved in the decision] <!-- optional -->
+* Date: [YYYY-MM-DD when the decision was last updated] <!-- optional -->
+
+Technical Story: [description | ticket/issue URL] <!-- optional -->
+
+## Context and Problem Statement
+
+[Describe the context and problem statement, e.g., in free form using two to three sentences. You may want to articulate the problem in form of a question.]
+
+## Decision Drivers <!-- optional -->
+
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
+
+## Considered Options
+
+* [option 1]
+* [option 2]
+* [option 3]
+* … <!-- numbers of options can vary -->
+
+## Decision Outcome
+
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
+
+### Positive Consequences <!-- optional -->
+
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
+
+### Negative Consequences <!-- optional -->
+
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
+
+## Pros and Cons of the Options <!-- optional -->
+
+### [option 1]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 2]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+### [option 3]
+
+[example | description | pointer to more information | …] <!-- optional -->
+
+* Good, because [argument a]
+* Good, because [argument b]
+* Bad, because [argument c]
+* … <!-- numbers of pros and cons can vary -->
+
+## Links <!-- optional -->
+
+* [Link type] [Link to ADR] <!-- example: Refined by [ADR-0005](0005-example.md) -->
+* … <!-- numbers of links can vary -->

--- a/adrs/adr-001-changing-error-detection-mechanism.md
+++ b/adrs/adr-001-changing-error-detection-mechanism.md
@@ -1,0 +1,36 @@
+# Title: Changing Error Detection Mechanism in Bashunit
+
+* Status: accepted
+* Authors: @Tito-Kati, with consensus from @khru and @Chemaclass
+* Date: 2023-10-14
+
+Technical Story:
+    - Issue: [TypedDevs/bashunit#182](https://github.com/TypedDevs/bashunit/issues/182)
+    - Pull Request: [TypedDevs/bashunit#189](https://github.com/TypedDevs/bashunit/pull/189)
+
+## Context and Problem Statement
+
+In the existing setup of bashunit, error detection within tests was based on return codes along with `set -e`.
+This mechanism would interrupt a test script if any execution within the script returned an error code other than 0.
+A specific scenario was identified where a non-existing function call within a test did not cause the test to fail as it should, as illustrated in issue [#182](https://github.com/TypedDevs/bashunit/issues/182).
+
+## Considered Options
+* Use stderr instead return codes and set -e.
+
+## Decision Outcome
+
+To rectify this, a new error detection mechanism was proposed in pull request [#189](https://github.com/TypedDevs/bashunit/pull/189).
+The changes shifted error detection from relying on return codes to utilizing stderr.
+Now, if any execution within a script writes something to stderr, it will be considered as failed.
+This adjustment also changes the behavior of the test runner slightly as tests will now run to the end even if there’s a failure at the beginning, aligning the behavior across different scenarios.
+
+### Positive Consequences
+
+The consequences include:
+- Enabling true Test Driven Development (TDD) in bashunit by ensuring that tests fail as expected when there's an error, providing a more accurate and reliable testing environment.
+- Altering the runner's behavior to continue executing tests even after an initial failure, which may be viewed as strange but is consistent with the new error detection mechanism.
+- Refining error reporting to align with standard practices, providing more descriptive insight into the errors.
+
+### Negative Consequences
+
+Unknown at the moment.

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -138,5 +138,6 @@ function console_results::print_error_test() {
   test_name=$(helper::normalize_test_function_name "$1")
   local error="$2"
 
-  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s\n    ${_COLOR_FAINT}%s${_COLOR_DEFAULT}" "${test_name}" "${error}"
+  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
+    ${_COLOR_FAINT}%s${_COLOR_DEFAULT}\n" "${test_name}" "${error}"
 }

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -134,8 +134,9 @@ function console_results::print_incomplete_test() {
 }
 
 function console_results::print_error_test() {
-  local test_name="${3:-$(helper::normalize_test_function_name "$1")}"
-  local error_code=$2
+  local test_name
+  test_name=$(helper::normalize_test_function_name "$1")
+  local error="$2"
 
-  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s with error code %s\n" "${test_name}" "${error_code}"
+  printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s\n    ${_COLOR_FAINT}%s${_COLOR_DEFAULT}" "${test_name}" "${error}"
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -98,13 +98,6 @@ function runner::parse_execution_result() {
   _ASSERTIONS_FAILED=$((_ASSERTIONS_FAILED + assertions_failed))
   _ASSERTIONS_SKIPPED=$((_ASSERTIONS_SKIPPED + assertions_skipped))
   _ASSERTIONS_INCOMPLETE=$((_ASSERTIONS_INCOMPLETE + assertions_incomplete))
-
-  local print_execution_result
-  print_execution_result="$(echo "$execution_result" | sed '$ d')"
-
-  if [ -n "$print_execution_result" ]; then
-    echo "$print_execution_result"
-  fi
 }
 
 function runner::run_test() {
@@ -116,17 +109,22 @@ function runner::run_test() {
   current_assertions_incomplete="$(state::get_assertions_incomplete)"
   local current_assertions_skipped
   current_assertions_skipped="$(state::get_assertions_skipped)"
+
+  exec 3>&1
+
   local test_execution_result
   test_execution_result=$(
     state::initialize_assertions_count
-
     runner::run_set_up
-    "$function_name" "$data" 2>&1
-    runner::run_tear_down
 
+    "$function_name" "$data" 2>&1 1>&3
+
+    runner::run_tear_down
     state::export_assertions_count
   )
-  local test_result_code=$?
+
+  exec 3>&-
+
   runner::parse_execution_result "$test_execution_result"
 
   local runtime_error
@@ -138,7 +136,7 @@ function runner::run_test() {
 
   if [[ -n $runtime_error ]]; then
     state::add_tests_failed
-    console_results::print_error_test "$function_name" "$test_result_code"
+    console_results::print_error_test "$function_name" "$runtime_error"
     return
   fi
 

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -63,22 +63,26 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 function test_bashunit_when_a_test_execution_error() {
   local test_file=./tests/acceptance/fake_error_test.sh
   fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
-\e[31m✗ Failed\e[0m: Error with error code 127
+\e[31m✗ Failed\e[0m: Error
+    \e[2mExpected\e[0m \e[1m\'127\'\e[0m
+    \e[2mto be exactly\e[0m \e[1m\'1\'\e[0m
+\e[31m✗ Failed\e[0m: Error
+    \e[2m./tests/acceptance/fake_error_test.sh: línea 4: invalid_function_name: orden no encontrada\e[0m
 
 \e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
-\e[2mAssertions:\e[0m \e[31m0 failed\e[0m, 0 total")
+\e[2mAssertions:\e[0m \e[31m1 failed\e[0m, 1 total")
 
   echo "
 #!/bin/bash
 function test_error() {
-  invalidFunctionName 2>/dev/null
-  assertGeneralError
+  invalid_function_name
+  assert_general_error
 }" > $test_file
 
   set +e
 
-  assertContains "$fixture" "$(./bashunit --verbose "$test_file")"
-  assertGeneralError "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture" "$(./bashunit --verbose "$test_file")"
+  assert_general_error "$(./bashunit --verbose "$test_file")"
 
   rm $test_file
 }
@@ -86,19 +90,20 @@ function test_error() {
 function test_bashunit_should_allow_test_drive_development() {
   local test_file=./tests/acceptance/fake_error_test.sh
   fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
-\e[31m✗ Failed\e[0m: Error tdd with error code 127
+\e[31m✗ Failed\e[0m: Error tdd
+    \e[2m./tests/acceptance/fake_error_test.sh: línea 3: assert_that_will_never_exist: orden no encontrada\e[0m
 
 \e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
 \e[2mAssertions:\e[0m \e[31m0 failed\e[0m, 0 total")
 
   echo "
   #!/bin/bash
-  function test_error_tdd() { assert_that_will_never_exist \"1\" \"1\" 2>/dev/null ; }" > $test_file
+  function test_error_tdd() { assert_that_will_never_exist \"1\" \"1\" ; }" > $test_file
 
   set +e
 
-  assertContains "$fixture" "$(./bashunit --verbose "$test_file")"
-  assertGeneralError "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture" "$(./bashunit --verbose "$test_file")"
+  assert_general_error "$(./bashunit --verbose "$test_file")"
 
   rm $test_file
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -62,12 +62,15 @@ function test_fail() { assert_equals \"1\" \"0\" ; }" > $test_file
 
 function test_bashunit_when_a_test_execution_error() {
   local test_file=./tests/acceptance/fake_error_test.sh
-  fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
+  local fixture_start
+  fixture_start=$(printf "Running ./tests/acceptance/fake_error_test.sh
 \e[31m✗ Failed\e[0m: Error
     \e[2mExpected\e[0m \e[1m\'127\'\e[0m
     \e[2mto be exactly\e[0m \e[1m\'1\'\e[0m
 \e[31m✗ Failed\e[0m: Error
-    \e[2m./tests/acceptance/fake_error_test.sh: línea 4: invalid_function_name: orden no encontrada\e[0m
+    \e[2m./tests/acceptance/fake_error_test.sh:")
+  local fixture_end
+  fixture_end=$(printf "\e[0m
 
 \e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
 \e[2mAssertions:\e[0m \e[31m1 failed\e[0m, 1 total")
@@ -81,7 +84,8 @@ function test_error() {
 
   set +e
 
-  assert_contains "$fixture" "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture_start" "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture_end" "$(./bashunit --verbose "$test_file")"
   assert_general_error "$(./bashunit --verbose "$test_file")"
 
   rm $test_file
@@ -89,9 +93,12 @@ function test_error() {
 
 function test_bashunit_should_allow_test_drive_development() {
   local test_file=./tests/acceptance/fake_error_test.sh
-  fixture=$(printf "Running ./tests/acceptance/fake_error_test.sh
+  local fixture_start
+  fixture_start=$(printf "Running ./tests/acceptance/fake_error_test.sh
 \e[31m✗ Failed\e[0m: Error tdd
-    \e[2m./tests/acceptance/fake_error_test.sh: línea 3: assert_that_will_never_exist: orden no encontrada\e[0m
+    \e[2m./tests/acceptance/fake_error_test.sh:")
+  local fixture_end
+  fixture_end=$(printf "\e[0m
 
 \e[2mTests:     \e[0m \e[31m1 failed\e[0m, 1 total
 \e[2mAssertions:\e[0m \e[31m0 failed\e[0m, 0 total")
@@ -102,7 +109,8 @@ function test_bashunit_should_allow_test_drive_development() {
 
   set +e
 
-  assert_contains "$fixture" "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture_start" "$(./bashunit --verbose "$test_file")"
+  assert_contains "$fixture_end" "$(./bashunit --verbose "$test_file")"
   assert_general_error "$(./bashunit --verbose "$test_file")"
 
   rm $test_file


### PR DESCRIPTION
## 📚 Description

"The objective of this PR is to change the behavior of how an error is detected within a test to mark it as failed.

Currently, the tests detected these errors using return codes along with set -e. The set -e makes a script (the test in this case) interrupt if any execution within the script returns an error code other than 0. This in theory sounds good since if something went wrong, the test execution was interrupted and marked as failed, but in practice, it is not so, since if a line executes several functions, only the return of the last one is counted, therefore for this common situation:
```bash
function test_a_non_existing_function_assert_empty() {
  assert_empty "$(a_non_existing_function)"
}
```
The test no longer failed, since although a_non_existing_function returns an error 127, the assert_empty always returns 0.

With the version of this PR, instead of using the returns of the functions, the error output is used, that is, if any execution within the script writes something in stderr, it will be considered as failed.

This changes the behavior of the runner a bit since now the tests will run to the end even if something failed at the beginning, this might seem strange but right now if one of our tests has 2 assertions and the first one fails, the second one is still executed. However, as soon as something fails within the test, it is completely evaluated as failed (even if valid assertions are given afterward), so we could conclude that we have homogenized the runner's behavior.

Another change that has been made is when printing the tests that fail due to an error, previously the name of the test was printed followed by a "with error X", which went against our error reporting standard, since in the line of the test name we never printed anything else.

![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/6fd77560-c35c-445c-86dd-4457cdeb522b)

Now, since error codes are not used for anything, instead what is done is printing on a new line, indented and in gray (with a format very similar to the rest of the assertions) the actual error that is occurring, therefore if for example a non-existing function is called, literally in the test it will say that it has failed because a non-existing function was called."

## 🔖 Changes

- Use stderr instead of return code to detect errors
- Standardize the printing of a test that fails due to an error
- Refactor acceptance tests for the new format

## ✅ To-do list

- [x] Make sure that all the pipeline passes
- [x] Make sure you have updated the documentation to reflect the changes or new features
- [ ] Make sure to update the `CHANGELOG.md` to reflect the new feature or fix
