### PR TITLE
fix: echo does not break test execution result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.13.0...main)
+
+- Fix echo does not break test execution results
+
 ## [0.13.0](https://github.com/TypedDevs/bashunit/compare/0.12.0...0.13.0) - 2024-06-23
 
 - Allow calling assertions standalone outside tests

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -181,7 +181,7 @@ function runner::run_test() {
   local runtime_error
   runtime_error=$(\
     echo "$test_execution_result" |\
-    head -n 1 |\
+    tail -n 1 |\
     sed -E -e 's/(.*)##ASSERTIONS_FAILED=.*/\1/g'\
   )
 

--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -24,6 +24,13 @@ function test_redirect_error_without_log() {
   assert_general_error
 }
 
+function test_echo_does_not_break_test_execution_result() {
+    printf "some text\nsome text"
+
+    _="$(render_into_error_fd_and_exit "...args")"
+    assert_exit_code 1
+}
+
 function render_into_error_fd_and_exit() {
   echo "$*" >&2
   exit 1

--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -25,10 +25,8 @@ function test_redirect_error_without_log() {
 }
 
 function test_echo_does_not_break_test_execution_result() {
-    printf "some text\nsome text"
-
     _="$(render_into_error_fd_and_exit "...args")"
-    assert_exit_code 1
+    assert_general_error
 }
 
 function render_into_error_fd_and_exit() {


### PR DESCRIPTION
## 📚 Description

This PR is for solving the issue https://github.com/TypedDevs/bashunit/issues/272

Echo statement with a new line inside a test was breaking the test execution result data and the head pipe on this variable was getting the echoed data and not the test execution result. As the test execution result data will be always at the last line, changing `head` to `tail` could resolve this issue.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
