### PR TITLE
Add missing assertions in non-stable version test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.11.0...main)
 
+- Add missing assertion in non-stable versions
 - Fix test with `rm` command in macOS
 - Add multi-invokers; consolidate parameterized-testing documentation
 - Add `fail()` function

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -68,5 +68,7 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$(printf "\e[1m\e[32mbashunit\e[0m - (non-stable) beta [2023-11-13]")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
-  todo "assert that bashunit is the only file that exists in the deps folder"
+  file_count_of_deps_directory=$(find ./deps -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')
+  assert_equals "$file_count_of_deps_directory" "1"
+  assert_equals "$(find ./deps -name 'bashunit')" "./deps/bashunit"
 }


### PR DESCRIPTION
## 📚 Description

Add assertions request in  `todo`

## 🔖 Changes

- Assert number of files in installed directory
- Assert the only file in installed directory is the `bashunit` file

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
