### PR TITLE
Enable simple custom assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.13.0...main)
 
 - Fix echo does not break test execution results
+- Add bashunit facade to enable custom assertions
 
 ## [0.13.0](https://github.com/TypedDevs/bashunit/compare/0.12.0...0.13.0) - 2024-06-23
 

--- a/bashunit
+++ b/bashunit
@@ -17,6 +17,7 @@ source "$BASHUNIT_ROOT_DIR/src/helpers.sh"
 source "$BASHUNIT_ROOT_DIR/src/upgrade.sh"
 source "$BASHUNIT_ROOT_DIR/src/assertions.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner.sh"
+source "$BASHUNIT_ROOT_DIR/src/bashunit.sh"
 source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
 _ASSERT_FN=""

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -79,6 +79,9 @@ export default defineConfig({
         text: 'Standalone',
         link: '/standalone'
       }, {
+        text: 'Custom asserts',
+        link: '/custom-asserts'
+      }, {
         text: 'Examples',
         link: '/examples'
       }, {

--- a/docs/custom-asserts.md
+++ b/docs/custom-asserts.md
@@ -1,0 +1,34 @@
+# Custom asserts
+
+**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+
+:::tip
+Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
+:::
+
+## assertion_failed
+> `bashunit::assertion_failed <expected> <actual> <failure_condition_message?>`
+
+## assertion_passed
+> `bashunit::assertion_passed`
+
+## Example
+
+```bash
+# Your custom assert using the bashunit facade
+function assert_foo() {
+  local actual="$1"
+
+  if [[ "foo" != "$actual" ]]; then
+    bashunit::assertion_failed "foo" "$actual"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+# Your test using your custom assert
+function test_assert_foo_passed() {
+  assert_foo "foo"
+}
+```

--- a/src/bashunit.sh
+++ b/src/bashunit.sh
@@ -15,3 +15,7 @@ function bashunit::assertion_failed() {
   console_results::print_failed_test "${label}" "${expected}" \
     "$failure_condition_message" "${actual}"
 }
+
+function bashunit::assertion_passed() {
+  state::add_assertions_passed
+}

--- a/src/bashunit.sh
+++ b/src/bashunit.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This file provides a facade to developers who wants
+# to interact with the internals of bashunit.
+# e.g. adding custom assertions
+
+function bashunit::assertion_failed() {
+  local expected=$1
+  local actual=$2
+  local failure_condition_message=${3:-"but got"}
+
+  local label
+  label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+  state::add_assertions_failed
+  console_results::print_failed_test "${label}" "${expected}" \
+    "$failure_condition_message" "${actual}"
+}

--- a/tests/functional/custom_asserts.sh
+++ b/tests/functional/custom_asserts.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function assert_foo() {
+  local actual="$1"
+  local expected="foo"
+
+  if [[ "$expected" != "$actual" ]]; then
+    bashunit::assertion_failed "$expected" "${actual}"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+function assert_positive_number() {
+  local actual="$1"
+
+  if [[ "$actual" -le 0 ]]; then
+    bashunit::assertion_failed "positive number" "${actual}" "got"
+    return
+  fi
+
+  bashunit::assertion_passed
+}

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+function set_up() {
+  _ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+  source "$_ROOT_DIR/custom_asserts.sh"
+}
+
+function test_assert_foo_success() {
+  assert_foo "foo"
+}
+
+function test_assert_foo_failing() {
+  assert_equals\
+    "$(console_results::print_failed_test "Assert foo" "foo" "but got" "bar")"\
+    "$(assert_foo "bar")"
+}
+
+function test_assert_positive_number_success() {
+  assert_positive_number "1"
+}
+
+function test_assert_positive_number_failing() {
+  assert_equals\
+    "$(console_results::print_failed_test "Assert positive number" "positive number" "got" "0")"\
+    "$(assert_positive_number "0")"
+}

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -5,21 +5,21 @@ function set_up() {
   source "$_ROOT_DIR/custom_asserts.sh"
 }
 
-function test_assert_foo_success() {
+function test_assert_foo_passed() {
   assert_foo "foo"
 }
 
-function test_assert_foo_failing() {
+function test_assert_foo_failed() {
   assert_equals\
     "$(console_results::print_failed_test "Assert foo" "foo" "but got" "bar")"\
     "$(assert_foo "bar")"
 }
 
-function test_assert_positive_number_success() {
+function test_assert_positive_number_passed() {
   assert_positive_number "1"
 }
 
-function test_assert_positive_number_failing() {
+function test_assert_positive_number_failed() {
   assert_equals\
     "$(console_results::print_failed_test "Assert positive number" "positive number" "got" "0")"\
     "$(assert_positive_number "0")"


### PR DESCRIPTION
## 🔖 Changes

- Add bashunit facade to enable custom assertions
  - `bashunit::assertion_failed()`
  - `bashunit::assertion_passed()`

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes

![Screenshot 2024-07-08 at 01 34 41](https://github.com/TypedDevs/bashunit/assets/5256287/3a0986ca-54f5-44c5-aa9b-95673792eca0)

