### PR TITLE
Create helper::trim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ TEST_SCRIPTS = $(wildcard $(TEST_SCRIPTS_DIR)/*/*[tT]est.sh)
 
 test/list:
 	@echo "Test scripts found:"
-	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
+	@echo "$(TEST_SCRIPTS)" | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
+	@./bashunit "$(TEST_SCRIPTS)"
 
 test/watch: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
-	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit $(TEST_SCRIPTS)
+	@./bashunit "$(TEST_SCRIPTS)"
+	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit "$(TEST_SCRIPTS)"
 
 env/example:
 	@echo "Copy the .env into the .env.example file without the values"

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -157,3 +157,13 @@ function helper::get_provider_data() {
     helper::execute_function_if_exists "$data_provider_function"
   fi
 }
+
+function helper::trim() {
+    local input_string="$1"
+    local trimmed_string
+
+    trimmed_string="${input_string#"${input_string%%[![:space:]]*}"}"
+    trimmed_string="${trimmed_string%"${trimmed_string##*[![:space:]]}"}"
+
+    echo "$trimmed_string"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -158,3 +158,15 @@ function test_get_provider_data_should_returns_empty_when_not_exists_provider_fu
 
   assert_equals "" "$(helper::get_provider_data "fake_function_get_not_existing_provider_data" "${BASH_SOURCE[0]}")"
 }
+
+function test_left_trim() {
+  assert_equals "foo" "$(helper::trim "       foo")"
+}
+
+function test_right_trim() {
+  assert_equals "foo" "$(helper::trim "foo       ")"
+}
+
+function test_trim() {
+  assert_equals "foo" "$(helper::trim "    foo   ")"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -102,7 +102,7 @@ function test_read_and_store_files_recursive() {
   result=$(helper::read_and_store_files_recursive "$path")
   IFS=' ' read -r -a result <<< "$result"
 
-  assert_equals "$expected_files_count" ${#result[@]}
+  assert_equals "$(helper::trim "$expected_files_count")" ${#result[@]}
 }
 
 function test_normalize_variable_name() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -102,7 +102,7 @@ function test_read_and_store_files_recursive() {
   result=$(helper::read_and_store_files_recursive "$path")
   IFS=' ' read -r -a result <<< "$result"
 
-  assert_equals "$(helper::trim "$expected_files_count")" ${#result[@]}
+  assert_equals "$(helper::trim "$expected_files_count")" "${#result[@]}"
 }
 
 function test_normalize_variable_name() {


### PR DESCRIPTION
## 📚 Description

- Create `helper::trim` and fix `test_read_and_store_files_recursive()` 
  - it failed in my local MacOS... I dont know why it didnt fail on the CI
- Fix `make test` especially when running the CI
