### PR TITLE
Add hash next to version in beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Allow calling assertions standalone outside tests
 - Add the latest version when installing beta
 - Add `assert_line_count`
+- Add hash to the installation script when installing a beta version
 
 ## [0.12.0](https://github.com/TypedDevs/bashunit/compare/0.11.0...0.12.0) - 2024-06-11
 

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,11 @@ function build_and_install_beta() {
   ./build.sh >/dev/null
   cd ..
 
+  local lastest_commit
+  lastest_commit=$(git rev-parse --short=8 HEAD);
+
   local beta_version
-  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"']'
+  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍 $lastest_commit'
 
   sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="'"$beta_version"'"/g' temp_bashunit/bin/bashunit
   cp temp_bashunit/bin/bashunit ./

--- a/install.sh
+++ b/install.sh
@@ -26,11 +26,11 @@ function build_and_install_beta() {
   ./build.sh >/dev/null
   cd ..
 
-  local lastest_commit
-  lastest_commit=$(git rev-parse --short=8 HEAD);
+  local latest_commit
+  latest_commit=$(git rev-parse --short=8 HEAD);
 
   local beta_version
-  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍 $lastest_commit'
+  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍'"$latest_commit"
 
   sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="'"$beta_version"'"/g' temp_bashunit/bin/bashunit
   cp temp_bashunit/bin/bashunit ./

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ function build_and_install_beta() {
   latest_commit=$(git rev-parse --short=8 HEAD);
 
   local beta_version
-  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍'"$latest_commit"
+  beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍 #'"$latest_commit"
 
   sed -i -e 's/BASHUNIT_VERSION=".*"/BASHUNIT_VERSION="'"$beta_version"'"/g' temp_bashunit/bin/bashunit
   cp temp_bashunit/bin/bashunit ./

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -65,7 +65,7 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$output"
   assert_file_exists "$installed_bashunit"
   assert_matches\
-    "$(printf "\(non-stable\) beta after ([0-9]+\.[0-9]+\.[0-9]+) \[2023-11-13\]")"\
+    "$(printf "\(non-stable\) beta after ([0-9]+\.[0-9]+\.[0-9]+) \[2023-11-13\] 🐍 \#([0-9aZ]*)")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
   file_count_of_deps_directory=$(find ./deps -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -65,7 +65,7 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$output"
   assert_file_exists "$installed_bashunit"
   assert_matches\
-    "$(printf "\(non-stable\) beta after ([0-9]+\.[0-9]+\.[0-9]+) \[2023-11-13\] 🐍 \#([0-9aZ]*)")"\
+    "$(printf "\(non-stable\) beta after ([0-9]+\.[0-9]+\.[0-9]+) \[2023-11-13\] 🐍 \#[a-fA-F0-9]{8}")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
   file_count_of_deps_directory=$(find ./deps -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/261
Show the current hash next to the `version` command in beta.

## 🖼️ Screenshots

### BEFORE

![Screenshot 2024-06-19 at 10 29 17](https://github.com/TypedDevs/bashunit/assets/5256287/bad7cfd7-0b8e-48cc-99ab-3a8ba2f5f081)

### AFTER 
![Screenshot 2024-06-19 at 10 28 51](https://github.com/TypedDevs/bashunit/assets/5256287/5a4eddab-7394-4884-9f1a-f914f2bb55e6)

