### PR TITLE
Fix wildcards tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,14 +58,14 @@ TEST_SCRIPTS = $(wildcard $(TEST_SCRIPTS_DIR)/*/*[tT]est.sh)
 
 test/list:
 	@echo "Test scripts found:"
-	@echo "$(TEST_SCRIPTS)" | tr ' ' '\n'
+	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit "$(TEST_SCRIPTS)"
+	@./bashunit $(TEST_SCRIPTS)
 
 test/watch: $(TEST_SCRIPTS)
-	@./bashunit "$(TEST_SCRIPTS)"
-	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit "$(TEST_SCRIPTS)"
+	@./bashunit $(TEST_SCRIPTS)
+	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit $(TEST_SCRIPTS)
 
 env/example:
 	@echo "Copy the .env into the .env.example file without the values"

--- a/bashunit
+++ b/bashunit
@@ -59,10 +59,9 @@ while [[ $# -gt 0 ]]; do
       trap '' EXIT && exit 0
       ;;
     *)
-      # shellcheck disable=SC2178
-      _FILES=$(helper::read_and_store_files_recursive "$argument")
-      # shellcheck disable=SC2128
-      IFS=' ' read -r -a _FILES <<< "$_FILES"
+      while IFS='' read -r line; do
+        _FILES+=("$line");
+      done < <(helper::find_files_recursive "$argument")
       shift
       ;;
   esac

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -101,25 +101,11 @@ function helper::unset_if_exists() {
   fi
 }
 
-function helper::read_and_store_files_recursive()
-{
-    local files=()
-    while IFS='' read -r line; do
-      files+=("$line");
-    done < <(helper::find_files_recursive "$1")
-
-    if [ ${#files[@]} -eq 0 ]; then
-        files+=("$1")
-    fi
-
-    echo "${files[@]}"
-}
-
 function helper::find_files_recursive() {
   local path="$1"
 
   if [[ -d "$path" ]]; then
-    find "$path" -type f -name '*[tT]est.sh' | sort | uniq
+    find "$path" -type f -name '*[tT]est.sh' | sort | uniq | tr '\n' ' '
   else
     echo "$path"
   fi

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -7,7 +7,7 @@ function runner::load_test_files() {
   if [[ ${#files[@]} == 0 ]]; then
     if [[ -n "${DEFAULT_PATH}" ]]; then
         # shellcheck disable=SC2178
-        files=$(helper::read_and_store_files_recursive "$DEFAULT_PATH")
+        files=$(helper::find_files_recursive "$DEFAULT_PATH")
         # shellcheck disable=SC2128
         IFS=' ' read -r -a files <<< "$files"
     else

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -93,18 +93,6 @@ function test_check_duplicate_functions_without_duplicates() {
   assert_successful_code "$(helper::check_duplicate_functions "$file")"
 }
 
-function test_read_and_store_files_recursive() {
-  local path="tests"
-  local expected_files_count
-  local result
-
-  expected_files_count="$(find "$path" -type f -name '*[tT]est.sh' -type f | wc -l)"
-  result=$(helper::read_and_store_files_recursive "$path")
-  IFS=' ' read -r -a result <<< "$result"
-
-  assert_equals "$(helper::trim "$expected_files_count")" "${#result[@]}"
-}
-
 function test_normalize_variable_name() {
   assert_equals "valid_name123" "$(helper::normalize_variable_name "valid_name123")"
   assert_equals "non_valid_symbols__________" "$(helper::normalize_variable_name "non_valid_symbols!@#$%^&*()")"


### PR DESCRIPTION
## 📚 Description

Follow up after https://github.com/TypedDevs/bashunit/pull/205

## 🔖 Changes

- Remove `read_and_store_files_recursive()` in favor of using just `find_files_recursive()`
- Fix `make test` script