### PR TITLE
Add current date on beta installation version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.10.0...main)
 
 - Fix find tests inside folder
+- Add current date on beta installation version
 
 ## [0.10.0](https://github.com/TypedDevs/bashunit/compare/0.9.0...0.10.0) - 2023-11-09
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,11 @@ function build_and_install_beta() {
   cd temp_bashunit
   ./build.sh >/dev/null
   cd ..
-  sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="(non-stable) beta"/g' temp_bashunit/bin/bashunit
+
+  local beta_version
+  beta_version='(non-stable) beta ['"$(date +'%Y-%m-%d')"']'
+
+  sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="'"$beta_version"'"/g' temp_bashunit/bin/bashunit
   cp temp_bashunit/bin/bashunit ./
   rm -rf temp_bashunit
 }

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -54,6 +54,7 @@ function test_install_downloads_the_given_version() {
 }
 
 function test_install_downloads_the_non_stable_beta_version() {
+  mock date echo "2023-11-13"
   local installed_bashunit="./deps/bashunit"
   local output
 
@@ -64,7 +65,7 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$output"
   assert_file_exists "$installed_bashunit"
   assert_equals\
-    "$(printf "\e[1m\e[32mbashunit\e[0m - (non-stable) beta")"\
+    "$(printf "\e[1m\e[32mbashunit\e[0m - (non-stable) beta [2023-11-13]")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
   todo "assert that bashunit is the only file that exists in the deps folder"


### PR DESCRIPTION
## 📚 Description

You can download and install the current beta from the main branch. However, currently there is no way to know when did you get that beta, so it can be confused to know which version contains as latest.

## 🔖 Changes

- When installing a beta version, append the current date; helpful to distinguish between different beta versions, so you will be able to know WHEN did you get that beta version.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
