### PR TITLE
Add GitHub Actions to installation doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add the latest version when installing beta
 - Add `assert_line_count`
 - Add hash to the installation script when installing a beta version
+- Add GitHub Actions to installation doc
 
 ## [0.12.0](https://github.com/TypedDevs/bashunit/compare/0.11.0...0.12.0) - 2024-06-11
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,37 @@ We try to keep it stable, but there is no promise that we won't change functions
 Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
 :::
 
+## GitHub Actions
+
+```yaml
+# example: .github/workflows/bashunit-tests.yml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install bashunit"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s lib latest"
+
+      - name: "Test"
+        run: "lib/bashunit tests/**/*_test.sh"
+```
+
+::: tip
+Check the pipelines running on bashunit itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+:::
+
 ## Brew
 
 You can install **bashunit** globally in your macOS (or Linux) using brew.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -55,10 +55,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Install bashunit"
-        run: "curl -s https://bashunit.typeddevs.com/install.sh | bash -s lib latest"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh"
 
       - name: "Test"
-        run: "lib/bashunit tests/**/*_test.sh"
+        run: "./bashunit tests/**/*_test.sh"
 ```
 
 ::: tip

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,7 +62,7 @@ jobs:
 ```
 
 ::: tip
-Check the pipelines running on bashunit itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::
 
 ## Brew


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/256 by @staabm

## 🔖 Changes

- Add new section "GitHub Actions" to installation documentation

![Screenshot 2024-06-19 at 11 10 58](https://github.com/TypedDevs/bashunit/assets/5256287/68285f33-ca98-44ad-9cf8-37c896d629ca)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

