### PR TITLE
docs: add MacPorts install info

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,6 +37,14 @@ You can install **bashunit** globally in your macOS (or Linux) using brew.
 brew install bashunit
 ```
 
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
 ## Git submodule
 
 You can use Git submodules to include external Git repositories, like **bashunit**, within your Git project.


### PR DESCRIPTION
## 📚 Description

Add instructions on how to install `bashunit` via MacPorts.
https://ports.macports.org/port/bashunit/

## 🔖 Changes

- Add entry to installation doc (`docs/installation.md`) detailing MacPorts installation of `bashunit`

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
