### PR TITLE
Fix: exit code when fn does not exist

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -20,7 +20,7 @@ function main::exec_assert() {
     assert_fn="assert_$assert_fn"
     if ! type "$assert_fn" > /dev/null 2>&1; then
       echo "Function $original_assert_fn does not exist."
-      exit 1
+      exit 127
     fi
   fi
 

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -79,5 +79,5 @@ function test_bashunit_direct_fn_call_failure() {
 
 function test_bashunit_direct_fn_call_non_existing_fn() {
   assert_match_snapshot "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
-  assert_general_error "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
+  assert_command_not_found "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
 }


### PR DESCRIPTION
## 📚 Description

In bash, when a function does not exist, the exist code must be `127`

## 🔖 Changes

- Do `exit 127` on `exec_assert()` when function does not exist
