### PR TITLE
Document how to verify the sha256sum of the final executable

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -6,12 +6,14 @@ This is a guide to know the steps to create a new release.
 1. Update the version in [CHANGELOG.md](../CHANGELOG.md)
 1. Update the version in [package.json](../package.json)
 1. Update the checksum(sha256) in [package.json](../package.json)
+    - `./build.sh bin && shasum -a 256 "bin/bashunit" | awk '{ print $1 }'`
 1. Create a [new release](https://github.com/TypedDevs/bashunit/releases/new) from GitHub
 1. Attach the latest executable to the release
     1. Generate a new bashunit with `build.sh`
     1. Attach the generated file to the release page on GitHub
     1. Keep the name `bashunit`
 1. Attach the sha256sum for that executable as a new file `checksum`
+    - `./build.sh bin && shasum -a 256 "bin/bashunit" > bin/checksum`
 1. Commit and push
-1. Rebase `latest` branch from the new created tag and push
+1. Rebase `latest` branch from the newly created tag and push
     1. This will trigger "build and deploy" the docs

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -5,6 +5,7 @@ This is a guide to know the steps to create a new release.
 1. Update the version in [BASHUNIT_VERSION](../bashunit)
 1. Update the version in [CHANGELOG.md](../CHANGELOG.md)
 1. Update the version in [package.json](../package.json)
+1. Update the checksum(sha256) in [package.json](../package.json)
 1. Create a [new release](https://github.com/TypedDevs/bashunit/releases/new) from GitHub
 1. Attach the latest executable to the release
     1. Generate a new bashunit with `build.sh`

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ docs/.vitepress/dist
 
 # installation
 bin/bashunit
+bin/checksum
 lib/bashunit

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ docs/.vitepress/dist
 
 # installation
 bin/bashunit
+lib/bashunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix echo does not break test execution results
 - Add bashunit facade to enable custom assertions
+- Document how to verify the sha256sum of the final executable
 
 ## [0.13.0](https://github.com/TypedDevs/bashunit/compare/0.12.0...0.13.0) - 2024-06-23
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,6 +15,20 @@ curl -s https://bashunit.typeddevs.com/install.sh | bash
 
 This will create a file inside a lib folder, such as `lib/bashunit`.
 
+### Verify
+
+```bash-vue
+# Verify the sha256sum for latest: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}";FILE="$DIR/bashunit"; HASH=$(shasum -a 256 "$FILE" | awk '{ print $1 }'); [ "$HASH" = "$KNOWN_HASH" ] && echo "Installer verified" || { echo "Installer corrupt"; rm "$FILE"; }
+```
+
+:::tip
+You can find the checksum for each version inside [GitHub's releases](https://github.com/TypedDevs/bashunit/releases). E.g.:
+```-vue
+https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checksum
+```
+:::
+
 #### Define custom tag and folder
 
 The installation script can receive two optional arguments:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,11 +15,11 @@ curl -s https://bashunit.typeddevs.com/install.sh | bash
 
 This will create a file inside a lib folder, such as `lib/bashunit`.
 
-### Verify
+#### Verify
 
 ```bash-vue
-# Verify the sha256sum for latest: {{ pkg.version }}
-DIR="lib"; KNOWN_HASH="{{pkg.checksum}}";FILE="$DIR/bashunit"; HASH=$(shasum -a 256 "$FILE" | awk '{ print $1 }'); [ "$HASH" = "$KNOWN_HASH" ] && echo "Installer verified" || { echo "Installer corrupt"; rm "$FILE"; }
+# Verify the sha256sum for latest stable: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}"; FILE="$DIR/bashunit"; [ "$(shasum -a 256 "$FILE" | awk '{ print $1 }')" = "$KNOWN_HASH" ] && echo -e "✓ \033[1mbashunit\033[0m verified." || { echo -e "✗ \033[1mbashunit\033[0m corrupt"; rm "$FILE"; }
 ```
 
 :::tip

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bashunit-docs",
   "version": "0.13.0",
+  "checksum": "6d9f1b49e4cf61d9837277251cce566eaa8b73e0f417474949a48336bd43a901",
   "description": "Docs for bashunit a simple testing library for bash scripts",
   "main": "index.js",
   "repository": "git@github.com:TypedDevs/bashunit.git",


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/277

## 🔖 Changes

- Add checksum to `package.js`
- Document how to check the sha256sum as part of the installation (optional step)
  - The docs will show a one liner command to check the latest checksum effortless 

![Screenshot 2024-07-08 at 15 33 10](https://github.com/TypedDevs/bashunit/assets/5256287/a92f1fd8-70fa-447c-ab3d-cf1fc2ae0b13)


## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes

## 🖼️ Demo

https://github.com/TypedDevs/bashunit/assets/5256287/e6e7a27a-b667-4171-86f6-81f2445d606e

![Screenshot 2024-07-08 at 17 01 14](https://github.com/TypedDevs/bashunit/assets/5256287/f8e0cb01-62df-4049-b5a3-f3922a172d1d)

## 🧗🏼  Extra

I added the checksum for all GitHub releases `>=0.8`.