### PR TITLE
Allow calling assertions outside tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.12.0...main)
 
-- ...
+- Allow calling assertions outside tests
 
 ## [0.12.0](https://github.com/TypedDevs/bashunit/compare/0.11.0...0.12.0) - 2024-06-11
 

--- a/bashunit
+++ b/bashunit
@@ -17,6 +17,7 @@ source "$BASHUNIT_ROOT_DIR/src/helpers.sh"
 source "$BASHUNIT_ROOT_DIR/src/upgrade.sh"
 source "$BASHUNIT_ROOT_DIR/src/assertions.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner.sh"
+source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
 ###############
 #### MAIN #####
@@ -83,11 +84,6 @@ if [[ -n $_ASSERT_FN ]]; then
   if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
       exit 1
   fi
-
 else
-  console_header::print_version_with_env
-  runner::load_test_files "$_FILTER" "${_FILES[@]}"
-  console_results::render_result
-  exit 0
+  main::exec_tests "$_FILTER" "${_FILES[@]}"
 fi
-

--- a/bashunit
+++ b/bashunit
@@ -22,12 +22,18 @@ source "$BASHUNIT_ROOT_DIR/src/runner.sh"
 #### MAIN #####
 ###############
 
+_ASSERT_FN=""
 _FILTER=""
 _FILES=()
 
 while [[ $# -gt 0 ]]; do
   argument="$1"
   case $argument in
+    -a|--assert)
+      _ASSERT_FN="$2"
+      shift
+      shift
+      ;;
     -f|--filter)
       _FILTER="$2"
       shift
@@ -72,8 +78,16 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-console_header::print_version_with_env
-runner::load_test_files "$_FILTER" "${_FILES[@]}"
-console_results::render_result
+if [[ -n $_ASSERT_FN ]]; then
+  "$_ASSERT_FN" "${_FILES[@]}"
+  if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
+      exit 1
+  fi
 
-exit 0
+else
+  console_header::print_version_with_env
+  runner::load_test_files "$_FILTER" "${_FILES[@]}"
+  console_results::render_result
+  exit 0
+fi
+

--- a/bashunit
+++ b/bashunit
@@ -19,10 +19,6 @@ source "$BASHUNIT_ROOT_DIR/src/assertions.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner.sh"
 source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
-###############
-#### MAIN #####
-###############
-
 _ASSERT_FN=""
 _FILTER=""
 _FILES=()
@@ -80,10 +76,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ -n $_ASSERT_FN ]]; then
-  "$_ASSERT_FN" "${_FILES[@]}"
-  if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
-      exit 1
-  fi
+  main::exec_assert "$_ASSERT_FN" "${_FILES[@]}"
 else
   main::exec_tests "$_FILTER" "${_FILES[@]}"
 fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -2,19 +2,20 @@
 
 function main::exec_tests() {
   local filter=$1
-  local files=("${@:2}") # Store all arguments starting from the second as an array
+  local args=("${@:2}")
 
   console_header::print_version_with_env
-  runner::load_test_files "$filter" "${files[@]}"
+  runner::load_test_files "$filter" "${args[@]}"
   console_results::render_result
   exit 0
 }
 
 function main::exec_assert() {
   local assert_fn=$1
-  local args=("${@:2}") # Store all arguments starting from the second as an array
+  local args=("${@:2}")
 
   "$assert_fn" "${args[@]}"
+
   if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
       exit 1
   fi

--- a/src/main.sh
+++ b/src/main.sh
@@ -9,3 +9,13 @@ function main::exec_tests() {
   console_results::render_result
   exit 0
 }
+
+function main::exec_assert() {
+  local assert_fn=$1
+  local args=("${@:2}") # Store all arguments starting from the second as an array
+
+  "$assert_fn" "${args[@]}"
+  if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
+      exit 1
+  fi
+}

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function main::exec_tests() {
+  local filter=$1
+  local files=("${@:2}") # Store all arguments starting from the second as an array
+
+  console_header::print_version_with_env
+  runner::load_test_files "$filter" "${files[@]}"
+  console_results::render_result
+  exit 0
+}

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function test_bashunit_direct_fn_call_passes() {
+  local expected="foo"
+  local actual="foo"
+
+  ./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual
+  assert_successful_code
+}
+
+function test_bashunit_direct_fn_call_failure() {
+  local expected="foo"
+  local actual="bar"
+
+  assert_match_snapshot "$(./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual)"
+  assert_general_error "$(./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual)"
+}

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,0 +1,3 @@
+[31m✗ Failed[0m: Main
+    [2mExpected[0m [1m'foo'[0m
+    [2mbut got[0m [1m'bar'[0m

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
-[31m✗ Failed[0m: Main
+[31m✗ Failed[0m: Main::exec assert
     [2mExpected[0m [1m'foo'[0m
     [2mbut got[0m [1m'bar'[0m


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/TypedDevs/bashunit/issues/257

## 🔖 Changes

- Add an option `-a|--assert` to `./bashunit` to allow running an [assertion](https://bashunit.typeddevs.com/assertions) from bashunit without the test context
- Benefits: provides the visual output from bashunit assertions + the result exit code is 0(passes) or 1(failures)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
