### PR TITLE
Add unmock function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Add `assert_equals_ignore_colors`
 - Add `assert_match_snapshot`
 - Add `unmock`
+    - Add `assert_is_mock`
+    - Add `assert_is_not_mock`
 - Add `SHOW_EXECUTION_TIME` to environment config
 - Add docs for environment variables
 - Improve data provider output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@
 - Add `assert_contains_ignore_case`
 - Add `assert_equals_ignore_colors`
 - Add `assert_match_snapshot`
+- Add `assert_is_mock`
+- Add `assert_is_not_mock`
 - Add `unmock`
-    - Add `assert_is_mock`
-    - Add `assert_is_not_mock`
 - Add `SHOW_EXECUTION_TIME` to environment config
 - Add docs for environment variables
 - Improve data provider output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add `assert_contains_ignore_case`
 - Add `assert_equals_ignore_colors`
 - Add `assert_match_snapshot`
+- Add `unmock`
 - Add `SHOW_EXECUTION_TIME` to environment config
 - Add docs for environment variables
 - Improve data provider output

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -598,6 +598,31 @@ function test_failure() {
 ```
 :::
 
+## assert_is_mock
+> `assert_is_mock "expected"`
+
+Reports an error if expected is not a mock.
+
+[assert_is_not_mock](#assert-is-not-mock) is the inverse of this assertion.
+
+::: code-group
+```bash [Example]
+function test_success_mock() {
+  mock ls
+  assert_is_mock ls
+}
+
+function test_success_spy() {
+  spy ls
+  assert_is_mock ls
+}
+
+function test_failure() {
+  assert_is_mock ls
+}
+```
+:::
+
 ## assert_not_equals
 > `assert_not_equals "expected" "actual"`
 
@@ -853,6 +878,31 @@ function test_failure() {
   local directory="/tmp"
 
   assert_is_directory_not_writable "$directory"
+}
+```
+:::
+
+## assert_is_not_mock
+> `assert_is_not_mock "expected"`
+
+Reports an error if expected is a mock.
+
+[assert_is_mock](#assert-is-mock) is the inverse of this assertion.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_is_not_mock ls
+}
+
+function test_failure_mock() {
+  mock ls
+  assert_is_not_mock ls
+}
+
+function test_failure_spy() {
+  spy ls
+  assert_is_not_mock ls
 }
 ```
 :::

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -27,7 +27,7 @@ Allows you to override the output of a callable.
 ```bash [Example]
 function test_example() {
   function code() {
-      ps a | grep bash
+    ps a | grep bash
   }
 
   mock ps<<EOF
@@ -50,6 +50,10 @@ Undo the previous overridden behavior of a callable using mock.
 ::: code-group
 ```bash [Example]
 function test_example() {
+  function code() {
+    ps a | grep bash
+  }
+
   mock ps<<EOF
 PID TTY          TIME CMD
 13525 pts/7    00:00:01 bash
@@ -57,7 +61,7 @@ PID TTY          TIME CMD
 EOF
 
   # At this point, ps will return the mocked value above
-  assert_equals "13525 pts/7 00:00:01 bash" "$(ps a | grep bash)"
+  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
 
   # From now on, ps will have the original behaviour again
   unmock ps

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -7,6 +7,8 @@ When creating tests, you might need to override existing function to be able to 
 
 Allows you to override the behavior of a callable.
 
+> You can undo a mock function, to revert it to its previous original behaviour, with `unmock`.
+
 ::: code-group
 ```bash [Example]
 function test_example() {
@@ -35,6 +37,30 @@ PID TTY          TIME CMD
 EOF
 
   assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+}
+```
+:::
+
+## unmock
+
+> `unmock "function"`
+
+Undo the previous overridden behavior of a callable using mock.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  # At this point, ps will return the mocked value above
+  assert_equals "13525 pts/7 00:00:01 bash" "$(ps a | grep bash)"
+
+  # From now on, ps will have the original behaviour again
+  unmock ps
 }
 ```
 :::

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -136,6 +136,7 @@ function runner::run_test() {
     "$function_name" "$data" 2>&1 1>&3
 
     runner::run_tear_down
+    runner::clean_mocks
     state::export_assertions_count
   )
 
@@ -199,6 +200,12 @@ function runner::run_set_up_before_script() {
 
 function runner::run_tear_down() {
   helper::execute_function_if_exists 'tear_down'
+}
+
+function runner::clean_mocks() {
+  for i in "${!MOCKED_FUNCTIONS[@]}"; do
+    unmock "${MOCKED_FUNCTIONS[$i]}"
+  done
 }
 
 function runner::run_tear_down_after_script() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -136,7 +136,7 @@ function runner::run_test() {
     "$function_name" "$data" 2>&1 1>&3
 
     runner::run_tear_down
-    runner::clean_mocks
+    runner::clear_mocks
     state::export_assertions_count
   )
 
@@ -202,7 +202,7 @@ function runner::run_tear_down() {
   helper::execute_function_if_exists 'tear_down'
 }
 
-function runner::clean_mocks() {
+function runner::clear_mocks() {
   for i in "${!MOCKED_FUNCTIONS[@]}"; do
     unmock "${MOCKED_FUNCTIONS[$i]}"
   done

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -77,6 +77,8 @@ function spy() {
   eval "function $command() { ${variable}_params=(\"\$*\"); ((${variable}_times++)) || true; }"
 
   export -f "${command?}"
+
+  MOCKED_FUNCTIONS+=("$command")
 }
 
 function assert_have_been_called() {

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -3,12 +3,13 @@
 declare -a MOCKED_FUNCTIONS=()
 
 function is_mock() {
-  local is_mock=false
   for i in "${!MOCKED_FUNCTIONS[@]}"; do
     if [[ "${MOCKED_FUNCTIONS[$i]}" == "$expected" ]]; then
       echo true
+      return
     fi
   done
+
   echo false
 }
 
@@ -16,10 +17,7 @@ function assert_is_mock() {
   local expected="$1"
   local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  local is_mock
-  is_mock="$(is_mock "$expected")"
-
-  if [[ $is_mock == false ]]; then
+  if [[ $(is_mock "$expected") == false ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${expected}" "to be a mock" "but is not a mock"
     return
@@ -32,12 +30,9 @@ function assert_is_not_mock() {
   local expected="$1"
   local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  local is_mock
-  is_mock="$(is_mock "$expected")"
-
-  if [[ $is_mock == true ]]; then
+  if [[ $(is_mock "$expected") == true ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "to be a mock" "but is not a mock"
+    console_results::print_failed_test "${label}" "${expected}" "to not be a mock" "but is a mock"
     return
   fi
 

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+function unmock() {
+  local command=$1
+  unset -f "$command"
+}
+
 function mock() {
   local command=$1
   shift

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -1,8 +1,59 @@
 #!/bin/bash
 
+declare -a MOCKED_FUNCTIONS=()
+
+function is_mock() {
+  local is_mock=false
+  for i in "${!MOCKED_FUNCTIONS[@]}"; do
+    if [[ "${MOCKED_FUNCTIONS[$i]}" == "$expected" ]]; then
+      echo true
+    fi
+  done
+  echo false
+}
+
+function assert_is_mock() {
+  local expected="$1"
+  local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  local is_mock
+  is_mock="$(is_mock "$expected")"
+
+  if [[ $is_mock == false ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${expected}" "to be a mock" "but is not a mock"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
+function assert_is_not_mock() {
+  local expected="$1"
+  local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  local is_mock
+  is_mock="$(is_mock "$expected")"
+
+  if [[ $is_mock == true ]]; then
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${expected}" "to be a mock" "but is not a mock"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
 function unmock() {
   local command=$1
   unset -f "$command"
+
+  for i in "${!MOCKED_FUNCTIONS[@]}"; do
+    if [[ "${MOCKED_FUNCTIONS[$i]}" == "$command" ]]; then
+      unset "MOCKED_FUNCTIONS[$i]"
+      break
+    fi
+  done
 }
 
 function mock() {
@@ -16,6 +67,8 @@ function mock() {
   fi
 
   export -f "${command?}"
+
+  MOCKED_FUNCTIONS+=("$command")
 }
 
 function spy() {

--- a/tests/acceptance/mock_test.sh
+++ b/tests/acceptance/mock_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#
+# Make sure that the runner::clean_mocks() is being called and removing the mocks and spies
+#
+function test_runner_clean_mocks_1() {
+  mock ls echo foo
+  assert_is_mock ls
+
+  spy ps
+  assert_is_mock ps
+}
+
+function test_runner_clean_mocks_2() {
+  assert_is_not_mock ls
+  assert_is_not_mock ps
+}

--- a/tests/acceptance/mock_test.sh
+++ b/tests/acceptance/mock_test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 #
-# Make sure that the runner::clean_mocks() is being called and removing the mocks and spies
+# Make sure that the runner::clear_mocks() is being called and removing the mocks and spies
 #
-function test_runner_clean_mocks_1() {
+function test_runner_clear_mocks_1() {
   mock ls echo foo
   assert_is_mock ls
 
@@ -11,7 +11,7 @@ function test_runner_clean_mocks_1() {
   assert_is_mock ps
 }
 
-function test_runner_clean_mocks_2() {
+function test_runner_clear_mocks_2() {
   assert_is_not_mock ls
   assert_is_not_mock ps
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -24,13 +24,20 @@ EOF
   assert_empty "$(assert_successful_code "$(code)")"
 }
 
-function test_successful_unmock() {
+function test_successful_unmock_mock() {
   mock ps<<EOF
 PID TTY          TIME CMD
 13525 pts/7    00:00:01 bash
 24162 pts/7    00:00:00 ps
 EOF
 
+  assert_is_mock ps
+  unmock ps
+  assert_is_not_mock ps
+}
+
+function test_successful_unmock_spy() {
+  spy ps
   assert_is_mock ps
   unmock ps
   assert_is_not_mock ps

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -25,15 +25,19 @@ EOF
 }
 
 function test_successful_unmock() {
+  function code() {
+    ps | wc -l
+  }
+
   mock ps<<EOF
 PID TTY          TIME CMD
 13525 pts/7    00:00:01 bash
 24162 pts/7    00:00:00 ps
 EOF
 
-  assert_equals "3" "$(helper::trim "$(ps | wc -l)")"
+  assert_equals "3" "$(helper::trim "$(code)")"
   unmock ps
-  assert_greater_than "3" "$(helper::trim "$(ps | wc -l)")"
+  assert_greater_than "3" "$(helper::trim "$(code)")"
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -43,6 +43,15 @@ function test_successful_unmock_spy() {
   assert_is_not_mock ps
 }
 
+function test_runner_clean_mocks_1() {
+  spy ps
+  assert_is_mock ps
+}
+
+function test_runner_clean_mocks_2() {
+  assert_is_not_mock ps
+}
+
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
   assert_equals "hello world" "$(ps)"

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -24,6 +24,18 @@ EOF
   assert_empty "$(assert_successful_code "$(code)")"
 }
 
+function test_successful_unmock() {
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  assert_equals "3" "$(helper::trim "$(ps | wc -l)")"
+  unmock ps
+  assert_greater_than "3" "$(helper::trim "$(ps | wc -l)")"
+}
+
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
   assert_equals "hello world" "$(ps)"

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -35,9 +35,9 @@ PID TTY          TIME CMD
 24162 pts/7    00:00:00 ps
 EOF
 
-  assert_not_contains "/bin/ps" "$(type ps)"
+  assert_is_mock ps
   unmock ps
-  assert_contains "/bin/ps" "$(type ps)"
+  assert_is_not_mock ps
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -43,6 +43,12 @@ function test_successful_unmock_spy() {
   assert_is_not_mock ps
 }
 
+function test_unsuccessful_unmock() {
+  assert_equals\
+    "$(console_results::print_failed_test "Unsuccessful unmock" "ps" "to be a mock" "but is not a mock")"\
+    "$(assert_is_mock ps)"
+}
+
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
   assert_equals "hello world" "$(ps)"

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -37,7 +37,7 @@ EOF
 
   assert_equals "3" "$(helper::trim "$(code)")"
   unmock ps
-  assert_greater_than "3" "$(helper::trim "$(code)")"
+  assert_not_equals "3" "$(helper::trim "$(code)")"
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -25,10 +25,6 @@ EOF
 }
 
 function test_successful_unmock() {
-  function code() {
-    ps | wc -l
-  }
-
   mock ps<<EOF
 PID TTY          TIME CMD
 13525 pts/7    00:00:01 bash

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -35,9 +35,9 @@ PID TTY          TIME CMD
 24162 pts/7    00:00:00 ps
 EOF
 
-  assert_equals "3" "$(helper::trim "$(code)")"
+  assert_not_contains "/bin/ps" "$(type ps)"
   unmock ps
-  assert_not_equals "3" "$(helper::trim "$(code)")"
+  assert_contains "/bin/ps" "$(type ps)"
 }
 
 function test_successful_override_ps_with_echo_with_mock() {

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -43,15 +43,6 @@ function test_successful_unmock_spy() {
   assert_is_not_mock ps
 }
 
-function test_runner_clean_mocks_1() {
-  spy ps
-  assert_is_mock ps
-}
-
-function test_runner_clean_mocks_2() {
-  assert_is_not_mock ps
-}
-
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
   assert_equals "hello world" "$(ps)"


### PR DESCRIPTION
## 📚 Description

Currently, you can mock a particular function with custom logic, but there is no way to rollback the mock for other tests. It would be useful to be able to remove/rollback the mocked behaviour. 

## 🔖 Changes

- Add unmock function

All mocks will be removed/rollback to their original behaviour after each test. 
This means that the mock live scope is tied to the test scope

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
