### PR TITLE
Copy pre-commit hook to real GIT_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL=/bin/bash
 
 STATIC_ANALYSIS_CHECKER := $(shell which shellcheck 2> /dev/null)
 LINTER_CHECKER := $(shell which ec 2> /dev/null)
+GIT_DIR = $(shell git rev-parse --git-dir 2> /dev/null)
 
 OS:=
 ifeq ($(OS),Windows_NT)
@@ -72,7 +73,7 @@ env/example:
 
 pre_commit/install:
 	@echo "Installing pre-commit hooks"
-	cp $(PRE_COMMIT_SCRIPTS_FILE) ./.git/hooks/
+	cp $(PRE_COMMIT_SCRIPTS_FILE) $(GIT_DIR)/hooks/
 
 pre_commit/run: test sa lint env/example
 


### PR DESCRIPTION
## 📚 Description

The Git repository is not always ".git" - for example, if this repository is a submodule or worktree, or if $GIT_DIR is set explicitly.

## 🔖 Changes

- Updates the Makefile to use `git rev-parse --git-dir` to find the real directory.

## ✅ To-do list

- [ ] ~~I updated the `CHANGELOG.md` to reflect the new feature or fix~~
- [ ] ~~I updated the documentation to reflect the changes~~

(This didn't seem like a big enough change to merit either of these.)