### PR TITLE
fix: `bashunit-e` file isn't created sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.11.0...main)
 
+- Fix test with `rm` command in macOS
 - Add multi-invokers; consolidate parameterized-testing documentation
 - Add `fail()` function
 - Remove all test mocks after each test case

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -24,7 +24,7 @@ function test_upgrade_when_a_new_version_found() {
     ./bin/bashunit
 
   if [[ $_OS == "OSX" ]]; then
-    rm ./bin/bashunit-e
+    rm -f ./bin/bashunit-e
   fi
 
   local output


### PR DESCRIPTION
## 📚 Description

Replace this text with a short description of your feature/bugfix.
Fix failing test due to the way `sed` command behave in macOS, sometimes the file `./bin/bashunit-e` isn't created  and the test fails:
<img width="600" alt="image" src="https://github.com/TypedDevs/bashunit/assets/62360034/2c6cb171-3ae9-4885-a561-c4baf9d156a6">

To avoid this I've added the `-f` flag to the `rm` command to in case the `./bin/bashunit-e` don't exist the command don't fail and breaks the test, doc related:
<img width="600" alt="image" src="https://github.com/TypedDevs/bashunit/assets/62360034/6a8d0c96-24e2-402a-9e04-6c8368d35d2e">


## 🔖 Changes

- Add `-f` flag to avoid problems with `rm` command in macOS

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
