### PR TITLE
fix: assert_line_count on multiline

### DIFF
--- a/src/assert.sh
+++ b/src/assert.sh
@@ -318,8 +318,9 @@ function assert_greater_or_equal_than() {
 
 function assert_line_count() {
   local expected="$1"
-  local input_str="$2"
-  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+  local input_arr=("${@:2}")
+  local input_str
+  input_str=$(printf '%s\n' "${input_arr[@]}")
 
   if [ -z "$input_str" ]; then
     local actual=0
@@ -331,6 +332,9 @@ function assert_line_count() {
   fi
 
   if [[ "$expected" != "$actual" ]]; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[0]}")"
+
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${input_str}"\
       "to contain number of lines equal to" "${expected}"\

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -333,7 +333,7 @@ function assert_line_count() {
 
   if [[ "$expected" != "$actual" ]]; then
     local label
-    label="$(helper::normalize_test_function_name "${FUNCNAME[0]}")"
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
 
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${input_str}"\

--- a/src/main.sh
+++ b/src/main.sh
@@ -24,7 +24,7 @@ function main::exec_assert() {
     fi
   fi
 
-  "$assert_fn" "${args[@]}" "$assert_fn"
+  "$assert_fn" "${args[@]}"
 
   if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
       exit 1

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -22,16 +22,8 @@ function test_bashunit_direct_fn_call_without_assert_prefix_passes() {
 
 function test_bashunit_assert_line_count() {
   local actual="first line
-second line"
-
-  ./bashunit -a line_count 2 "$actual"
-  assert_successful_code
-}
-
-function test_bashunit_assert_line_count_with_explicit_line_break() {
-  local actual="first line
-second line
-\n four line"
+  \n
+four line"
 
   ./bashunit -a line_count 4 "$actual"
   assert_successful_code

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -28,6 +28,15 @@ second line"
   assert_successful_code
 }
 
+function test_bashunit_assert_line_count_with_explicit_line_break() {
+  local actual="first line
+second line
+\n four line"
+
+  ./bashunit -a line_count 4 "$actual"
+  assert_successful_code
+}
+
 function test_bashunit_direct_fn_call_failure() {
   local expected="foo"
   local actual="bar"

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -20,6 +20,14 @@ function test_bashunit_direct_fn_call_without_assert_prefix_passes() {
   assert_successful_code
 }
 
+function test_bashunit_assert_line_count() {
+  local actual="first line
+second line"
+
+  ./bashunit -a line_count 2 "$actual"
+  assert_successful_code
+}
+
 function test_bashunit_direct_fn_call_failure() {
   local expected="foo"
   local actual="bar"

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
-[31m✗ Failed[0m: assert_equals
+[31m✗ Failed[0m: Main::exec assert
     [2mExpected[0m [1m'foo'[0m
     [2mbut got[0m [1m'bar'[0m


### PR DESCRIPTION
## 📚 Description

Issue: https://github.com/phpstan/phpstan-src/pull/3160#discussion_r1643902055

Multiline strings are passes as multiple args to `assert_line_count` which makes it complicated to pass around and manipulate as unique string.

## 🔖 Changes

- `assert_line_count` uses first arg for the expected and the rest (think about a `variadic ...string arg`) will be the string itself that will be use to count its lines.

 ## 💡 Extra
Tradeoff: I had to rollback https://github.com/TypedDevs/bashunit/pull/262 in order to make it working. I think I can make it back again, but it might take another couple of hours... so, I thought to ship this first, make it work, and then in a follow up make it better.