### PR TITLE
chore: add fail() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.11.0...main)
 
+- Add `fail()` function
+
 ## [0.11.0](https://github.com/TypedDevs/bashunit/compare/0.10.1...0.11.0) - 2024-03-02
 
 - Add `--upgrade` option to `./bashunit`

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -856,3 +856,20 @@ function test_failure() {
 }
 ```
 :::
+
+## fail
+> `fail "failure message"`
+
+Unambiguously reports an error message. Useful for reporting specific message
+when testing situations not covered by any `assert_*` functions.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  true || fail "This will never fail"
+}
+function test_failure() {
+  [ $(date +%-H) -lt 6 ] || fail "It's late, go to bed"
+}
+```
+:::

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -866,10 +866,14 @@ when testing situations not covered by any `assert_*` functions.
 ::: code-group
 ```bash [Example]
 function test_success() {
-  true || fail "This will never fail"
+  if [ "$(date +%-H)" -gt 25 ]; then
+    fail "Something is very wrong with your clock"
+  fi
 }
 function test_failure() {
-  [ $(date +%-H) -lt 6 ] || fail "It's late, go to bed"
+  if [ "$(date +%-H)" -lt 25 ]; then
+    fail "This test will always fail"
+  fi
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+function fail() {
+  local message=$1
+  local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+
+  state::add_assertions_failed
+  console_results::print_failure_message "${label}" "$message"
+}
+
 function assert_equals() {
   local expected="$1"
   local actual="$2"

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -131,6 +131,16 @@ function console_results::print_successful_test() {
   fi
 }
 
+function console_results::print_failure_message() {
+  local test_name=$1
+  local failure_message=$2
+
+  printf "\
+${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
+    ${_COLOR_FAINT}Message:${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
+    "${test_name}" "${failure_message}"
+}
+
 function console_results::print_failed_test() {
   local test_name=$1
   local expected=$2

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+function test_successful_fail() {
+  true || fail "This cannot fail"
+}
+
 function test_unsuccessful_fail() {
   assert_equals\
     "$(console_results::print_failure_message "Unsuccessful fail" "Failure message")"\

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+function test_unsuccessful_fail() {
+  assert_equals\
+    "$(console_results::print_failure_message "Unsuccessful fail" "Failure message")"\
+    "$(fail "Failure message")"
+}
+
 function test_successful_assert_equals() {
   assert_empty "$(assert_equals "1" "1")"
 }


### PR DESCRIPTION
## 📚 Description

Adds new `fail()` function for general purpose test failures not covered by the various `assert_*` functions.

## 🔖 Changes

- Added `fail()` function in assert.sh
- Added `console_results::print_failure_message()` function in console_results.sh
- Added test case

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
