### PR TITLE
Add phpctl to the examples page

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -23,3 +23,6 @@ A specification for adding human and machine-readable meaning to commit messages
 
 ### [Tito-Kati/fizzbuzz-bashunit](https://github.com/Tito-Kati/fizzbuzz-bashunit)
 Popular introductory FizzBuzz kata solved in Bash with **bashunit** as the testing framework.
+
+### [phpctl](https://github.com/opencodeco/phpctl)
+It is a Docker (containers) based development environment for PHP.


### PR DESCRIPTION
[phpclt ](https://github.com/opencodeco/phpctl)is a CLI tool that works as a set of Bash scripts for a container-based development environment for PHP and its tested using bashunit.

## 📚 Description

This PR adds the project to the examples listing in the docs.

## 🔖 Changes

- Adding a new level-3 heading to the `docs/example.md` file.

## ✅ To-do list

- [x] ~I updated the `CHANGELOG.md` to reflect the new feature or fix~ (not applicable)
- [x] I updated the documentation to reflect the changes
