### PR TITLE
Fix test_creates_a_snapshot for macOS

### DIFF
--- a/tests/unit/assert_snapshot_test.sh
+++ b/tests/unit/assert_snapshot_test.sh
@@ -6,7 +6,7 @@ function test_successful_assert_match_snapshot() {
 
 function test_creates_a_snapshot() {
   local snapshot_file_path=tests/unit/snapshots/assert_snapshot_test_sh.test_creates_a_snapshot.snapshot
-  local expected=$(("$_ASSERTIONS_SNAPSHOT" + 1))
+  local expected=$((_ASSERTIONS_SNAPSHOT + 1))
 
   assert_file_not_exists $snapshot_file_path
 


### PR DESCRIPTION
## 📚 Description

The unit tests on macOS was broken due to a typo on one snapshot test. [See CI](https://github.com/TypedDevs/bashunit/actions/runs/6805316312/job/18504570525).

## 🔖 Changes

- Fix `test_creates_a_snapshot` for macOS
