### PR TITLE
Support displaying clock without perl (for non-macOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add bashunit facade to enable custom assertions
 - Document how to verify the `sha256sum` of the final executable
 - Enable display execution time on macOS with `SHOW_EXECUTION_TIME`
-- Support for displaying the clock without `perl` (for non-MacOS)
+- Support for displaying the clock without `perl` (for non-macOS)
 - Add `-l|--log-junit <log.xml>` option
 - Add `-r|--report-html <report.html>` option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Fix echo does not break test execution results
 - Add bashunit facade to enable custom assertions
 - Document how to verify the `sha256sum` of the final executable
-- Enable display execution time on MacOS with `SHOW_EXECUTION_TIME`
-  - Use `perl` for this. In case it is not installed, then rollback to `date`
+- Enable display execution time on macOS with `SHOW_EXECUTION_TIME`
+- Support for displaying the clock without `perl` (for non-MacOS)
 - Add `-l|--log-junit <log.xml>` option
 - Add `-r|--report-html <report.html>` option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add bashunit facade to enable custom assertions
 - Document how to verify the `sha256sum` of the final executable
 - Enable display execution time on MacOS with `SHOW_EXECUTION_TIME`
+  - Use `perl` for this. In case it is not installed, then rollback to `date`
 - Add `-l|--log-junit <log.xml>` option
 - Add `-r|--report-html <report.html>` option
 

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -13,8 +13,9 @@ function clock::now() {
 _START_TIME=$(clock::now)
 
 function clock::runtime_in_milliseconds() {
-  if [[ -n $_START_TIME ]]; then
-    echo $(( $(clock::now) - _START_TIME ))
+  end_time=$(clock::now)
+  if [[ -n $end_time ]]; then
+    echo $(( end_time - _START_TIME ))
   else
     echo ""
   fi

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
 function clock::now() {
-  perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)'
+  if perl --version > /dev/null 2>&1; then
+    perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)'
+  elif [[ "$_OS" != "OSX" ]]; then
+    date +%s%N
+  else
+    echo ""
+  fi
 }
 
 _START_TIME=$(clock::now)
 
 function clock::runtime_in_milliseconds() {
-  echo $(( $(clock::now) - _START_TIME ))
+  if [[ -n $_START_TIME ]]; then
+    echo $(( $(clock::now) - _START_TIME ))
+  else
+    echo ""
+  fi
 }

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -16,17 +16,24 @@ function test_now_with_perl() {
   assert_equals "1720705883457" "$(clock::now)"
 }
 
-function test_now_without_perl_no_osx() {
+function test_now_on_linux_without_perl() {
   export _OS="Linux"
   mock perl /dev/null
   mock date echo "1720705883457"
 
   assert_equals "1720705883457" "$(clock::now)"
 }
+function test_now_on_windows_without_perl() {
+  export _OS="Windows"
+  mock perl /dev/null
+  mock date echo "1720705883457"
 
-function test_now_without_perl_and_osx() {
+  assert_equals "1720705883457" "$(clock::now)"
+}
+
+function test_now_on_osx_without_perl() {
   export _OS="OSX"
-  mock perl echo ""
+  mock perl /dev/null
 
   assert_equals "" "$(clock::now)"
 }
@@ -39,7 +46,7 @@ function test_runtime_in_milliseconds_when_not_empty_time() {
 
 function test_runtime_in_milliseconds_when_empty_time() {
   export _OS="OSX"
-  mock perl echo ""
+  mock perl /dev/null
 
-  assert_empty "$(clock::now)"
+  assert_empty "$(clock::runtime_in_milliseconds)"
 }

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -10,6 +10,10 @@ function tear_down_after_script() {
   export _OS=$__ORIGINAL_OS
 }
 
+function mock_non_existing_fn() {
+  return 127;
+}
+
 function test_now_with_perl() {
   mock perl echo "1720705883457"
 
@@ -18,14 +22,14 @@ function test_now_with_perl() {
 
 function test_now_on_linux_without_perl() {
   export _OS="Linux"
-  mock perl /dev/null
+  mock perl mock_non_existing_fn
   mock date echo "1720705883457"
 
   assert_equals "1720705883457" "$(clock::now)"
 }
 function test_now_on_windows_without_perl() {
   export _OS="Windows"
-  mock perl /dev/null
+  mock perl mock_non_existing_fn
   mock date echo "1720705883457"
 
   assert_equals "1720705883457" "$(clock::now)"
@@ -33,7 +37,7 @@ function test_now_on_windows_without_perl() {
 
 function test_now_on_osx_without_perl() {
   export _OS="OSX"
-  mock perl /dev/null
+  mock perl mock_non_existing_fn
 
   assert_equals "" "$(clock::now)"
 }

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+function test_now_with_perl() {
+  mock perl echo "1720705883457"
+
+  assert_equals "1720705883457" "$(clock::now)"
+}
+
+function test_now_without_perl_no_osx() {
+  export _OS="Linux"
+
+  mock perl /dev/null
+  mock date echo "1720705883457"
+
+  assert_equals "1720705883457" "$(clock::now)"
+}
+
+function test_now_without_perl_and_osx() {
+  export _OS="OSX"
+
+  mock perl echo ""
+
+  assert_equals "" "$(clock::now)"
+}

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+__ORIGINAL_OS=""
+
+function set_up_before_script() {
+  __ORIGINAL_OS=$_OS
+}
+
+function tear_down_after_script() {
+  export _OS=$__ORIGINAL_OS
+}
+
 function test_now_with_perl() {
   mock perl echo "1720705883457"
 

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -50,7 +50,7 @@ function test_runtime_in_milliseconds_when_not_empty_time() {
 
 function test_runtime_in_milliseconds_when_empty_time() {
   export _OS="OSX"
-  mock perl /dev/null
+  mock perl mock_non_existing_fn
 
   assert_empty "$(clock::runtime_in_milliseconds)"
 }

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -18,7 +18,6 @@ function test_now_with_perl() {
 
 function test_now_without_perl_no_osx() {
   export _OS="Linux"
-
   mock perl /dev/null
   mock date echo "1720705883457"
 
@@ -27,8 +26,20 @@ function test_now_without_perl_no_osx() {
 
 function test_now_without_perl_and_osx() {
   export _OS="OSX"
-
   mock perl echo ""
 
   assert_equals "" "$(clock::now)"
+}
+
+function test_runtime_in_milliseconds_when_not_empty_time() {
+  mock perl echo "1720705883457"
+
+  assert_not_empty "$(clock::runtime_in_milliseconds)"
+}
+
+function test_runtime_in_milliseconds_when_empty_time() {
+  export _OS="OSX"
+  mock perl echo ""
+
+  assert_empty "$(clock::now)"
 }

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -266,11 +266,6 @@ function test_total_asserts_is_the_sum_of_passed_skipped_incomplete_snapshot_and
 }
 
 function test_render_execution_time() {
-  if [[ $_OS == "OSX" ]]; then
-    skip "Skipping in OSX"
-    return
-  fi
-
   local render_result
   render_result=$(
     # shellcheck disable=SC2034
@@ -282,11 +277,6 @@ function test_render_execution_time() {
 }
 
 function test_not_render_execution_time() {
-  if [[ $_OS == "OSX" ]]; then
-    skip "Skipping in OSX"
-    return
-  fi
-
   local render_result
   render_result=$(
     # shellcheck disable=SC2034


### PR DESCRIPTION
## 📚 Description

Here https://github.com/TypedDevs/bashunit/pull/279 ([diff](https://github.com/TypedDevs/bashunit/pull/279/files#diff-4a7672be1d0d2231ed4f311f4f82104470065074a0e9241fb52d4ce5bd1f617dL108)) we found a way to enable the exec time for all OS, however it's depending on `perl`. It is very unluckily that it's not installed by default, but in case it wouldn't be installed it would be interesting to use the old logic using `date` - which is something that all OS should have with more probability than `perl`.

## 🔖 Changes

- Use `date` to get the time in case `perl` is not installed

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
