### PR TITLE
Fix: assert_line_count

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -318,21 +318,25 @@ function assert_greater_or_equal_than() {
 
 function assert_line_count() {
   local expected="$1"
-  local actual="$2"
+  local input_str="$2"
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  if [ -z "$actual" ]; then
-    local actual_line_count=0
+  if [ -z "$input_str" ]; then
+    local actual=0
   else
-    local actual_line_count
-    actual_line_count=$(echo "$actual" | wc -l | tr -d '[:blank:]')
+    local actual
+    actual=$(echo "$input_str" | wc -l | tr -d '[:blank:]')
+    if [[ actual -eq 1 ]]; then
+      actual=$(grep -o '\\n' <<< "$input_str" | wc -l | tr -d '[:blank:]')
+      ((actual++))
+    fi
   fi
 
-  if [[ "$expected" != "$actual_line_count" ]]; then
+  if [[ "$expected" != "$actual" ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${actual}"\
+    console_results::print_failed_test "${label}" "${input_str}"\
       "to contain number of lines equal to" "${expected}"\
-      "but found" "${actual_line_count}"
+      "but found" "${actual}"
     return
   fi
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -326,10 +326,8 @@ function assert_line_count() {
   else
     local actual
     actual=$(echo "$input_str" | wc -l | tr -d '[:blank:]')
-    if [[ actual -eq 1 ]]; then
-      actual=$(grep -o '\\n' <<< "$input_str" | wc -l | tr -d '[:blank:]')
-      ((actual++))
-    fi
+    additional_new_lines=$(grep -o '\\n' <<< "$input_str" | wc -l | tr -d '[:blank:]')
+    ((actual+=additional_new_lines))
   fi
 
   if [[ "$expected" != "$actual" ]]; then

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -349,6 +349,14 @@ function test_successful_assert_line_count_multiline_string_in_one_line() {
   assert_empty "$(assert_line_count 4 "one\ntwo\nthree\nfour")"
 }
 
+function test_successful_assert_line_count_multiline_with_new_lines() {
+  local multiline_str="this\nis\nline\none
+  this is line 5
+  this is line 6"
+
+  assert_empty "$(assert_line_count 6 "$multiline_str")"
+}
+
 function test_unsuccessful_assert_line_count() {
   assert_equals\
     "$(console_results::print_failed_test\

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -356,10 +356,12 @@ function test_successful_assert_line_count_multiline_string_in_one_line() {
 
 function test_successful_assert_line_count_multiline_with_new_lines() {
   local multiline_str="this \n is \n a multiline \n in one
-  this is line 5
-  this is \n line seven"
+  \n
+  this is line 7
+  this is \n line nine
+  "
 
-  assert_empty "$(assert_line_count 7 "$multiline_str")"
+  assert_empty "$(assert_line_count 10 "$multiline_str")"
 }
 
 function test_unsuccessful_assert_line_count() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -345,6 +345,10 @@ function test_successful_assert_line_count() {
   assert_empty "$(assert_line_count 3 "$multi_line_string")"
 }
 
+function test_successful_assert_line_count_multiline_string_in_one_line() {
+  assert_empty "$(assert_line_count 4 "one\ntwo\nthree\nfour")"
+}
+
 function test_unsuccessful_assert_line_count() {
   assert_equals\
     "$(console_results::print_failed_test\

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -355,11 +355,11 @@ function test_successful_assert_line_count_multiline_string_in_one_line() {
 }
 
 function test_successful_assert_line_count_multiline_with_new_lines() {
-  local multiline_str="this\nis\nline\none
+  local multiline_str="this \n is \n a multiline \n in one
   this is line 5
-  this is line 6"
+  this is \n line seven"
 
-  assert_empty "$(assert_line_count 6 "$multiline_str")"
+  assert_empty "$(assert_line_count 7 "$multiline_str")"
 }
 
 function test_unsuccessful_assert_line_count() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -334,15 +334,20 @@ function test_unsuccessful_assert_equals_ignore_colors() {
     "$(assert_equals_ignore_colors "$string" "$string")"
 }
 
-function test_successful_assert_line_count() {
-  local one_line_string="one line"
-  local multi_line_string="this is line one
+function test_successful_assert_line_count_empty_str() {
+  assert_empty "$(assert_line_count 0 "")"
+}
+
+function test_successful_assert_line_count_one_line() {
+  assert_empty "$(assert_line_count 1 "one line")"
+}
+
+function test_successful_assert_count_multiline() {
+  local multiline_string="this is line one
   this is line two
   this is line three"
 
-  assert_empty "$(assert_line_count 0 "")"
-  assert_empty "$(assert_line_count 1 "$one_line_string")"
-  assert_empty "$(assert_line_count 3 "$multi_line_string")"
+  assert_empty "$(assert_line_count 3 "$multiline_string")"
 }
 
 function test_successful_assert_line_count_multiline_string_in_one_line() {


### PR DESCRIPTION
## 📚 Description

Related to: https://github.com/phpstan/phpstan-src/pull/3160#discussion_r1643031961 
> The `\n` are ignored when counting the lines `actual=$(echo "$input_str" | wc -l | tr -d '[:blank:]')`

## 🔖 Changes

- Count additionally the `\n` of a string on `assert_line_count`
