### PR TITLE
Add assert_equals_ignore_colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Installer no longer needs git
 - Add `assert_contains_ignore_case`
-- Add `assert_equals_without_colors`
+- Add `assert_equals_ignore_colors`
 
 ## [0.9.0](https://github.com/TypedDevs/bashunit/compare/0.8.0...0.9.0) - 2023-10-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Installer no longer needs git
 - Add `assert_contains_ignore_case`
+- Add `assert_equals_without_colors`
 
 ## [0.9.0](https://github.com/TypedDevs/bashunit/compare/0.8.0...0.9.0) - 2023-10-15
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -23,6 +23,23 @@ function test_failure() {
 ```
 :::
 
+## assert_equals_without_colors
+> `assert_equals_without_colors "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals_without_colors "foo" "\e[31mfoo"
+}
+
+function test_failure() {
+  assert_equals_without_colors "\e[31mfoo" "\e[31mfoo"
+}
+```
+:::
+
 ## assert_contains
 > `assert_contains "needle" "haystack"`
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -23,19 +23,19 @@ function test_failure() {
 ```
 :::
 
-## assert_equals_without_colors
-> `assert_equals_without_colors "expected" "actual"`
+## assert_equals_ignore_colors
+> `assert_equals_ignore_colors "expected" "actual"`
 
 Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
 
 ::: code-group
 ```bash [Example]
 function test_success() {
-  assert_equals_without_colors "foo" "\e[31mfoo"
+  assert_equals_ignore_colors "foo" "\e[31mfoo"
 }
 
 function test_failure() {
-  assert_equals_without_colors "\e[31mfoo" "\e[31mfoo"
+  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -14,7 +14,7 @@ function assert_equals() {
   state::add_assertions_passed
 }
 
-function assert_equals_without_colors() {
+function assert_equals_ignore_colors() {
   local expected="$1"
   local actual="$2"
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -14,6 +14,20 @@ function assert_equals() {
   state::add_assertions_passed
 }
 
+function assert_equals_without_colors() {
+  local expected="$1"
+  local actual="$2"
+  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  local expected_without_colors
+  expected_without_colors=$(echo -e "$expected" | sed "s/\x1B\[[0-9;]*[JKmsu]//g")
+
+  local actual_without_colors
+  actual_without_colors=$(echo -e "$actual" | sed "s/\x1B\[[0-9;]*[JKmsu]//g")
+
+  assert_equals "$expected_without_colors" "$actual_without_colors" "$label"
+}
+
 function assert_empty() {
   local expected="$1"
   local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -19,13 +19,10 @@ function assert_equals_without_colors() {
   local actual="$2"
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  local expected_without_colors
-  expected_without_colors=$(echo -e "$expected" | sed "s/\x1B\[[0-9;]*[JKmsu]//g")
-
   local actual_without_colors
   actual_without_colors=$(echo -e "$actual" | sed "s/\x1B\[[0-9;]*[JKmsu]//g")
 
-  assert_equals "$expected_without_colors" "$actual_without_colors" "$label"
+  assert_equals "$expected" "$actual_without_colors" "$label"
 }
 
 function assert_empty() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -305,3 +305,9 @@ function test_unsuccessful_assert_greater_or_equal_than() {
       "Unsuccessful assert greater or equal than" "1" "to be greater or equal than" "3")"\
     "$(assert_greater_or_equal_than "3" "1")"
 }
+
+function test_successful_assert_equals_without_colors() {
+  assert_equals_without_colors\
+    "✗ Failed foo"\
+    "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
+}

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -306,20 +306,20 @@ function test_unsuccessful_assert_greater_or_equal_than() {
     "$(assert_greater_or_equal_than "3" "1")"
 }
 
-function test_successful_assert_equals_without_colors() {
-  assert_equals_without_colors\
+function test_successful_assert_equals_ignore_colors() {
+  assert_equals_ignore_colors\
     "✗ Failed foo"\
     "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 }
 
-function test_unsuccessful_assert_equals_without_colors() {
+function test_unsuccessful_assert_equals_ignore_colors() {
   local string="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 
   assert_equals\
     "$(console_results::print_failed_test\
-      "Unsuccessful assert equals without colors"\
+      "Unsuccessful assert equals ignore colors"\
       "$string"\
       "but got"\
       "✗ Failed foo")"\
-    "$(assert_equals_without_colors "$string" "$string")"
+    "$(assert_equals_ignore_colors "$string" "$string")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -311,3 +311,15 @@ function test_successful_assert_equals_without_colors() {
     "✗ Failed foo"\
     "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 }
+
+function test_unsuccessful_assert_equals_without_colors() {
+  local string="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
+
+  assert_equals\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert equals without colors"\
+      "$string"\
+      "but got"\
+      "✗ Failed foo")"\
+    "$(assert_equals_without_colors "$string" "$string")"
+}


### PR DESCRIPTION
## 🔖 Changes

- Added `assert_equals_ignore_colors`

<img width="1133" alt="Screenshot 2023-10-18 at 10 38 52" src="https://github.com/TypedDevs/bashunit/assets/5256287/e5eba1e3-293f-4535-8ca0-eb2efbde6b2b">

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
