### PR TITLE
fix: use the bash executable specified by PATH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,9 @@
 
 mkdir -p bin
 
-cat src/*.sh > bin/temp.sh
+echo '#!/usr/bin/env bash' > bin/temp.sh
+
+cat src/*.sh >> bin/temp.sh
 cat bashunit >> bin/temp.sh
 grep -v '^source' bin/temp.sh > bin/bashunit
 rm bin/temp.sh


### PR DESCRIPTION
## 📚 Description

Update the release script so the final bashunit script will use PATH to find bash. The version of bash in /bin on macOS is very old, and forcing tests to use it is quite limiting.

## 🔖 Changes

- Change `build.sh` so it prepends `#!/usr/bin/env bash` to the final `bashunit` script.

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
