### PR TITLE
Add LATEST_BASHUNIT_VERSION when installing beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.12.0...main)
 
+- Add the latest version when installing beta
 - Allow calling assertions standalone outside tests
 - Add `assert_line_count`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.12.0...main)
 
-- Add the latest version when installing beta
 - Allow calling assertions standalone outside tests
+- Add the latest version when installing beta
 - Add `assert_line_count`
 
 ## [0.12.0](https://github.com/TypedDevs/bashunit/compare/0.11.0...0.12.0) - 2024-06-11

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ function build_and_install_beta() {
   cd ..
 
   local beta_version
-  beta_version='(non-stable) beta ['"$(date +'%Y-%m-%d')"']'
+  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"']'
 
   sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="'"$beta_version"'"/g' temp_bashunit/bin/bashunit
   cp temp_bashunit/bin/bashunit ./

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -64,8 +64,8 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$(printf "> Downloading non-stable version: 'beta'\n> bashunit has been installed in the 'deps' folder")"\
     "$output"
   assert_file_exists "$installed_bashunit"
-  assert_equals\
-    "$(printf "\e[1m\e[32mbashunit\e[0m - (non-stable) beta [2023-11-13]")"\
+  assert_matches\
+    "$(printf "\(non-stable\) beta after ([0-9]+\.[0-9]+\.[0-9]+) \[2023-11-13\]")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
   file_count_of_deps_directory=$(find ./deps -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')


### PR DESCRIPTION
## 📚 Description

Right now when installing a beta release, you see only the date. I would like to see the latest stable release as well.

## 🔖 Changes

- Add `after X.Y.Z` release when installing a beta release

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix


## 🖼️ Screenshots

#### BEFORE

![Screenshot 2024-06-17 at 14 10 11](https://github.com/TypedDevs/bashunit/assets/5256287/79e8ef6a-7b38-470c-a57c-a45f13099659)

#### AFTER

![Screenshot 2024-06-17 at 14 09 42](https://github.com/TypedDevs/bashunit/assets/5256287/5882e4af-4f97-456c-9dc5-0bc19be61877)

