### PR TITLE
Generate checksum on build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix echo does not break test execution results
 - Add bashunit facade to enable custom assertions
 - Document how to verify the `sha256sum` of the final executable
+- Generate checksum on build
 - Enable display execution time on macOS with `SHOW_EXECUTION_TIME`
 - Support for displaying the clock without `perl` (for non-macOS)
 - Add `-l|--log-junit <log.xml>` option

--- a/build.sh
+++ b/build.sh
@@ -2,22 +2,42 @@
 
 source src/check_os.sh
 
+function generate_bin() {
+  local output_file=$1
+  echo '#!/usr/bin/env bash' > bin/temp.sh
+
+  echo "Generating bashunit in the 'bin' folder..."
+  cat src/*.sh >> bin/temp.sh
+  cat bashunit >> bin/temp.sh
+  grep -v '^source' bin/temp.sh > "$output_file"
+  rm bin/temp.sh
+  chmod u+x "$output_file"
+}
+
+function generate_checksum() {
+  if [[ "$_OS" == "Windows" ]]; then
+    return
+  fi
+
+  local file=$1
+  if [[ "$_OS" == "OSX" ]]; then
+    checksum=$(shasum -a 256 "$file")
+  elif [[ "$_OS" == "Linux" ]]; then
+    checksum=$(sha256sum "$file")
+  fi
+
+  echo "$checksum" > bin/checksum
+  echo "$checksum"
+}
+
+########################
+######### MAIN #########
+########################
+
 mkdir -p bin
 output_file="bin/bashunit"
 
-echo '#!/usr/bin/env bash' > bin/temp.sh
-
-echo "Generating bashunit in the 'bin' folder..."
-cat src/*.sh >> bin/temp.sh
-cat bashunit >> bin/temp.sh
-grep -v '^source' bin/temp.sh > "$output_file"
-rm bin/temp.sh
-chmod u+x "$output_file"
-
-if [[ "$_OS" == "OSX" ]]; then
-  checksum=$(shasum -a 256 $output_file)
-  echo "$checksum" > bin/checksum
-  echo "$checksum"
-fi
+generate_bin "$output_file"
+generate_checksum "$output_file"
 
 echo "⚡️Build completed⚡️"

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-mkdir -p bin
+source src/check_os.sh
 
+mkdir -p bin
 output_file="bin/bashunit"
 
 echo '#!/usr/bin/env bash' > bin/temp.sh
@@ -12,5 +13,11 @@ cat bashunit >> bin/temp.sh
 grep -v '^source' bin/temp.sh > "$output_file"
 rm bin/temp.sh
 chmod u+x "$output_file"
+
+if [[ "$_OS" == "OSX" ]]; then
+  checksum=$(shasum -a 256 $output_file)
+  echo "$checksum" > bin/checksum
+  echo "$checksum"
+fi
 
 echo "⚡️Build completed⚡️"


### PR DESCRIPTION
## 📚 Description

When creating a new release, you need to generate the checksum after doing the build and use it in different places. This PR is helping into automating the generation of the checksum so there is one manual step less to do.

## 🔖 Changes

- Improve build script to generate the checksum (sha256) automatically
  - Only in macOS and Linux

## 📹  Demo

https://github.com/user-attachments/assets/8d9adddf-d365-4120-b23b-84b5cf9d9414

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
