### PR TITLE
Reducing shifts in entrypoint

### DIFF
--- a/bashunit
+++ b/bashunit
@@ -35,43 +35,34 @@ while [[ $# -gt 0 ]]; do
     -a|--assert)
       _ASSERT_FN="$2"
       shift
-      shift
       ;;
     -f|--filter)
       _FILTER="$2"
       shift
-      shift
       ;;
     -s|--simple)
       export SIMPLE_OUTPUT=true
-      shift
       ;;
     -v|--verbose)
       export SIMPLE_OUTPUT=false
-      shift
       ;;
     --debug)
       set -x
-      shift
       ;;
     -S|--stop-on-failure)
       export STOP_ON_FAILURE=true
-      shift
       ;;
     -e|--env)
       # shellcheck disable=SC1090
       source "$2"
       shift
-      shift
       ;;
     -l|--log-junit)
       export LOG_JUNIT="$2";
       shift
-      shift
       ;;
     -r|--report-html)
       export REPORT_HTML="$2";
-      shift
       shift
       ;;
     --version)
@@ -90,9 +81,9 @@ while [[ $# -gt 0 ]]; do
       while IFS='' read -r line; do
         _ARGS+=("$line");
       done < <(helper::find_files_recursive "$argument")
-      shift
       ;;
   esac
+  shift
 done
 
 set +eu

--- a/src/logger.sh
+++ b/src/logger.sh
@@ -58,9 +58,10 @@ function logger::generate_junit_xml() {
   {
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     echo "<testsuites>"
-    echo "  <testsuite name=\"bashunit\" tests=\"${#TEST_NAMES[@]}\" time=\"$time\""
+    echo "  <testsuite name=\"bashunit\" tests=\"${#TEST_NAMES[@]}\""
     echo "             passed=\"$test_passed\" failures=\"$tests_failed\" incomplete=\"$tests_incomplete\""
-    echo "             skipped=\"$tests_skipped\" snapshot=\"$tests_snapshot\">"
+    echo "             skipped=\"$tests_skipped\" snapshot=\"$tests_snapshot\""
+    echo "             time=\"$time\">"
 
     for i in "${!TEST_NAMES[@]}"; do
       local file="${TEST_FILES[$i]}"
@@ -70,7 +71,8 @@ function logger::generate_junit_xml() {
 
       echo "    <testcase file=\"$file\""
       echo "        name=\"$name\""
-      echo "        status=\"$status\" time=\"$test_time\">"
+      echo "        status=\"$status\""
+      echo "        time=\"$test_time\">"
       echo "    </testcase>"
     done
 


### PR DESCRIPTION
## 🔖 Changes

- move time attr to unique line
- simplify case in entrypoint reducing shifts

---

> shift is a bash built-in which kind of removes arguments from the beginning of the argument list. Given that the 3 arguments provided to the script are available in $1, $2, $3, then a call to shift will make $2 the new $1. A shift 2 will shift by two making new $1 the old $3.
> source: https://unix.stackexchange.com/a/174568