### PR TITLE
Optimize bashunit

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -85,22 +85,14 @@ function helper::get_functions_to_run() {
 # @param $1 string Eg: "do_something"
 #
 function helper::execute_function_if_exists() {
-  local function_name=$1
-
-  if declare -F | awk '{print $3}' | grep -Eq "^${function_name}$"; then
-    "$function_name"
-  fi
+  "$1" 2>/dev/null
 }
 
 #
 # @param $1 string Eg: "do_something"
 #
 function helper::unset_if_exists() {
-  local function_name=$1
-
-  if declare -F | awk '{print $3}' | grep -Eq "^${function_name}$"; then
-    unset "$function_name"
-  fi
+  unset "$1" 2>/dev/null
 }
 
 function helper::find_files_recursive() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -190,32 +190,24 @@ function runner::run_test() {
 }
 
 function runner::run_set_up() {
-  helper::execute_function_if_exists 'setUp' # Deprecated: please use set_up instead.
   helper::execute_function_if_exists 'set_up'
 }
 
 function runner::run_set_up_before_script() {
-  helper::execute_function_if_exists 'setUpBeforeScript' # Deprecated: please use set_up_before_script instead.
   helper::execute_function_if_exists 'set_up_before_script'
 }
 
 function runner::run_tear_down() {
-  helper::execute_function_if_exists 'tearDown' # Deprecated: please use tear_down instead.
   helper::execute_function_if_exists 'tear_down'
 }
 
 function runner::run_tear_down_after_script() {
-  helper::execute_function_if_exists 'tearDownAfterScript' # Deprecated: please use tear_down_after_script instead.
   helper::execute_function_if_exists 'tear_down_after_script'
 }
 
 function runner::clean_set_up_and_tear_down_after_script() {
-  helper::unset_if_exists 'setUp' # Deprecated: please use set_up instead.
   helper::unset_if_exists 'set_up'
-  helper::unset_if_exists 'tearDown' # Deprecated: please use tear_down instead.
   helper::unset_if_exists 'tear_down'
-  helper::unset_if_exists 'setUpBeforeScript' # Deprecated: please use set_up_before_script instead.
   helper::unset_if_exists 'set_up_before_script'
-  helper::unset_if_exists 'tearDownAfterScript' # Deprecated: please use tear_down_after_script instead.
   helper::unset_if_exists 'tear_down_after_script'
 }


### PR DESCRIPTION
## 📚 Description

By removing the call to the deprecated setUp/tearDown functions and modifying the implementation of the execute_function_if_exists and unset_if_exists helpers, I've managed to reduce the execution time of the library's own tests by around 15% in my local environment.

To calculate these times, I have been running the following script while making changes and taking an average of the times:

```bash
for i in {1..10}; do make test | grep "Time taken: " >> result_2_f; done
```

After all the changes, the results I have obtained from main vs this branch are as follows:
![imagen](https://github.com/TypedDevs/bashunit/assets/13595197/bfd51541-9d7e-411e-abad-62548628ecc0)

Removing the deprecations meant a reduction of about 5%, and modifying the implementation of the helpers accounted for the remaining 10% reduction.

## 🔖 Changes

- Remove support to deprecated setUp/tearDown functions
- Optimize test execution speed

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
