### PR TITLE
Allow adding extra info on print_failed_test

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -324,12 +324,15 @@ function assert_line_count() {
   if [ -z "$actual" ]; then
     local actual_line_count=0
   else
-    local actual_line_count=$(echo "$actual" | wc -l | tr -d '[:blank:]')
+    local actual_line_count
+    actual_line_count=$(echo "$actual" | wc -l | tr -d '[:blank:]')
   fi
 
   if [[ "$expected" != "$actual_line_count" ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${actual}" "to contain number of lines equal to" "${expected}"
+    console_results::print_failed_test "${label}" "${actual}"\
+      "to contain number of lines equal to" "${expected}"\
+      "but found" "${actual_line_count}"
     return
   fi
 

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -146,12 +146,20 @@ function console_results::print_failed_test() {
   local expected=$2
   local failure_condition_message=$3
   local actual=$4
+  local extra_key=$5
+  local extra_value=$6
 
   printf "\
 ${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
     ${_COLOR_FAINT}Expected${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}
     ${_COLOR_FAINT}%s${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
     "${test_name}" "${expected}" "${failure_condition_message}" "${actual}"
+
+  if [ -n "$extra_key" ]; then
+     printf "\
+    ${_COLOR_FAINT}%s${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
+    "${extra_key}" "${extra_value}"
+  fi
 }
 
 function console_results::print_failed_snapshot_test() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -348,6 +348,6 @@ function test_successful_assert_line_count() {
 function test_unsuccessful_assert_line_count() {
   assert_equals\
     "$(console_results::print_failed_test\
-      "Unsuccessful assert line count" "one_line_string" "to contain number of lines equal to" "10")"\
+      "Unsuccessful assert line count" "one_line_string" "to contain number of lines equal to" "10" "but found" "1")"\
     "$(assert_line_count 10 "one_line_string")"
 }


### PR DESCRIPTION

## 🔖 Changes

- allow adding extra info on print_failed_test
- add extra info to `assert_line_count`
