### PR TITLE
Add versioning to the webpage

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,14 +1,26 @@
-import { defineConfig } from 'vitepress'
+import { DefaultTheme } from "vitepress";
+import defineVersionedConfig from 'vitepress-versioning-plugin';
 import pkg from '../../package.json'
 
 // https://vitepress.dev/reference/site-config
-export default defineConfig({
+export default defineVersionedConfig({
   title: 'bashunit - A simple testing library for bash scripts',
   titleTemplate: 'bashunit',
   description: 'Test your bash scripts in the fastest and simplest way, discover the most modern bash testing library.',
   lang: 'en-US',
   cleanUrls: true,
   lastUpdated: true,
+
+  versioning: {
+    latestVersion: '0.14.0',
+    sidebars: {
+      sidebarContentProcessor(sidebar: DefaultTheme.SidebarMulti) {
+        console.log(sidebar);
+        return sidebar
+      },
+    },
+  },
+
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],
@@ -30,6 +42,12 @@ export default defineConfig({
   },
 
   themeConfig: {
+
+    versionSwitcher: {
+      // text: pkg.version + ' (latest)',
+      // includeLatestVersion: false,
+    },
+
     // https://vitepress.dev/reference/default-theme-config
     externalLinkIcon: true,
     siteTitle: false,
@@ -44,52 +62,52 @@ export default defineConfig({
       alt: 'bashunit'
     },
 
-    sidebar: {
-      '/': [{
-        text: 'Quickstart',
-        link: '/quickstart',
-      }, {
-        text: 'Installation',
-        link: '/installation',
-      }, {
-        text: 'Command line',
-        link: '/command-line'
-      }, {
-        text: 'Configuration',
-        link: '/configuration'
-      }, {
-        text: 'Test files',
-        link: '/test-files',
-      }, {
-        text: 'Parameterized tests',
-        link: '/parameterized-tests',
-      }, {
-        text: 'Test doubles',
-        link: '/test-doubles'
-      }, {
-        text: 'Assertions',
-        link: '/assertions'
-      }, {
-        text: 'Snapshots',
-        link: '/snapshots'
-      }, {
-        text: 'Skipping/incomplete',
-        link: '/skipping-incomplete'
-      }, {
-        text: 'Standalone',
-        link: '/standalone'
-      }, {
-        text: 'Custom asserts',
-        link: '/custom-asserts'
-      }, {
-        text: 'Examples',
-        link: '/examples'
-      }, {
-        text: 'Support',
-        link: '/support',
-      }],
-      '/blog/': []
-    },
+    // sidebar: {
+    //   '/': [{
+    //     text: 'Quickstart',
+    //     link: '/quickstart',
+    //   }, {
+    //     text: 'Installation',
+    //     link: '/installation',
+    //   }, {
+    //     text: 'Command line',
+    //     link: '/command-line'
+    //   }, {
+    //     text: 'Configuration',
+    //     link: '/configuration'
+    //   }, {
+    //     text: 'Test files',
+    //     link: '/test-files',
+    //   }, {
+    //     text: 'Parameterized tests',
+    //     link: '/parameterized-tests',
+    //   }, {
+    //     text: 'Test doubles',
+    //     link: '/test-doubles'
+    //   }, {
+    //     text: 'Assertions',
+    //     link: '/assertions'
+    //   }, {
+    //     text: 'Snapshots',
+    //     link: '/snapshots'
+    //   }, {
+    //     text: 'Skipping/incomplete',
+    //     link: '/skipping-incomplete'
+    //   }, {
+    //     text: 'Standalone',
+    //     link: '/standalone'
+    //   }, {
+    //     text: 'Custom asserts',
+    //     link: '/custom-asserts'
+    //   }, {
+    //     text: 'Examples',
+    //     link: '/examples'
+    //   }, {
+    //     text: 'Support',
+    //     link: '/support',
+    //   }],
+    //   '/blog/': []
+    // },
 
     socialLinks: [
       { icon: 'x', link: 'https://x.com/bashunit' },
@@ -137,4 +155,4 @@ export default defineConfig({
   srcExclude: [
     'blog/0000-00-00-template.md'
   ]
-})
+}, __dirname)

--- a/docs/.vitepress/navbars/versioned/0.10.0.json
+++ b/docs/.vitepress/navbars/versioned/0.10.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.10.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.10.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.10.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.10.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.10.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.10.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.10.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.10.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.10.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.10.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.10.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.10.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.10.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.10.0/support"
+  }
+]

--- a/docs/.vitepress/navbars/versioned/0.11.0.json
+++ b/docs/.vitepress/navbars/versioned/0.11.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.11.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.11.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.11.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.11.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.11.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.11.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.11.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.11.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.11.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.11.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.11.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.11.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.11.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.11.0/support"
+  }
+]

--- a/docs/.vitepress/navbars/versioned/0.12.0.json
+++ b/docs/.vitepress/navbars/versioned/0.12.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.12.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.12.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.12.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.12.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.12.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.12.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.12.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.12.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.12.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.12.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.12.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.12.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.12.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.12.0/support"
+  }
+]

--- a/docs/.vitepress/navbars/versioned/0.13.0.json
+++ b/docs/.vitepress/navbars/versioned/0.13.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.13.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.13.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.13.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.13.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.13.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.13.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.13.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.13.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.13.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.13.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.13.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.13.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.13.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.13.0/support"
+  }
+]

--- a/docs/.vitepress/sidebars/versioned/0.10.0.json
+++ b/docs/.vitepress/sidebars/versioned/0.10.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.10.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.10.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.10.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.10.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.10.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.10.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.10.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.10.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.10.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.10.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.10.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.10.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.10.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.10.0/support"
+  }
+]

--- a/docs/.vitepress/sidebars/versioned/0.11.0.json
+++ b/docs/.vitepress/sidebars/versioned/0.11.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.11.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.11.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.11.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.11.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.11.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.11.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.11.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.11.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.11.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.11.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.11.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.11.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.11.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.11.0/support"
+  }
+]

--- a/docs/.vitepress/sidebars/versioned/0.12.0.json
+++ b/docs/.vitepress/sidebars/versioned/0.12.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.12.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.12.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.12.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.12.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.12.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.12.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.12.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.12.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.12.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.12.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.12.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.12.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.12.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.12.0/support"
+  }
+]

--- a/docs/.vitepress/sidebars/versioned/0.13.0.json
+++ b/docs/.vitepress/sidebars/versioned/0.13.0.json
@@ -1,0 +1,58 @@
+[
+  {
+    "text": "Quickstart",
+    "link": "/0.13.0/quickstart"
+  },
+  {
+    "text": "Installation",
+    "link": "/0.13.0/installation"
+  },
+  {
+    "text": "Command line",
+    "link": "/0.13.0/command-line"
+  },
+  {
+    "text": "Configuration",
+    "link": "/0.13.0/configuration"
+  },
+  {
+    "text": "Test files",
+    "link": "/0.13.0/test-files"
+  },
+  {
+    "text": "Parameterized tests",
+    "link": "/0.13.0/parameterized-tests"
+  },
+  {
+    "text": "Test doubles",
+    "link": "/0.13.0/test-doubles"
+  },
+  {
+    "text": "Assertions",
+    "link": "/0.13.0/assertions"
+  },
+  {
+    "text": "Snapshots",
+    "link": "/0.13.0/snapshots"
+  },
+  {
+    "text": "Skipping/incomplete",
+    "link": "/0.13.0/skipping-incomplete"
+  },
+  {
+    "text": "Standalone",
+    "link": "/0.13.0/standalone"
+  },
+  {
+    "text": "Custom asserts",
+    "link": "/0.13.0/custom-asserts"
+  },
+  {
+    "text": "Examples",
+    "link": "/0.13.0/examples"
+  },
+  {
+    "text": "Support",
+    "link": "/0.13.0/support"
+  }
+]

--- a/docs/versions/0.10.0/ProductHuntBanner.vue
+++ b/docs/versions/0.10.0/ProductHuntBanner.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="product-hunt-banner__container">
+    <a
+      href="https://www.producthunt.com/posts/bashunit?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-bashunit"
+      target="_blank"
+      rel="noreferrer"
+      title="bashunit - Product Hunt"
+    >
+      <img
+        class="product-hunt-banner__logo--light"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=light"
+        alt="Product Hunt"
+      />
+      <img
+        class="product-hunt-banner__logo--dark"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=dark"
+        alt="Product Hunt"
+      />
+    </a>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style>
+.product-hunt-banner__container {
+  text-align: center;
+  margin-top: 4rem;
+}
+
+.product-hunt-banner__logo--light{
+    display: inline-block;
+}
+
+.product-hunt-banner__logo--dark{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--light{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--dark{
+    display: inline-block;
+}
+</style>

--- a/docs/versions/0.10.0/assertions.md
+++ b/docs/versions/0.10.0/assertions.md
@@ -1,0 +1,900 @@
+# Assertions
+
+When creating tests, you'll need to verify your commands and functions.
+We provide assertions for these checks.
+Below is their documentation.
+
+## assert_equals
+> `assert_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal.
+
+[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals "foo" "foo"
+}
+
+function test_failure() {
+  assert_equals "foo" "bar"
+}
+```
+:::
+
+## assert_equals_ignore_colors
+> `assert_equals_ignore_colors "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals_ignore_colors "foo" "\e[31mfoo"
+}
+
+function test_failure() {
+  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
+}
+```
+:::
+
+## assert_contains
+> `assert_contains "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+
+[assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains "foo" "foobar"
+}
+
+function test_failure() {
+  assert_contains "baz" "foobar"
+}
+```
+
+:::
+
+## assert_contains_ignore_case
+> `assert_contains_ignore_case "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+Differences in casing are ignored when needle is searched for in haystack.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains_ignore_case "foo" "FooBar"
+}
+function test_failure() {
+  assert_contains_ignore_case "baz" "FooBar"
+}
+```
+:::
+
+## assert_empty
+> `assert_empty "actual"`
+
+Reports an error if `actual` is not empty.
+
+[assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_empty ""
+}
+
+function test_failure() {
+  assert_empty "foo"
+}
+```
+:::
+
+## assert_matches
+> `assert_matches "pattern" "value"`
+
+Reports an error if `value` does not match the regular expression `pattern`.
+
+[assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_matches "^foo" "foobar"
+}
+
+function test_failure() {
+  assert_matches "^bar" "foobar"
+}
+```
+:::
+
+## assert_string_starts_with
+> `assert_string_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does not starts with `needle`.
+
+[assert_string_not_starts_with](#assert-string-not-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_starts_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_starts_with "baz" "foobar"
+}
+```
+:::
+
+## assert_string_ends_with
+> `assert_string_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does not ends with `needle`.
+
+[assert_string_not_ends_with](#assert-string-not-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_ends_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_ends_with "foo" "foobar"
+}
+```
+:::
+
+## assert_line_count
+> `assert_line_count "count" "haystack"`
+
+Reports an error if `haystack` does not contain `count` lines.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local string="this is line one
+this is line two
+this is line three"
+
+  assert_line_count 3 "$string"
+}
+
+function test_failure() {
+  assert_line_count 2 "foobar"
+}
+```
+:::
+
+## assert_less_than
+> `assert_less_than "expected" "actual"`
+
+Reports an error if `actual` is not less than `expected`.
+
+[assert_greater_than](#assert-greater-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_than "999" "1"
+}
+
+function test_failure() {
+  assert_less_than "1" "999"
+}
+```
+:::
+
+## assert_less_or_equal_than
+> `assert_less_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not less than or equal to `expected`.
+
+[assert_greater_than](#assert-greater-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_or_equal_than "999" "1"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_less_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_less_or_equal_than "1" "999"
+}
+```
+:::
+
+## assert_greater_than
+> `assert_greater_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than `expected`.
+
+[assert_less_than](#assert-less-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_than "1" "999"
+}
+
+function test_failure() {
+  assert_greater_than "999" "1"
+}
+```
+:::
+
+## assert_greater_or_equal_than
+> `assert_greater_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than or equal to `expected`.
+
+[assert_less_or_equal_than](#assert-less-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_or_equal_than "1" "999"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_greater_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_greater_or_equal_than "999" "1"
+}
+```
+:::
+
+## assert_exit_code
+> `assert_exit_code "expected" ["callable"]`
+
+Reports an error if the exit code of `callable` is not equal to `expected`.
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
+are more semantic versions of this assertion, for which you don't need to specify an exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "1" "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_exit_code "1"
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "0" "$(foo)"
+}
+```
+:::
+
+## assert_array_contains
+> `assert_array_contains "needle" "haystack"`
+
+Reports an error if `needle` is not an element of `haystack`.
+
+[assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "bar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "foobar" "${haystack[@]}"
+}
+```
+:::
+
+## assert_successful_code
+> `assert_successful_code ["callable"]`
+
+Reports an error if the exit code of `callable` is not successful (`0`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 0
+  }
+
+  assert_successful_code "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 0
+  }
+
+  foo # function took instead `callable`
+
+  assert_successful_code
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_successful_code "$(foo)"
+}
+```
+:::
+
+## assert_general_error
+> `assert_general_error ["callable"]`
+
+Reports an error if the exit code of `callable` is not a general error (`1`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_general_error "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_general_error
+}
+
+function test_failure() {
+  function foo() {
+    return 0
+  }
+
+  assert_general_error "$(foo)"
+}
+```
+:::
+
+## assert_command_not_found
+> `assert_general_error ["callable"]`
+
+Reports an error if `callable` exists.
+In other words, if executing `callable` does not return a command not found exit code (`127`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  assert_command_not_found "$(foo > /dev/null 2>&1)"
+}
+
+function test_success_without_callable() {
+  foo > /dev/null 2>&1
+
+  assert_command_not_found
+}
+
+function test_failure() {
+  assert_command_not_found "$(ls > /dev/null 2>&1)"
+}
+```
+:::
+
+## assert_file_exists
+> `assert_file_exists "file"`
+
+Reports an error if `file` does not exists, or it is a directory.
+
+[assert_file_not_exists](#assert-file-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_exists "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  rm -f $file_path
+
+  assert_file_exists "$file_path"
+}
+```
+:::
+
+## assert_is_file
+> `assert_is_file "file"`
+
+Reports an error if `file` is not a file.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local dir_path="bar"
+  mkdir "$dir_path"
+
+  assert_is_file "$dir_path"
+  rmdir "$dir_path"
+}
+```
+:::
+
+## assert_is_file_empty
+> `assert_is_file_empty "file"`
+
+Reports an error if `file` is not empty.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  echo "bar" > "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_exists
+> `assert_directory_exists "directory"`
+
+Reports an error if `directory` does not exist.
+
+[assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_directory_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory
+> `assert_is_directory "directory"`
+
+Reports an error if `directory` is not a directory.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory "$directory"
+}
+
+function test_failure() {
+  local file="/etc/hosts"
+
+  assert_is_directory "$file"
+}
+```
+:::
+
+## assert_is_directory_empty
+> `assert_is_directory_empty "directory"`
+
+Reports an error if `directory` is not an empty directory.
+
+[assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/etc"
+
+  assert_is_directory_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_readable
+> `assert_is_directory_readable "directory"`
+
+Reports an error if `directory` is not a readable directory.
+
+[assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_writable
+> `assert_is_directory_writable "directory"`
+
+Reports an error if `directory` is not a writable directory.
+
+[assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/tmp"
+
+  assert_is_directory_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_writable "$directory"
+}
+```
+:::
+
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal.
+
+[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
+## assert_not_contains
+> `assert_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is a substring of `haystack`.
+
+[assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_contains "baz" "foobar"
+}
+
+function test_failure() {
+  assert_not_contains "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_starts_with
+> `assert_string_not_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does starts with `needle`.
+
+[assert_string_starts_with](#assert-string-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_starts_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_starts_with "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_ends_with
+> `assert_string_not_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does ends with `needle`.
+
+[assert_string_ends_with](#assert-string-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_ends_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_ends_with "bar" "foobar"
+}
+```
+:::
+
+## assert_not_empty
+> `assert_not_empty "actual"`
+
+Reports an error if `actual` is empty.
+
+[assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_empty "foo"
+}
+
+function test_failure() {
+  assert_not_empty ""
+}
+```
+:::
+
+## assert_not_matches
+> `assert_not_matches "pattern" "value"`
+
+Reports an error if `value` matches the regular expression `pattern`.
+
+[assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_matches "foo$" "foobar"
+}
+
+function test_failure() {
+  assert_not_matches "bar$" "foobar"
+}
+```
+:::
+
+## assert_array_not_contains
+> `assert_array_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is an element of `haystack`.
+
+[assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "foobar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "baz" "${haystack[@]}"
+}
+```
+:::
+
+## assert_file_not_exists
+> `assert_file_not_exists "file"`
+
+Reports an error if `file` does exists.
+
+[assert_file_exists](#assert-file-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+  rm "$file_path"
+
+  assert_file_not_exists "$file_path"
+}
+
+function test_failed() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_not_exists "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_not_exists
+> `assert_directory_not_exists "directory"`
+
+Reports an error if `directory` exists.
+
+[assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_not_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_directory_not_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_empty
+> `assert_is_directory_not_empty "directory"`
+
+Reports an error if `directory` is empty.
+
+[assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/etc"
+
+  assert_is_directory_not_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_not_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_readable
+> `assert_is_directory_not_readable "directory"`
+
+Reports an error if `directory` is readable.
+
+[assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_not_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_is_directory_not_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_writable
+> `assert_is_directory_not_writable "directory"`
+
+Reports an error if `directory` is writable.
+
+[assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_not_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/tmp"
+
+  assert_is_directory_not_writable "$directory"
+}
+```
+:::
+
+## fail
+> `fail "failure message"`
+
+Unambiguously reports an error message. Useful for reporting specific message
+when testing situations not covered by any `assert_*` functions.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  if [ "$(date +%-H)" -gt 25 ]; then
+    fail "Something is very wrong with your clock"
+  fi
+}
+function test_failure() {
+  if [ "$(date +%-H)" -lt 25 ]; then
+    fail "This test will always fail"
+  fi
+}
+```
+:::

--- a/docs/versions/0.10.0/command-line.md
+++ b/docs/versions/0.10.0/command-line.md
@@ -1,0 +1,218 @@
+# Command line
+
+**bashunit** command accepts options to control its behavior. These options will override the environment [configuration](/configuration), which you can use to make the change permanent.
+
+## Directory or file
+
+> `bashunit "directory|file"`
+
+Specifies the `directory` or `file` containing the tests to be run.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+You can use `DEFAULT_PATH` option in your [configuration](/configuration#default-path)
+to choose where the tests are located by default.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+./bashunit ./tests
+
+# concrete test by full path
+./bashunit ./tests/example_test.sh
+
+# all test matching given wildcard
+./bashunit ./tests/**/*_test.sh
+```
+:::
+
+## Assert
+
+> `bashunit -a|--assert function "arg1" "arg2"`
+
+Run a core assert function standalone without a test context. Read more: [Standalone](/standalone)
+
+::: code-group
+```bash [Example]
+./bashunit --assert equals "foo" "bar"
+```
+```[Output]
+✗ Failed: Main::exec assert
+    Expected 'foo'
+    but got 'bar'
+```
+:::
+
+## Debug
+
+> `bashunit --debug`
+
+Enables a shell mode in which all executed commands are printed to the terminal. Printing every command as executed may help you visualize the script's control flow if it is not working as expected.
+
+::: code-group
+```bash [Example]
+./bashunit --debug
+```
+:::
+
+## Environment
+
+> `bashunit -e|--env "file path"`
+
+Loads a custom env file overriding the `.env` environment variables.
+
+::: code-group
+```bash [Example]
+./bashunit tests --env .env.production
+```
+:::
+
+## Filter
+
+> `bashunit -f|--filter "test name"`
+
+Filters the tests to be run based on the `test name`.
+
+::: code-group
+```bash [Example]
+# run all test functions including "something" in it's name
+./bashunit ./tests --filter "something"
+```
+:::
+
+## Logging
+
+> `bashunit -l|--log-junit <out.xml>`
+
+Creates a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --log-junit log-junit.xml
+```
+:::
+
+## Report
+
+> `bashunit -r|--report-html <out.html>`
+
+Creates a report HTML file that contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --report-html report.html
+```
+:::
+
+## Output
+
+> `bashunit -s|--simple`
+>
+> `bashunit -v|--verbose`
+
+Enables simplified or verbose output to the console.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+This command flag will always take precedence over the environment configuration.
+
+You can use `SIMPLE_OUTPUT` option in your [configuration](/configuration#output)
+to choose the default output display.
+
+::: code-group
+```[Output]
+........
+```
+```bash [Example]
+./bashunit ./tests --simple
+```
+:::
+
+::: code-group
+```[Output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+✓ Passed: Text should contain
+✓ Passed: Text should match a regular expression
+✓ Passed: Text should not contain
+✓ Passed: Text should not match a regular expression
+```
+```bash [Example]
+./bashunit ./tests --verbose
+```
+:::
+
+## Stop on failure
+
+> `bashunit -S|--stop-on-failure`
+
+Force to stop the runner right after encountering one failing test.
+
+You can use `STOP_ON_FAILURE` option in your [configuration](/configuration#stop-on-failure)
+to make this behavior permanent.
+
+::: code-group
+```bash [Example]
+./bashunit --stop-on-failure
+```
+:::
+
+## Version
+
+> `bashunit --version`
+
+Displays the current version of **bashunit**.
+
+::: code-group
+```-vue [Output]
+bashunit - {{ pkg.version }}
+```
+```bash [Example]
+./bashunit --version
+```
+:::
+
+## Upgrade
+
+> `bashunit --upgrade`
+
+Upgrade **bashunit** to latest version.
+
+::: code-group
+```bash [Example]
+./bashunit --upgrade
+```
+:::
+
+## Help
+
+> `bashunit --help`
+
+Displays a help message with all allowed arguments and options.
+
+::: code-group
+```[Output]
+bashunit [arguments] [options]
+
+Arguments:
+  Specifies the directory or file containing [...]
+
+Options:
+  -f|--filter
+    Filters the tests to run based on the test name.
+
+  [...]
+```
+```bash [Example]
+./bashunit --help
+```
+:::
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.10.0/configuration.md
+++ b/docs/versions/0.10.0/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+Environment configuration to control **bashunit** behavior.
+
+It serves to configure the behavior of bashunit in your project.
+You need to create a `.env` file in the root directory,
+but you can give it another name if you pass it as an argument to the command with
+`--env` [option](/command-line#environment).
+
+## Default path
+
+> `DEFAULT_PATH=directory|file`
+
+Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+DEFAULT_PATH=tests
+
+# concrete test by full path
+DEFAULT_PATH=tests/example_test.sh
+
+# all test matching given wildcard
+DEFAULT_PATH=tests/**/*_test.sh
+```
+:::
+
+## Output
+
+> `SIMPLE_OUTPUT=true|false`
+
+Enables simplified output to the console. `false` by default.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+Similar as using `-s|--simple|-v|--verbose` option on the [command line](/command-line#output).
+
+::: code-group
+```bash [Simple output]
+....
+```
+```bash [.env]
+SIMPLE_OUTPUT=true
+```
+:::
+
+::: code-group
+```[Verbose output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+```
+```bash [.env]
+SIMPLE_OUTPUT=false
+```
+:::
+
+## Stop on failure
+
+> `STOP_ON_FAILURE=true|false`
+
+Force to stop the runner right after encountering one failing test. `false` by default.
+
+Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#stop-on-failure).
+
+## Show header
+
+> `SHOW_HEADER=true|false`
+>
+> `HEADER_ASCII_ART=true|false`
+
+Specify if you want to show the bashunit header. `true` by default.
+
+Additionally, you can use the env-var `HEADER_ASCII_ART` to display bashunit in ASCII. `false` by default.
+
+::: code-group
+``` [Without header]
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=false
+```
+:::
+
+::: code-group
+```-vue [Plain header]
+bashunit - {{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+```
+:::
+
+::: code-group
+```-vue [ASCII header]
+__               _                   _    // [!code hl]
+| |__   __ _ ___| |__  __ __ ____ (_) |_  // [!code hl]
+| '_ \ / _' / __| '_ \| | | | '_ \| | __| // [!code hl]
+| |_) | (_| \__ \ | | | |_| | | | | | |_  // [!code hl]
+|_.__/ \__,_|___/_| |_|\___/|_| |_|_|\__| // [!code hl]
+{{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+HEADER_ASCII_ART=true
+```
+:::
+
+## Show execution time
+
+> `SHOW_EXECUTION_TIME=true|false`
+
+Specify if you want to display the execution time after running **bashunit**. `true` by default.
+
+::: warning
+This feature is not available on macOS.
+:::
+
+::: code-group
+```-vue [With execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+Time taken: 14 ms  // [!code hl]
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=true
+```
+:::
+
+::: code-group
+```[Without execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=false
+```
+:::
+
+## Log JUnit
+
+> `LOG_JUNIT=log-junit.xml`
+
+Create a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+## Report HTML
+
+> `REPORT_HTML=report.html`
+
+Create a report HTML file that contains information about the test results of your bashunit tests.
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.10.0/custom-asserts.md
+++ b/docs/versions/0.10.0/custom-asserts.md
@@ -1,0 +1,34 @@
+# Custom asserts
+
+**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+
+:::tip
+Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
+:::
+
+## assertion_failed
+> `bashunit::assertion_failed <expected> <actual> <failure_condition_message?>`
+
+## assertion_passed
+> `bashunit::assertion_passed`
+
+## Example
+
+```bash
+# Your custom assert using the bashunit facade
+function assert_foo() {
+  local actual="$1"
+
+  if [[ "foo" != "$actual" ]]; then
+    bashunit::assertion_failed "foo" "$actual"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+# Your test using your custom assert
+function test_assert_foo_passed() {
+  assert_foo "foo"
+}
+```

--- a/docs/versions/0.10.0/examples.md
+++ b/docs/versions/0.10.0/examples.md
@@ -1,0 +1,28 @@
+# Examples
+
+## Demo example
+
+**bashunit** includes a sample script and its associated test file in the examples folder of its repository.
+In there, you'll find various tests showcasing the file and different **bashunit** functionalities.
+
+[Take a look](https://github.com/TypedDevs/bashunit/tree/main/example).
+
+## Real examples
+
+If you're interested in real-world examples, below is a list of actual projects that use **bashunit** to test their Bash scripts.
+
+::: info
+If your project utilizes **bashunit**, you can add it to this list by submitting a pull request to us.
+:::
+
+### [TypedDevs/bashunit](https://github.com/TypedDevs/bashunit)
+**bashunit** uses itself to test the proper operation of each one of its features.
+
+### [Chemaclass/conventional-commits](https://github.com/Chemaclass/conventional-commits)
+A specification for adding human and machine-readable meaning to commit messages.
+
+### [Tito-Kati/fizzbuzz-bashunit](https://github.com/Tito-Kati/fizzbuzz-bashunit)
+Popular introductory FizzBuzz kata solved in Bash with **bashunit** as the testing framework.
+
+### [phpctl](https://github.com/opencodeco/phpctl)
+It is a Docker (containers) based development environment for PHP.

--- a/docs/versions/0.10.0/index.md
+++ b/docs/versions/0.10.0/index.md
@@ -1,0 +1,85 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: bashunit
+  text: v0.10.0
+  tagline: Test your bash scripts in the fastest and simplest way, discover the most modern bash testing library.
+  image:
+    src: /logo.svg
+    alt: bashunit
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /0.10.0/quickstart
+    - theme: alt
+      text: Assertions
+      link: /0.10.0/assertions
+    - theme: alt
+      text: Blog
+      link: /blog/
+
+features:
+  - icon:
+      src: /flexible.svg
+    title: Flexible
+    details: Robust assertions for comparing, matching, and validating results, ensuring thorough testing of your codebase.
+  - icon:
+      src: /accessible.svg
+    title: Accessible
+    details: An intuitive API and clear documentation for a smooth developer experience, reducing testing complexity.
+  - icon:
+      src: /updated.svg
+    title: Updated
+    details: A vibrant GitHub community for support, collaboration, and continuous library enhancement. Join forces with like-minded developers.
+  - icon:
+      src: /multiplatform.svg
+    title: Multiplatform
+    details: Seamlessly operates on Linux, macOS, and Windows (via WSL), facilitating a consistent testing environment across major platforms.
+---
+
+<ProductHuntBanner />
+
+<h2 class="home__award-title">Honors & Awards</h2>
+
+<div class="home__award-container">
+  <a
+    href="https://twitter.com/getmanfred/status/1737191954289487900"
+    target="_blank"
+  >
+    <img
+      src="/awards/manfred-2023.jpg"
+      alt="The Manfred Awards 2023 - bashunit - Side Project of the Year"
+    />
+  </a>
+</div>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import VanillaTilt from 'vanilla-tilt';
+import ProductHuntBanner from "./ProductHuntBanner.vue";
+
+onMounted(() => {
+  const heroImage = document.querySelector('.VPHero .VPImage');
+
+  VanillaTilt.init(heroImage, {
+    'full-page-listening': true,
+    reverse: true,
+    gyroscope: false
+  });
+});
+</script>
+
+<style scoped>
+.home__award-title {
+  text-align: center;
+  margin: 4rem 0;
+  font-size: 2.75rem;
+}
+
+.home__award-container {
+  display: grid;
+  justify-content: center;
+}
+</style>

--- a/docs/versions/0.10.0/installation.md
+++ b/docs/versions/0.10.0/installation.md
@@ -1,0 +1,100 @@
+# Installation
+
+Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
+you can add **bashunit** as a dependency in your repository according to your preferences.
+
+Here, we provide different options that you can use to install **bashunit** in your application.
+
+## install.sh
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+#### Verify
+
+```bash-vue
+# Verify the sha256sum for latest stable: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}"; FILE="$DIR/bashunit"; [ "$(shasum -a 256 "$FILE" | awk '{ print $1 }')" = "$KNOWN_HASH" ] && echo -e "✓ \033[1mbashunit\033[0m verified." || { echo -e "✗ \033[1mbashunit\033[0m corrupt"; rm "$FILE"; }
+```
+
+:::tip
+You can find the checksum for each version inside [GitHub's releases](https://github.com/TypedDevs/bashunit/releases). E.g.:
+```-vue
+https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checksum
+```
+:::
+
+#### Define custom tag and folder
+
+The installation script can receive two optional arguments:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
+```
+- `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default
+
+::: tip
+You can use `beta` as `[version]` to get the next non-stable preview release.
+We try to keep it stable, but there is no promise that we won't change functions or their signatures without prior notice.
+:::
+
+::: tip
+Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
+:::
+
+## GitHub Actions
+
+```yaml
+# example: .github/workflows/bashunit-tests.yml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install bashunit"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh"
+
+      - name: "Test"
+        run: "./bashunit tests/**/*_test.sh"
+```
+
+::: tip
+Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+:::
+
+## Brew
+
+You can install **bashunit** globally in your macOS (or Linux) using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.10.0/parameterized-tests.md
+++ b/docs/versions/0.10.0/parameterized-tests.md
@@ -1,0 +1,101 @@
+# Parameterized tests
+
+**bashunit** offers two ways to parameterize your test functions:
+- **Multi-invokers**: are the most flexible option, as they allow passing multiple arguments to the test function and permit arguments containing whitespace.
+- **Data providers**: offer a simple alternative for cases when the test function needs to accept only a single word as an argument.
+
+---
+
+Both of these are specified using a special comment before the test function declaration. The comment specifies the name of a separate auxiliary bash function which **bashunit** will invoke prior to the test. This auxiliary function will determine how many times the test function will be invoked, and what arguments will be passed to the test function each time.
+
+The benefit of this is that each of these invocations is a full test itself, and can succeed or fail independently of the other tests. Also, [set_up](/test-files#set-up-function) and [tear_down](/test-files#tear-down-function) are called before and after each invocation of the test function. Using these tools can often result in less code repetition in your test files, and a clearer way to develop a suite of closely related tests quickly.
+
+:::tip
+The same multi-invoker or data provider function can be specified for multiple tests. This allows developing tests for related tools quickly. For example, if you had a tool that creates directories and another which removes directories, you could write one test for each tool and parameterize them to operate on the same set of directories.
+:::
+
+### Multi-invokers
+
+A multi-invoker function is specified as follows:
+
+::: code-group
+```bash [Example]
+# multi_invoker invoker_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The invoker function should call the special function `run_test`, passing any arbitrary arguments to that function. **bashunit** will invoke the original test function each time `run_test` is called, passing the corresponding arguments.
+
+::: code-group
+```bash [Example]
+function invoker_with_args() {
+  run_test arg1 arg2
+  run_test "arg1 with spaces" "arg2 with more spaces" "and even arg3"
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  command_we_want_to_test "$@"
+
+  assert_exit_code "0"
+}
+```
+:::
+
+In this example, the `invoker_with_args` will be executed instead of invoking `test_command_with_args` directly. Each time `invoker_with_args` calls `run_test` with some arguments, **bashunit** will call the original test function with those arguments. In this case the test simply verifies that `command_we_want_to_test` can accept these arguments without raising an error, but it could also verify other behaviors of the command. In this next example, we test that a `mkdir_command` we are developing can create a new directory with specified octal permissions.
+
+::: code-group
+```bash [Example]
+function invoker_for_mkdir() {
+  run_test /tmp/dirA 755
+  run_test "/tmp/private dir" 700
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  local directory="$1"
+  local perms="$2"
+
+  assert_directory_not_exists "$directory"
+  mkdir_command "${directory}" --perms "${perms}"
+  assert_directory_exists "$directory"
+  assert_equals "$perm" "$(stat --format %a "$directory")
+}
+```
+:::
+
+### Data providers
+
+A data provider function is specified as follows:
+
+::: code-group
+```bash [Example]
+# data_provider provider_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The provider function can return a space-separated list of values like `one two three` or a single value `one`. In case of a list of values, the test function will be invoked multiple times, each time being passed a different value from the list.
+
+::: code-group
+```bash [Example]
+function provider_directories() {
+  local directories=("/usr" "/etc" "/var")
+  echo "${directories[@]}"
+}
+
+# data_provider provider_directories
+function test_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of simple strings provided by this function, and the test function will be executed passing each time the current iteration value as the first argument.

--- a/docs/versions/0.10.0/quickstart.md
+++ b/docs/versions/0.10.0/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+**bashunit** is a dedicated testing tool crafted specifically for Bash scripts. It empowers you with tests on your Bash codebase, ensuring that your scripts operate reliably and as intended.
+
+With an intuitive API and documentation, it streamlines the process for developers to implement and manage tests. This is beneficial regardless of the project's size or intricacy in Bash.
+
+Thanks to **bashunit**, verifying and validating your Bash code has never been so easy.
+
+## Installation
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+See more about [installation](/installation).
+
+## Usage
+
+Once **bashunit** is installed, you're ready to get started.
+
+1.  First, create a folder to place your tests:
+    ```bash
+    mkdir tests
+    ```
+
+2.  Next, create your first test file named `example_test.sh` within this folder:
+    ::: code-group
+    ```bash [tests/example_test.sh]
+    #!/bin/bash
+
+    function test_bashunit_is_working() {
+      assert_equals "bashunit is working" "bashunit is working"
+    }
+    ```
+    :::
+
+3.  Finally, run the **bashunit** executable:
+    ```bash
+    ./lib/bashunit ./tests
+    ```
+
+4.  If everything works correctly, you should see an output similar to the following:
+    ```
+    Running tests/example_test.sh
+    ✓ Passed: Bashunit is working
+
+    Tests:      1 passed, 1 total
+    Assertions: 1 passed, 1 total
+    All tests passed
+    Time taken: 100 ms
+    ```
+
+5.  Now you can start testing the functionalities of your own Bash scripts.
+
+## Next steps
+
+Dive deeper into the documentation to discover the options provided by [test files](/test-files),
+[parameterized tests](/parameterized-tests), [test doubles](test-doubles) and [assertions](assertions),
+among many other features.

--- a/docs/versions/0.10.0/skipping-incomplete.md
+++ b/docs/versions/0.10.0/skipping-incomplete.md
@@ -1,0 +1,77 @@
+# Skipping and incomplete tests
+
+There may be various scenarios where the "passed" and "failed" outcomes for a test are not sufficient.
+To address these situations, the following functions are available for your use.
+
+## skip
+> `skip "[reason]"`
+
+Not all tests can be run in every environment; when such situations arise, you can mark a test as skipped.
+
+It reports that the test has been skipped, including the `[reason]` if one was specified.
+
+Skipping tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were skipped in the final output.
+
+::: code-group
+```bash [Example]
+function test_skipped() {
+  if [[ $OS != "GEOS" ]]; then
+    skip
+    return
+  fi
+
+  assert_empty "not reached"
+}
+
+function test_skipped_with_reason() {
+  if [[ $OS != "GEOS" ]]; then
+    skip "Not running under Commodore"
+    return
+  fi
+
+  assert_empty "not reached"
+}
+```
+```[Output]
+↷ Skipped: Skipped
+↷ Skipped: Skipped with reason
+    Not running under Commodore
+
+Tests:      2 skipped, 2 total
+Assertions: 2 skipped, 2 total
+Some tests skipped
+```
+:::
+
+## todo
+> `todo "[pending]"`
+
+You may come up with a test that you'd like to implement later.
+Instead of leaving the test implementation empty —which would mark the test as complete— you can flag it as incomplete.
+
+Reports that the test is incomplete as it is under development, including any `[pending]` to do details if specified.
+
+Incomplete tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were incomplete in the final output.
+
+::: code-group
+```bash [Example]
+function test_incomplete() {
+  todo
+}
+
+function test_incomplete_with_pending_details() {
+  todo "Detailed description of what needs to be done"
+}
+```
+```[Output]
+✒ Incomplete: Incomplete
+✒ Incomplete: Incomplete with pending details
+    Detailed description of what needs to be done
+
+Tests:      2 incomplete, 2 total
+Assertions: 2 incomplete, 2 total
+Some tests incomplete
+```
+:::

--- a/docs/versions/0.10.0/snapshots.md
+++ b/docs/versions/0.10.0/snapshots.md
@@ -1,0 +1,54 @@
+# Snapshots
+
+Snapshot testing is valuable for verifying the output of commands or scripts over time.
+By capturing and comparing the "snapshot" of the output at different stages,
+you can easily spot unintended changes or regressions.
+This way, it helps maintain the expected behavior while modifications are being made,
+making the verification process more efficient and reliable.
+
+## assert_match_snapshot
+> `assert_match_snapshot "actual"`
+
+Reports an error if `actual` does not match the existing snapshot file associated with the current test function.
+If no such file exists, a new one is created with the provided value.
+
+::: tip
+You can update the snapshot by deleting it and running its test again.
+:::
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot "$(ls)"
+}
+
+function test_failure() {
+  assert_match_snapshot "$(date)"
+}
+```
+```[First run]
+Running snapshot_test.sh
+✎ Snapshot: Success
+✎ Snapshot: Failure
+
+Tests:      2 snapshot, 2 total
+Assertions: 2 snapshot, 2 total
+Some snapshots created
+```
+```[Subsequent runs]
+Running snapshot_test.sh
+✓ Passed: Success
+✗ Failed: Failure
+    Expected to match the snapshot
+    Mon Jul 27 [-13:37:46-]{+13:37:49+} UTC 1987
+
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
+Some tests failed
+```
+:::
+
+::: warning
+You need to run the tests for this example twice to see them work.
+The first time you run them, the snapshots will be generated and the second time they will be asserted.
+:::

--- a/docs/versions/0.10.0/standalone.md
+++ b/docs/versions/0.10.0/standalone.md
@@ -1,0 +1,45 @@
+# Standalone
+
+You can use all bashunit assertions outside any tests if you would like to use them in integration or end-to-end tests, for entire applications or executables.
+
+## Executing an assertion
+
+If you want to use the nice assertions syntax of bashunit - without the tests context/functions, but to end-to-end tests executables, you can use the `-a|--assert` option when running `./bashunit` and call the assertion directly from there.
+
+The return exit code will be:
+- `0` success assertion
+- `1` failed assertion
+- `127` non-existing function
+
+::: info
+The prefix `assert_` is optional.
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a equals "foo" "foo"
+```
+```[Output]
+# No output - exit code 0 (success)
+```
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_not_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a not_equals "foo" "foo"
+```
+```[Output]
+✗ Failed: Main::exec not_equals
+    Expected 'foo'
+    but got 'foo'
+```
+:::
+

--- a/docs/versions/0.10.0/support.md
+++ b/docs/versions/0.10.0/support.md
@@ -1,0 +1,17 @@
+# Support
+
+If you encounter any issues, require clarification, or wish to suggest improvements, the primary avenue for support is through [our GitHub repository's issue tracking system](https://github.com/TypedDevs/bashunit/issues).
+How to Get Support:
+
+1.  **Navigate to our Issues Page**:
+    Visit the issues section of our repository.
+2.  **Search for Existing Issues**:
+    Before creating a new issue, please search to ensure that your concern hasn't been addressed already.
+3.  **Create a New Issue**:
+    If your concern isn't previously reported, click on the 'New issue' button.
+    Please provide as much detail as possible, including error messages, steps to reproduce, and expected outcomes.
+4.  **Engage Constructively**:
+    When interacting on issues, please be respectful and constructive, understanding that the community aims to help and enhance the tool collaboratively.
+
+We value our community's feedback and aim to address all concerns in a timely and effective manner.
+Your active participation and constructive feedback play a pivotal role in the continuous improvement of **bashunit**.

--- a/docs/versions/0.10.0/test-doubles.md
+++ b/docs/versions/0.10.0/test-doubles.md
@@ -1,0 +1,133 @@
+# Test doubles
+
+When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
+
+## mock
+> `mock "function" "body"`
+
+Allows you to override the behavior of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  mock ps echo hello world
+
+  assert_equals "hello world" "$(ps)"
+}
+```
+:::
+
+> `mock "function" "output"`
+
+Allows you to override the output of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  function code() {
+    ps a | grep bash
+  }
+
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+}
+```
+:::
+
+## spy
+> `spy "function"`
+
+Overrides the original behavior of a callable to allow you to make various assertions about its calls.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called
+> `assert_have_been_called "spy"`
+
+Reports an error if `spy` is not called.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+
+  assert_have_been_called ps
+}
+
+function test_failure() {
+  spy ps
+
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called_with
+> `assert_have_been_called_with "expected" "spy"`
+
+Reports an error if `callable` is not called with `expected`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps bar foo
+
+  assert_have_been_called_with "foo bar" ps
+}
+```
+:::
+
+## assert_have_been_called_times
+> assert_have_been_called_times "expected" "spy"
+
+Reports an error if `spy` is not called exactly `expected` times.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 2 ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 1 ps
+}
+```
+:::

--- a/docs/versions/0.10.0/test-files.md
+++ b/docs/versions/0.10.0/test-files.md
@@ -1,0 +1,91 @@
+# Test files
+
+**bashunit** offers a range of features for test files.
+In this section, you'll find information about these features along with some helpful tips.
+
+## Test file names
+
+**bashunit** is flexible about how you name your test files.
+
+You can use a directory name, and bashunit will look for all files (ending with `test.sh`) recursively inside that directory, and execute them.
+
+If you're using wildcards for scanning your tests, keep in mind that the initial search can slow down if you don't filter the test files in the wildcard.
+
+To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh`).
+This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
+
+This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.
+
+## Test function names
+
+**bashunit** will search for and execute all test functions it finds within each test file.
+To distinguish test functions from auxiliary functions, the names must be prefixed with the word `test`.
+The function names are case-insensitive.
+Below are some example test function names that would work seamlessly:
+
+::: code-group
+```bash [Example]
+function test_should_validate_an_ok_exit_code() { ... }
+function testRenderAllTestsPassedWhenNotFailedTests { ... }
+test_getFunctionsToRun_with_filter_should_return_matching_functions() { ... }
+```
+:::
+
+::: tip
+You're free to use any of Bash's syntax options to define these functions.
+:::
+
+## `set_up` function
+
+The `set_up` auxiliary function is called, if it is present in the test file, before each test function in the test file is executed.
+This provides a hook to prepare the environment or set initial variables specific to each test case.
+For example, you might want to create temporary directories or files that your test will manipulate.
+
+::: code-group
+```bash [Example]
+function set_up() {
+  touch temp_file.txt
+}
+```
+:::
+
+## `tear_down` function
+
+The `tear_down` auxiliary function is called, if it is present in the test file, immediately after each test function in the test file is executed.
+This auxiliary function offers you a place to clean up any resources allocated or changes made during the `set_up` or test function itself.
+This helps to ensure that each test starts with a fresh state.
+
+::: code-group
+```bash [Example]
+function tear_down() {
+  rm temp_file.txt
+}
+```
+:::
+
+## `set_up_before_script` function
+
+The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
+This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
+
+::: code-group
+```bash [Example]
+function set_up_before_script() {
+  open_database_connection
+}
+```
+:::
+
+## `tear_down_after_script` function
+
+The `tear_down_after_script` auxiliary function is called, if it is present in the test file, only once when all the test functions in the test file have been executed.
+This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
+It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
+
+::: code-group
+```bash [Example]
+function tear_down_after_script() {
+  close_database_connection
+}
+```
+:::

--- a/docs/versions/0.11.0/ProductHuntBanner.vue
+++ b/docs/versions/0.11.0/ProductHuntBanner.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="product-hunt-banner__container">
+    <a
+      href="https://www.producthunt.com/posts/bashunit?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-bashunit"
+      target="_blank"
+      rel="noreferrer"
+      title="bashunit - Product Hunt"
+    >
+      <img
+        class="product-hunt-banner__logo--light"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=light"
+        alt="Product Hunt"
+      />
+      <img
+        class="product-hunt-banner__logo--dark"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=dark"
+        alt="Product Hunt"
+      />
+    </a>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style>
+.product-hunt-banner__container {
+  text-align: center;
+  margin-top: 4rem;
+}
+
+.product-hunt-banner__logo--light{
+    display: inline-block;
+}
+
+.product-hunt-banner__logo--dark{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--light{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--dark{
+    display: inline-block;
+}
+</style>

--- a/docs/versions/0.11.0/assertions.md
+++ b/docs/versions/0.11.0/assertions.md
@@ -1,0 +1,900 @@
+# Assertions
+
+When creating tests, you'll need to verify your commands and functions.
+We provide assertions for these checks.
+Below is their documentation.
+
+## assert_equals
+> `assert_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal.
+
+[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals "foo" "foo"
+}
+
+function test_failure() {
+  assert_equals "foo" "bar"
+}
+```
+:::
+
+## assert_equals_ignore_colors
+> `assert_equals_ignore_colors "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals_ignore_colors "foo" "\e[31mfoo"
+}
+
+function test_failure() {
+  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
+}
+```
+:::
+
+## assert_contains
+> `assert_contains "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+
+[assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains "foo" "foobar"
+}
+
+function test_failure() {
+  assert_contains "baz" "foobar"
+}
+```
+
+:::
+
+## assert_contains_ignore_case
+> `assert_contains_ignore_case "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+Differences in casing are ignored when needle is searched for in haystack.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains_ignore_case "foo" "FooBar"
+}
+function test_failure() {
+  assert_contains_ignore_case "baz" "FooBar"
+}
+```
+:::
+
+## assert_empty
+> `assert_empty "actual"`
+
+Reports an error if `actual` is not empty.
+
+[assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_empty ""
+}
+
+function test_failure() {
+  assert_empty "foo"
+}
+```
+:::
+
+## assert_matches
+> `assert_matches "pattern" "value"`
+
+Reports an error if `value` does not match the regular expression `pattern`.
+
+[assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_matches "^foo" "foobar"
+}
+
+function test_failure() {
+  assert_matches "^bar" "foobar"
+}
+```
+:::
+
+## assert_string_starts_with
+> `assert_string_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does not starts with `needle`.
+
+[assert_string_not_starts_with](#assert-string-not-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_starts_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_starts_with "baz" "foobar"
+}
+```
+:::
+
+## assert_string_ends_with
+> `assert_string_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does not ends with `needle`.
+
+[assert_string_not_ends_with](#assert-string-not-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_ends_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_ends_with "foo" "foobar"
+}
+```
+:::
+
+## assert_line_count
+> `assert_line_count "count" "haystack"`
+
+Reports an error if `haystack` does not contain `count` lines.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local string="this is line one
+this is line two
+this is line three"
+
+  assert_line_count 3 "$string"
+}
+
+function test_failure() {
+  assert_line_count 2 "foobar"
+}
+```
+:::
+
+## assert_less_than
+> `assert_less_than "expected" "actual"`
+
+Reports an error if `actual` is not less than `expected`.
+
+[assert_greater_than](#assert-greater-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_than "999" "1"
+}
+
+function test_failure() {
+  assert_less_than "1" "999"
+}
+```
+:::
+
+## assert_less_or_equal_than
+> `assert_less_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not less than or equal to `expected`.
+
+[assert_greater_than](#assert-greater-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_or_equal_than "999" "1"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_less_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_less_or_equal_than "1" "999"
+}
+```
+:::
+
+## assert_greater_than
+> `assert_greater_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than `expected`.
+
+[assert_less_than](#assert-less-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_than "1" "999"
+}
+
+function test_failure() {
+  assert_greater_than "999" "1"
+}
+```
+:::
+
+## assert_greater_or_equal_than
+> `assert_greater_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than or equal to `expected`.
+
+[assert_less_or_equal_than](#assert-less-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_or_equal_than "1" "999"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_greater_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_greater_or_equal_than "999" "1"
+}
+```
+:::
+
+## assert_exit_code
+> `assert_exit_code "expected" ["callable"]`
+
+Reports an error if the exit code of `callable` is not equal to `expected`.
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
+are more semantic versions of this assertion, for which you don't need to specify an exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "1" "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_exit_code "1"
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "0" "$(foo)"
+}
+```
+:::
+
+## assert_array_contains
+> `assert_array_contains "needle" "haystack"`
+
+Reports an error if `needle` is not an element of `haystack`.
+
+[assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "bar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "foobar" "${haystack[@]}"
+}
+```
+:::
+
+## assert_successful_code
+> `assert_successful_code ["callable"]`
+
+Reports an error if the exit code of `callable` is not successful (`0`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 0
+  }
+
+  assert_successful_code "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 0
+  }
+
+  foo # function took instead `callable`
+
+  assert_successful_code
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_successful_code "$(foo)"
+}
+```
+:::
+
+## assert_general_error
+> `assert_general_error ["callable"]`
+
+Reports an error if the exit code of `callable` is not a general error (`1`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_general_error "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_general_error
+}
+
+function test_failure() {
+  function foo() {
+    return 0
+  }
+
+  assert_general_error "$(foo)"
+}
+```
+:::
+
+## assert_command_not_found
+> `assert_general_error ["callable"]`
+
+Reports an error if `callable` exists.
+In other words, if executing `callable` does not return a command not found exit code (`127`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  assert_command_not_found "$(foo > /dev/null 2>&1)"
+}
+
+function test_success_without_callable() {
+  foo > /dev/null 2>&1
+
+  assert_command_not_found
+}
+
+function test_failure() {
+  assert_command_not_found "$(ls > /dev/null 2>&1)"
+}
+```
+:::
+
+## assert_file_exists
+> `assert_file_exists "file"`
+
+Reports an error if `file` does not exists, or it is a directory.
+
+[assert_file_not_exists](#assert-file-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_exists "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  rm -f $file_path
+
+  assert_file_exists "$file_path"
+}
+```
+:::
+
+## assert_is_file
+> `assert_is_file "file"`
+
+Reports an error if `file` is not a file.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local dir_path="bar"
+  mkdir "$dir_path"
+
+  assert_is_file "$dir_path"
+  rmdir "$dir_path"
+}
+```
+:::
+
+## assert_is_file_empty
+> `assert_is_file_empty "file"`
+
+Reports an error if `file` is not empty.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  echo "bar" > "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_exists
+> `assert_directory_exists "directory"`
+
+Reports an error if `directory` does not exist.
+
+[assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_directory_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory
+> `assert_is_directory "directory"`
+
+Reports an error if `directory` is not a directory.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory "$directory"
+}
+
+function test_failure() {
+  local file="/etc/hosts"
+
+  assert_is_directory "$file"
+}
+```
+:::
+
+## assert_is_directory_empty
+> `assert_is_directory_empty "directory"`
+
+Reports an error if `directory` is not an empty directory.
+
+[assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/etc"
+
+  assert_is_directory_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_readable
+> `assert_is_directory_readable "directory"`
+
+Reports an error if `directory` is not a readable directory.
+
+[assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_writable
+> `assert_is_directory_writable "directory"`
+
+Reports an error if `directory` is not a writable directory.
+
+[assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/tmp"
+
+  assert_is_directory_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_writable "$directory"
+}
+```
+:::
+
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal.
+
+[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
+## assert_not_contains
+> `assert_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is a substring of `haystack`.
+
+[assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_contains "baz" "foobar"
+}
+
+function test_failure() {
+  assert_not_contains "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_starts_with
+> `assert_string_not_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does starts with `needle`.
+
+[assert_string_starts_with](#assert-string-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_starts_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_starts_with "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_ends_with
+> `assert_string_not_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does ends with `needle`.
+
+[assert_string_ends_with](#assert-string-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_ends_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_ends_with "bar" "foobar"
+}
+```
+:::
+
+## assert_not_empty
+> `assert_not_empty "actual"`
+
+Reports an error if `actual` is empty.
+
+[assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_empty "foo"
+}
+
+function test_failure() {
+  assert_not_empty ""
+}
+```
+:::
+
+## assert_not_matches
+> `assert_not_matches "pattern" "value"`
+
+Reports an error if `value` matches the regular expression `pattern`.
+
+[assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_matches "foo$" "foobar"
+}
+
+function test_failure() {
+  assert_not_matches "bar$" "foobar"
+}
+```
+:::
+
+## assert_array_not_contains
+> `assert_array_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is an element of `haystack`.
+
+[assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "foobar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "baz" "${haystack[@]}"
+}
+```
+:::
+
+## assert_file_not_exists
+> `assert_file_not_exists "file"`
+
+Reports an error if `file` does exists.
+
+[assert_file_exists](#assert-file-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+  rm "$file_path"
+
+  assert_file_not_exists "$file_path"
+}
+
+function test_failed() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_not_exists "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_not_exists
+> `assert_directory_not_exists "directory"`
+
+Reports an error if `directory` exists.
+
+[assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_not_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_directory_not_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_empty
+> `assert_is_directory_not_empty "directory"`
+
+Reports an error if `directory` is empty.
+
+[assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/etc"
+
+  assert_is_directory_not_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_not_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_readable
+> `assert_is_directory_not_readable "directory"`
+
+Reports an error if `directory` is readable.
+
+[assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_not_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_is_directory_not_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_writable
+> `assert_is_directory_not_writable "directory"`
+
+Reports an error if `directory` is writable.
+
+[assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_not_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/tmp"
+
+  assert_is_directory_not_writable "$directory"
+}
+```
+:::
+
+## fail
+> `fail "failure message"`
+
+Unambiguously reports an error message. Useful for reporting specific message
+when testing situations not covered by any `assert_*` functions.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  if [ "$(date +%-H)" -gt 25 ]; then
+    fail "Something is very wrong with your clock"
+  fi
+}
+function test_failure() {
+  if [ "$(date +%-H)" -lt 25 ]; then
+    fail "This test will always fail"
+  fi
+}
+```
+:::

--- a/docs/versions/0.11.0/command-line.md
+++ b/docs/versions/0.11.0/command-line.md
@@ -1,0 +1,218 @@
+# Command line
+
+**bashunit** command accepts options to control its behavior. These options will override the environment [configuration](/configuration), which you can use to make the change permanent.
+
+## Directory or file
+
+> `bashunit "directory|file"`
+
+Specifies the `directory` or `file` containing the tests to be run.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+You can use `DEFAULT_PATH` option in your [configuration](/configuration#default-path)
+to choose where the tests are located by default.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+./bashunit ./tests
+
+# concrete test by full path
+./bashunit ./tests/example_test.sh
+
+# all test matching given wildcard
+./bashunit ./tests/**/*_test.sh
+```
+:::
+
+## Assert
+
+> `bashunit -a|--assert function "arg1" "arg2"`
+
+Run a core assert function standalone without a test context. Read more: [Standalone](/standalone)
+
+::: code-group
+```bash [Example]
+./bashunit --assert equals "foo" "bar"
+```
+```[Output]
+✗ Failed: Main::exec assert
+    Expected 'foo'
+    but got 'bar'
+```
+:::
+
+## Debug
+
+> `bashunit --debug`
+
+Enables a shell mode in which all executed commands are printed to the terminal. Printing every command as executed may help you visualize the script's control flow if it is not working as expected.
+
+::: code-group
+```bash [Example]
+./bashunit --debug
+```
+:::
+
+## Environment
+
+> `bashunit -e|--env "file path"`
+
+Loads a custom env file overriding the `.env` environment variables.
+
+::: code-group
+```bash [Example]
+./bashunit tests --env .env.production
+```
+:::
+
+## Filter
+
+> `bashunit -f|--filter "test name"`
+
+Filters the tests to be run based on the `test name`.
+
+::: code-group
+```bash [Example]
+# run all test functions including "something" in it's name
+./bashunit ./tests --filter "something"
+```
+:::
+
+## Logging
+
+> `bashunit -l|--log-junit <out.xml>`
+
+Creates a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --log-junit log-junit.xml
+```
+:::
+
+## Report
+
+> `bashunit -r|--report-html <out.html>`
+
+Creates a report HTML file that contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --report-html report.html
+```
+:::
+
+## Output
+
+> `bashunit -s|--simple`
+>
+> `bashunit -v|--verbose`
+
+Enables simplified or verbose output to the console.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+This command flag will always take precedence over the environment configuration.
+
+You can use `SIMPLE_OUTPUT` option in your [configuration](/configuration#output)
+to choose the default output display.
+
+::: code-group
+```[Output]
+........
+```
+```bash [Example]
+./bashunit ./tests --simple
+```
+:::
+
+::: code-group
+```[Output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+✓ Passed: Text should contain
+✓ Passed: Text should match a regular expression
+✓ Passed: Text should not contain
+✓ Passed: Text should not match a regular expression
+```
+```bash [Example]
+./bashunit ./tests --verbose
+```
+:::
+
+## Stop on failure
+
+> `bashunit -S|--stop-on-failure`
+
+Force to stop the runner right after encountering one failing test.
+
+You can use `STOP_ON_FAILURE` option in your [configuration](/configuration#stop-on-failure)
+to make this behavior permanent.
+
+::: code-group
+```bash [Example]
+./bashunit --stop-on-failure
+```
+:::
+
+## Version
+
+> `bashunit --version`
+
+Displays the current version of **bashunit**.
+
+::: code-group
+```-vue [Output]
+bashunit - {{ pkg.version }}
+```
+```bash [Example]
+./bashunit --version
+```
+:::
+
+## Upgrade
+
+> `bashunit --upgrade`
+
+Upgrade **bashunit** to latest version.
+
+::: code-group
+```bash [Example]
+./bashunit --upgrade
+```
+:::
+
+## Help
+
+> `bashunit --help`
+
+Displays a help message with all allowed arguments and options.
+
+::: code-group
+```[Output]
+bashunit [arguments] [options]
+
+Arguments:
+  Specifies the directory or file containing [...]
+
+Options:
+  -f|--filter
+    Filters the tests to run based on the test name.
+
+  [...]
+```
+```bash [Example]
+./bashunit --help
+```
+:::
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.11.0/configuration.md
+++ b/docs/versions/0.11.0/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+Environment configuration to control **bashunit** behavior.
+
+It serves to configure the behavior of bashunit in your project.
+You need to create a `.env` file in the root directory,
+but you can give it another name if you pass it as an argument to the command with
+`--env` [option](/command-line#environment).
+
+## Default path
+
+> `DEFAULT_PATH=directory|file`
+
+Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+DEFAULT_PATH=tests
+
+# concrete test by full path
+DEFAULT_PATH=tests/example_test.sh
+
+# all test matching given wildcard
+DEFAULT_PATH=tests/**/*_test.sh
+```
+:::
+
+## Output
+
+> `SIMPLE_OUTPUT=true|false`
+
+Enables simplified output to the console. `false` by default.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+Similar as using `-s|--simple|-v|--verbose` option on the [command line](/command-line#output).
+
+::: code-group
+```bash [Simple output]
+....
+```
+```bash [.env]
+SIMPLE_OUTPUT=true
+```
+:::
+
+::: code-group
+```[Verbose output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+```
+```bash [.env]
+SIMPLE_OUTPUT=false
+```
+:::
+
+## Stop on failure
+
+> `STOP_ON_FAILURE=true|false`
+
+Force to stop the runner right after encountering one failing test. `false` by default.
+
+Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#stop-on-failure).
+
+## Show header
+
+> `SHOW_HEADER=true|false`
+>
+> `HEADER_ASCII_ART=true|false`
+
+Specify if you want to show the bashunit header. `true` by default.
+
+Additionally, you can use the env-var `HEADER_ASCII_ART` to display bashunit in ASCII. `false` by default.
+
+::: code-group
+``` [Without header]
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=false
+```
+:::
+
+::: code-group
+```-vue [Plain header]
+bashunit - {{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+```
+:::
+
+::: code-group
+```-vue [ASCII header]
+__               _                   _    // [!code hl]
+| |__   __ _ ___| |__  __ __ ____ (_) |_  // [!code hl]
+| '_ \ / _' / __| '_ \| | | | '_ \| | __| // [!code hl]
+| |_) | (_| \__ \ | | | |_| | | | | | |_  // [!code hl]
+|_.__/ \__,_|___/_| |_|\___/|_| |_|_|\__| // [!code hl]
+{{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+HEADER_ASCII_ART=true
+```
+:::
+
+## Show execution time
+
+> `SHOW_EXECUTION_TIME=true|false`
+
+Specify if you want to display the execution time after running **bashunit**. `true` by default.
+
+::: warning
+This feature is not available on macOS.
+:::
+
+::: code-group
+```-vue [With execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+Time taken: 14 ms  // [!code hl]
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=true
+```
+:::
+
+::: code-group
+```[Without execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=false
+```
+:::
+
+## Log JUnit
+
+> `LOG_JUNIT=log-junit.xml`
+
+Create a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+## Report HTML
+
+> `REPORT_HTML=report.html`
+
+Create a report HTML file that contains information about the test results of your bashunit tests.
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.11.0/custom-asserts.md
+++ b/docs/versions/0.11.0/custom-asserts.md
@@ -1,0 +1,34 @@
+# Custom asserts
+
+**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+
+:::tip
+Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
+:::
+
+## assertion_failed
+> `bashunit::assertion_failed <expected> <actual> <failure_condition_message?>`
+
+## assertion_passed
+> `bashunit::assertion_passed`
+
+## Example
+
+```bash
+# Your custom assert using the bashunit facade
+function assert_foo() {
+  local actual="$1"
+
+  if [[ "foo" != "$actual" ]]; then
+    bashunit::assertion_failed "foo" "$actual"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+# Your test using your custom assert
+function test_assert_foo_passed() {
+  assert_foo "foo"
+}
+```

--- a/docs/versions/0.11.0/examples.md
+++ b/docs/versions/0.11.0/examples.md
@@ -1,0 +1,28 @@
+# Examples
+
+## Demo example
+
+**bashunit** includes a sample script and its associated test file in the examples folder of its repository.
+In there, you'll find various tests showcasing the file and different **bashunit** functionalities.
+
+[Take a look](https://github.com/TypedDevs/bashunit/tree/main/example).
+
+## Real examples
+
+If you're interested in real-world examples, below is a list of actual projects that use **bashunit** to test their Bash scripts.
+
+::: info
+If your project utilizes **bashunit**, you can add it to this list by submitting a pull request to us.
+:::
+
+### [TypedDevs/bashunit](https://github.com/TypedDevs/bashunit)
+**bashunit** uses itself to test the proper operation of each one of its features.
+
+### [Chemaclass/conventional-commits](https://github.com/Chemaclass/conventional-commits)
+A specification for adding human and machine-readable meaning to commit messages.
+
+### [Tito-Kati/fizzbuzz-bashunit](https://github.com/Tito-Kati/fizzbuzz-bashunit)
+Popular introductory FizzBuzz kata solved in Bash with **bashunit** as the testing framework.
+
+### [phpctl](https://github.com/opencodeco/phpctl)
+It is a Docker (containers) based development environment for PHP.

--- a/docs/versions/0.11.0/index.md
+++ b/docs/versions/0.11.0/index.md
@@ -1,0 +1,85 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: bashunit
+  text: v0.11.0
+  tagline: Test your bash scripts in the fastest and simplest way, discover the most modern bash testing library.
+  image:
+    src: /logo.svg
+    alt: bashunit
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /0.11.0/quickstart
+    - theme: alt
+      text: Assertions
+      link: /0.11.0/assertions
+    - theme: alt
+      text: Blog
+      link: /blog/
+
+features:
+  - icon:
+      src: /flexible.svg
+    title: Flexible
+    details: Robust assertions for comparing, matching, and validating results, ensuring thorough testing of your codebase.
+  - icon:
+      src: /accessible.svg
+    title: Accessible
+    details: An intuitive API and clear documentation for a smooth developer experience, reducing testing complexity.
+  - icon:
+      src: /updated.svg
+    title: Updated
+    details: A vibrant GitHub community for support, collaboration, and continuous library enhancement. Join forces with like-minded developers.
+  - icon:
+      src: /multiplatform.svg
+    title: Multiplatform
+    details: Seamlessly operates on Linux, macOS, and Windows (via WSL), facilitating a consistent testing environment across major platforms.
+---
+
+<ProductHuntBanner />
+
+<h2 class="home__award-title">Honors & Awards</h2>
+
+<div class="home__award-container">
+  <a
+    href="https://twitter.com/getmanfred/status/1737191954289487900"
+    target="_blank"
+  >
+    <img
+      src="/awards/manfred-2023.jpg"
+      alt="The Manfred Awards 2023 - bashunit - Side Project of the Year"
+    />
+  </a>
+</div>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import VanillaTilt from 'vanilla-tilt';
+import ProductHuntBanner from "./ProductHuntBanner.vue";
+
+onMounted(() => {
+  const heroImage = document.querySelector('.VPHero .VPImage');
+
+  VanillaTilt.init(heroImage, {
+    'full-page-listening': true,
+    reverse: true,
+    gyroscope: false
+  });
+});
+</script>
+
+<style scoped>
+.home__award-title {
+  text-align: center;
+  margin: 4rem 0;
+  font-size: 2.75rem;
+}
+
+.home__award-container {
+  display: grid;
+  justify-content: center;
+}
+</style>

--- a/docs/versions/0.11.0/installation.md
+++ b/docs/versions/0.11.0/installation.md
@@ -1,0 +1,100 @@
+# Installation
+
+Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
+you can add **bashunit** as a dependency in your repository according to your preferences.
+
+Here, we provide different options that you can use to install **bashunit** in your application.
+
+## install.sh
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+#### Verify
+
+```bash-vue
+# Verify the sha256sum for latest stable: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}"; FILE="$DIR/bashunit"; [ "$(shasum -a 256 "$FILE" | awk '{ print $1 }')" = "$KNOWN_HASH" ] && echo -e "✓ \033[1mbashunit\033[0m verified." || { echo -e "✗ \033[1mbashunit\033[0m corrupt"; rm "$FILE"; }
+```
+
+:::tip
+You can find the checksum for each version inside [GitHub's releases](https://github.com/TypedDevs/bashunit/releases). E.g.:
+```-vue
+https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checksum
+```
+:::
+
+#### Define custom tag and folder
+
+The installation script can receive two optional arguments:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
+```
+- `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default
+
+::: tip
+You can use `beta` as `[version]` to get the next non-stable preview release.
+We try to keep it stable, but there is no promise that we won't change functions or their signatures without prior notice.
+:::
+
+::: tip
+Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
+:::
+
+## GitHub Actions
+
+```yaml
+# example: .github/workflows/bashunit-tests.yml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install bashunit"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh"
+
+      - name: "Test"
+        run: "./bashunit tests/**/*_test.sh"
+```
+
+::: tip
+Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+:::
+
+## Brew
+
+You can install **bashunit** globally in your macOS (or Linux) using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.11.0/parameterized-tests.md
+++ b/docs/versions/0.11.0/parameterized-tests.md
@@ -1,0 +1,101 @@
+# Parameterized tests
+
+**bashunit** offers two ways to parameterize your test functions:
+- **Multi-invokers**: are the most flexible option, as they allow passing multiple arguments to the test function and permit arguments containing whitespace.
+- **Data providers**: offer a simple alternative for cases when the test function needs to accept only a single word as an argument.
+
+---
+
+Both of these are specified using a special comment before the test function declaration. The comment specifies the name of a separate auxiliary bash function which **bashunit** will invoke prior to the test. This auxiliary function will determine how many times the test function will be invoked, and what arguments will be passed to the test function each time.
+
+The benefit of this is that each of these invocations is a full test itself, and can succeed or fail independently of the other tests. Also, [set_up](/test-files#set-up-function) and [tear_down](/test-files#tear-down-function) are called before and after each invocation of the test function. Using these tools can often result in less code repetition in your test files, and a clearer way to develop a suite of closely related tests quickly.
+
+:::tip
+The same multi-invoker or data provider function can be specified for multiple tests. This allows developing tests for related tools quickly. For example, if you had a tool that creates directories and another which removes directories, you could write one test for each tool and parameterize them to operate on the same set of directories.
+:::
+
+### Multi-invokers
+
+A multi-invoker function is specified as follows:
+
+::: code-group
+```bash [Example]
+# multi_invoker invoker_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The invoker function should call the special function `run_test`, passing any arbitrary arguments to that function. **bashunit** will invoke the original test function each time `run_test` is called, passing the corresponding arguments.
+
+::: code-group
+```bash [Example]
+function invoker_with_args() {
+  run_test arg1 arg2
+  run_test "arg1 with spaces" "arg2 with more spaces" "and even arg3"
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  command_we_want_to_test "$@"
+
+  assert_exit_code "0"
+}
+```
+:::
+
+In this example, the `invoker_with_args` will be executed instead of invoking `test_command_with_args` directly. Each time `invoker_with_args` calls `run_test` with some arguments, **bashunit** will call the original test function with those arguments. In this case the test simply verifies that `command_we_want_to_test` can accept these arguments without raising an error, but it could also verify other behaviors of the command. In this next example, we test that a `mkdir_command` we are developing can create a new directory with specified octal permissions.
+
+::: code-group
+```bash [Example]
+function invoker_for_mkdir() {
+  run_test /tmp/dirA 755
+  run_test "/tmp/private dir" 700
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  local directory="$1"
+  local perms="$2"
+
+  assert_directory_not_exists "$directory"
+  mkdir_command "${directory}" --perms "${perms}"
+  assert_directory_exists "$directory"
+  assert_equals "$perm" "$(stat --format %a "$directory")
+}
+```
+:::
+
+### Data providers
+
+A data provider function is specified as follows:
+
+::: code-group
+```bash [Example]
+# data_provider provider_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The provider function can return a space-separated list of values like `one two three` or a single value `one`. In case of a list of values, the test function will be invoked multiple times, each time being passed a different value from the list.
+
+::: code-group
+```bash [Example]
+function provider_directories() {
+  local directories=("/usr" "/etc" "/var")
+  echo "${directories[@]}"
+}
+
+# data_provider provider_directories
+function test_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of simple strings provided by this function, and the test function will be executed passing each time the current iteration value as the first argument.

--- a/docs/versions/0.11.0/quickstart.md
+++ b/docs/versions/0.11.0/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+**bashunit** is a dedicated testing tool crafted specifically for Bash scripts. It empowers you with tests on your Bash codebase, ensuring that your scripts operate reliably and as intended.
+
+With an intuitive API and documentation, it streamlines the process for developers to implement and manage tests. This is beneficial regardless of the project's size or intricacy in Bash.
+
+Thanks to **bashunit**, verifying and validating your Bash code has never been so easy.
+
+## Installation
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+See more about [installation](/installation).
+
+## Usage
+
+Once **bashunit** is installed, you're ready to get started.
+
+1.  First, create a folder to place your tests:
+    ```bash
+    mkdir tests
+    ```
+
+2.  Next, create your first test file named `example_test.sh` within this folder:
+    ::: code-group
+    ```bash [tests/example_test.sh]
+    #!/bin/bash
+
+    function test_bashunit_is_working() {
+      assert_equals "bashunit is working" "bashunit is working"
+    }
+    ```
+    :::
+
+3.  Finally, run the **bashunit** executable:
+    ```bash
+    ./lib/bashunit ./tests
+    ```
+
+4.  If everything works correctly, you should see an output similar to the following:
+    ```
+    Running tests/example_test.sh
+    ✓ Passed: Bashunit is working
+
+    Tests:      1 passed, 1 total
+    Assertions: 1 passed, 1 total
+    All tests passed
+    Time taken: 100 ms
+    ```
+
+5.  Now you can start testing the functionalities of your own Bash scripts.
+
+## Next steps
+
+Dive deeper into the documentation to discover the options provided by [test files](/test-files),
+[parameterized tests](/parameterized-tests), [test doubles](test-doubles) and [assertions](assertions),
+among many other features.

--- a/docs/versions/0.11.0/skipping-incomplete.md
+++ b/docs/versions/0.11.0/skipping-incomplete.md
@@ -1,0 +1,77 @@
+# Skipping and incomplete tests
+
+There may be various scenarios where the "passed" and "failed" outcomes for a test are not sufficient.
+To address these situations, the following functions are available for your use.
+
+## skip
+> `skip "[reason]"`
+
+Not all tests can be run in every environment; when such situations arise, you can mark a test as skipped.
+
+It reports that the test has been skipped, including the `[reason]` if one was specified.
+
+Skipping tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were skipped in the final output.
+
+::: code-group
+```bash [Example]
+function test_skipped() {
+  if [[ $OS != "GEOS" ]]; then
+    skip
+    return
+  fi
+
+  assert_empty "not reached"
+}
+
+function test_skipped_with_reason() {
+  if [[ $OS != "GEOS" ]]; then
+    skip "Not running under Commodore"
+    return
+  fi
+
+  assert_empty "not reached"
+}
+```
+```[Output]
+↷ Skipped: Skipped
+↷ Skipped: Skipped with reason
+    Not running under Commodore
+
+Tests:      2 skipped, 2 total
+Assertions: 2 skipped, 2 total
+Some tests skipped
+```
+:::
+
+## todo
+> `todo "[pending]"`
+
+You may come up with a test that you'd like to implement later.
+Instead of leaving the test implementation empty —which would mark the test as complete— you can flag it as incomplete.
+
+Reports that the test is incomplete as it is under development, including any `[pending]` to do details if specified.
+
+Incomplete tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were incomplete in the final output.
+
+::: code-group
+```bash [Example]
+function test_incomplete() {
+  todo
+}
+
+function test_incomplete_with_pending_details() {
+  todo "Detailed description of what needs to be done"
+}
+```
+```[Output]
+✒ Incomplete: Incomplete
+✒ Incomplete: Incomplete with pending details
+    Detailed description of what needs to be done
+
+Tests:      2 incomplete, 2 total
+Assertions: 2 incomplete, 2 total
+Some tests incomplete
+```
+:::

--- a/docs/versions/0.11.0/snapshots.md
+++ b/docs/versions/0.11.0/snapshots.md
@@ -1,0 +1,54 @@
+# Snapshots
+
+Snapshot testing is valuable for verifying the output of commands or scripts over time.
+By capturing and comparing the "snapshot" of the output at different stages,
+you can easily spot unintended changes or regressions.
+This way, it helps maintain the expected behavior while modifications are being made,
+making the verification process more efficient and reliable.
+
+## assert_match_snapshot
+> `assert_match_snapshot "actual"`
+
+Reports an error if `actual` does not match the existing snapshot file associated with the current test function.
+If no such file exists, a new one is created with the provided value.
+
+::: tip
+You can update the snapshot by deleting it and running its test again.
+:::
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot "$(ls)"
+}
+
+function test_failure() {
+  assert_match_snapshot "$(date)"
+}
+```
+```[First run]
+Running snapshot_test.sh
+✎ Snapshot: Success
+✎ Snapshot: Failure
+
+Tests:      2 snapshot, 2 total
+Assertions: 2 snapshot, 2 total
+Some snapshots created
+```
+```[Subsequent runs]
+Running snapshot_test.sh
+✓ Passed: Success
+✗ Failed: Failure
+    Expected to match the snapshot
+    Mon Jul 27 [-13:37:46-]{+13:37:49+} UTC 1987
+
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
+Some tests failed
+```
+:::
+
+::: warning
+You need to run the tests for this example twice to see them work.
+The first time you run them, the snapshots will be generated and the second time they will be asserted.
+:::

--- a/docs/versions/0.11.0/standalone.md
+++ b/docs/versions/0.11.0/standalone.md
@@ -1,0 +1,45 @@
+# Standalone
+
+You can use all bashunit assertions outside any tests if you would like to use them in integration or end-to-end tests, for entire applications or executables.
+
+## Executing an assertion
+
+If you want to use the nice assertions syntax of bashunit - without the tests context/functions, but to end-to-end tests executables, you can use the `-a|--assert` option when running `./bashunit` and call the assertion directly from there.
+
+The return exit code will be:
+- `0` success assertion
+- `1` failed assertion
+- `127` non-existing function
+
+::: info
+The prefix `assert_` is optional.
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a equals "foo" "foo"
+```
+```[Output]
+# No output - exit code 0 (success)
+```
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_not_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a not_equals "foo" "foo"
+```
+```[Output]
+✗ Failed: Main::exec not_equals
+    Expected 'foo'
+    but got 'foo'
+```
+:::
+

--- a/docs/versions/0.11.0/support.md
+++ b/docs/versions/0.11.0/support.md
@@ -1,0 +1,17 @@
+# Support
+
+If you encounter any issues, require clarification, or wish to suggest improvements, the primary avenue for support is through [our GitHub repository's issue tracking system](https://github.com/TypedDevs/bashunit/issues).
+How to Get Support:
+
+1.  **Navigate to our Issues Page**:
+    Visit the issues section of our repository.
+2.  **Search for Existing Issues**:
+    Before creating a new issue, please search to ensure that your concern hasn't been addressed already.
+3.  **Create a New Issue**:
+    If your concern isn't previously reported, click on the 'New issue' button.
+    Please provide as much detail as possible, including error messages, steps to reproduce, and expected outcomes.
+4.  **Engage Constructively**:
+    When interacting on issues, please be respectful and constructive, understanding that the community aims to help and enhance the tool collaboratively.
+
+We value our community's feedback and aim to address all concerns in a timely and effective manner.
+Your active participation and constructive feedback play a pivotal role in the continuous improvement of **bashunit**.

--- a/docs/versions/0.11.0/test-doubles.md
+++ b/docs/versions/0.11.0/test-doubles.md
@@ -1,0 +1,133 @@
+# Test doubles
+
+When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
+
+## mock
+> `mock "function" "body"`
+
+Allows you to override the behavior of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  mock ps echo hello world
+
+  assert_equals "hello world" "$(ps)"
+}
+```
+:::
+
+> `mock "function" "output"`
+
+Allows you to override the output of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  function code() {
+    ps a | grep bash
+  }
+
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+}
+```
+:::
+
+## spy
+> `spy "function"`
+
+Overrides the original behavior of a callable to allow you to make various assertions about its calls.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called
+> `assert_have_been_called "spy"`
+
+Reports an error if `spy` is not called.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+
+  assert_have_been_called ps
+}
+
+function test_failure() {
+  spy ps
+
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called_with
+> `assert_have_been_called_with "expected" "spy"`
+
+Reports an error if `callable` is not called with `expected`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps bar foo
+
+  assert_have_been_called_with "foo bar" ps
+}
+```
+:::
+
+## assert_have_been_called_times
+> assert_have_been_called_times "expected" "spy"
+
+Reports an error if `spy` is not called exactly `expected` times.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 2 ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 1 ps
+}
+```
+:::

--- a/docs/versions/0.11.0/test-files.md
+++ b/docs/versions/0.11.0/test-files.md
@@ -1,0 +1,91 @@
+# Test files
+
+**bashunit** offers a range of features for test files.
+In this section, you'll find information about these features along with some helpful tips.
+
+## Test file names
+
+**bashunit** is flexible about how you name your test files.
+
+You can use a directory name, and bashunit will look for all files (ending with `test.sh`) recursively inside that directory, and execute them.
+
+If you're using wildcards for scanning your tests, keep in mind that the initial search can slow down if you don't filter the test files in the wildcard.
+
+To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh`).
+This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
+
+This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.
+
+## Test function names
+
+**bashunit** will search for and execute all test functions it finds within each test file.
+To distinguish test functions from auxiliary functions, the names must be prefixed with the word `test`.
+The function names are case-insensitive.
+Below are some example test function names that would work seamlessly:
+
+::: code-group
+```bash [Example]
+function test_should_validate_an_ok_exit_code() { ... }
+function testRenderAllTestsPassedWhenNotFailedTests { ... }
+test_getFunctionsToRun_with_filter_should_return_matching_functions() { ... }
+```
+:::
+
+::: tip
+You're free to use any of Bash's syntax options to define these functions.
+:::
+
+## `set_up` function
+
+The `set_up` auxiliary function is called, if it is present in the test file, before each test function in the test file is executed.
+This provides a hook to prepare the environment or set initial variables specific to each test case.
+For example, you might want to create temporary directories or files that your test will manipulate.
+
+::: code-group
+```bash [Example]
+function set_up() {
+  touch temp_file.txt
+}
+```
+:::
+
+## `tear_down` function
+
+The `tear_down` auxiliary function is called, if it is present in the test file, immediately after each test function in the test file is executed.
+This auxiliary function offers you a place to clean up any resources allocated or changes made during the `set_up` or test function itself.
+This helps to ensure that each test starts with a fresh state.
+
+::: code-group
+```bash [Example]
+function tear_down() {
+  rm temp_file.txt
+}
+```
+:::
+
+## `set_up_before_script` function
+
+The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
+This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
+
+::: code-group
+```bash [Example]
+function set_up_before_script() {
+  open_database_connection
+}
+```
+:::
+
+## `tear_down_after_script` function
+
+The `tear_down_after_script` auxiliary function is called, if it is present in the test file, only once when all the test functions in the test file have been executed.
+This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
+It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
+
+::: code-group
+```bash [Example]
+function tear_down_after_script() {
+  close_database_connection
+}
+```
+:::

--- a/docs/versions/0.12.0/ProductHuntBanner.vue
+++ b/docs/versions/0.12.0/ProductHuntBanner.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="product-hunt-banner__container">
+    <a
+      href="https://www.producthunt.com/posts/bashunit?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-bashunit"
+      target="_blank"
+      rel="noreferrer"
+      title="bashunit - Product Hunt"
+    >
+      <img
+        class="product-hunt-banner__logo--light"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=light"
+        alt="Product Hunt"
+      />
+      <img
+        class="product-hunt-banner__logo--dark"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=dark"
+        alt="Product Hunt"
+      />
+    </a>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style>
+.product-hunt-banner__container {
+  text-align: center;
+  margin-top: 4rem;
+}
+
+.product-hunt-banner__logo--light{
+    display: inline-block;
+}
+
+.product-hunt-banner__logo--dark{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--light{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--dark{
+    display: inline-block;
+}
+</style>

--- a/docs/versions/0.12.0/assertions.md
+++ b/docs/versions/0.12.0/assertions.md
@@ -1,0 +1,900 @@
+# Assertions
+
+When creating tests, you'll need to verify your commands and functions.
+We provide assertions for these checks.
+Below is their documentation.
+
+## assert_equals
+> `assert_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal.
+
+[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals "foo" "foo"
+}
+
+function test_failure() {
+  assert_equals "foo" "bar"
+}
+```
+:::
+
+## assert_equals_ignore_colors
+> `assert_equals_ignore_colors "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals_ignore_colors "foo" "\e[31mfoo"
+}
+
+function test_failure() {
+  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
+}
+```
+:::
+
+## assert_contains
+> `assert_contains "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+
+[assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains "foo" "foobar"
+}
+
+function test_failure() {
+  assert_contains "baz" "foobar"
+}
+```
+
+:::
+
+## assert_contains_ignore_case
+> `assert_contains_ignore_case "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+Differences in casing are ignored when needle is searched for in haystack.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains_ignore_case "foo" "FooBar"
+}
+function test_failure() {
+  assert_contains_ignore_case "baz" "FooBar"
+}
+```
+:::
+
+## assert_empty
+> `assert_empty "actual"`
+
+Reports an error if `actual` is not empty.
+
+[assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_empty ""
+}
+
+function test_failure() {
+  assert_empty "foo"
+}
+```
+:::
+
+## assert_matches
+> `assert_matches "pattern" "value"`
+
+Reports an error if `value` does not match the regular expression `pattern`.
+
+[assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_matches "^foo" "foobar"
+}
+
+function test_failure() {
+  assert_matches "^bar" "foobar"
+}
+```
+:::
+
+## assert_string_starts_with
+> `assert_string_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does not starts with `needle`.
+
+[assert_string_not_starts_with](#assert-string-not-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_starts_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_starts_with "baz" "foobar"
+}
+```
+:::
+
+## assert_string_ends_with
+> `assert_string_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does not ends with `needle`.
+
+[assert_string_not_ends_with](#assert-string-not-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_ends_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_ends_with "foo" "foobar"
+}
+```
+:::
+
+## assert_line_count
+> `assert_line_count "count" "haystack"`
+
+Reports an error if `haystack` does not contain `count` lines.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local string="this is line one
+this is line two
+this is line three"
+
+  assert_line_count 3 "$string"
+}
+
+function test_failure() {
+  assert_line_count 2 "foobar"
+}
+```
+:::
+
+## assert_less_than
+> `assert_less_than "expected" "actual"`
+
+Reports an error if `actual` is not less than `expected`.
+
+[assert_greater_than](#assert-greater-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_than "999" "1"
+}
+
+function test_failure() {
+  assert_less_than "1" "999"
+}
+```
+:::
+
+## assert_less_or_equal_than
+> `assert_less_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not less than or equal to `expected`.
+
+[assert_greater_than](#assert-greater-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_or_equal_than "999" "1"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_less_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_less_or_equal_than "1" "999"
+}
+```
+:::
+
+## assert_greater_than
+> `assert_greater_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than `expected`.
+
+[assert_less_than](#assert-less-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_than "1" "999"
+}
+
+function test_failure() {
+  assert_greater_than "999" "1"
+}
+```
+:::
+
+## assert_greater_or_equal_than
+> `assert_greater_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than or equal to `expected`.
+
+[assert_less_or_equal_than](#assert-less-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_or_equal_than "1" "999"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_greater_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_greater_or_equal_than "999" "1"
+}
+```
+:::
+
+## assert_exit_code
+> `assert_exit_code "expected" ["callable"]`
+
+Reports an error if the exit code of `callable` is not equal to `expected`.
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
+are more semantic versions of this assertion, for which you don't need to specify an exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "1" "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_exit_code "1"
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "0" "$(foo)"
+}
+```
+:::
+
+## assert_array_contains
+> `assert_array_contains "needle" "haystack"`
+
+Reports an error if `needle` is not an element of `haystack`.
+
+[assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "bar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "foobar" "${haystack[@]}"
+}
+```
+:::
+
+## assert_successful_code
+> `assert_successful_code ["callable"]`
+
+Reports an error if the exit code of `callable` is not successful (`0`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 0
+  }
+
+  assert_successful_code "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 0
+  }
+
+  foo # function took instead `callable`
+
+  assert_successful_code
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_successful_code "$(foo)"
+}
+```
+:::
+
+## assert_general_error
+> `assert_general_error ["callable"]`
+
+Reports an error if the exit code of `callable` is not a general error (`1`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_general_error "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_general_error
+}
+
+function test_failure() {
+  function foo() {
+    return 0
+  }
+
+  assert_general_error "$(foo)"
+}
+```
+:::
+
+## assert_command_not_found
+> `assert_general_error ["callable"]`
+
+Reports an error if `callable` exists.
+In other words, if executing `callable` does not return a command not found exit code (`127`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  assert_command_not_found "$(foo > /dev/null 2>&1)"
+}
+
+function test_success_without_callable() {
+  foo > /dev/null 2>&1
+
+  assert_command_not_found
+}
+
+function test_failure() {
+  assert_command_not_found "$(ls > /dev/null 2>&1)"
+}
+```
+:::
+
+## assert_file_exists
+> `assert_file_exists "file"`
+
+Reports an error if `file` does not exists, or it is a directory.
+
+[assert_file_not_exists](#assert-file-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_exists "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  rm -f $file_path
+
+  assert_file_exists "$file_path"
+}
+```
+:::
+
+## assert_is_file
+> `assert_is_file "file"`
+
+Reports an error if `file` is not a file.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local dir_path="bar"
+  mkdir "$dir_path"
+
+  assert_is_file "$dir_path"
+  rmdir "$dir_path"
+}
+```
+:::
+
+## assert_is_file_empty
+> `assert_is_file_empty "file"`
+
+Reports an error if `file` is not empty.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  echo "bar" > "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_exists
+> `assert_directory_exists "directory"`
+
+Reports an error if `directory` does not exist.
+
+[assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_directory_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory
+> `assert_is_directory "directory"`
+
+Reports an error if `directory` is not a directory.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory "$directory"
+}
+
+function test_failure() {
+  local file="/etc/hosts"
+
+  assert_is_directory "$file"
+}
+```
+:::
+
+## assert_is_directory_empty
+> `assert_is_directory_empty "directory"`
+
+Reports an error if `directory` is not an empty directory.
+
+[assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/etc"
+
+  assert_is_directory_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_readable
+> `assert_is_directory_readable "directory"`
+
+Reports an error if `directory` is not a readable directory.
+
+[assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_writable
+> `assert_is_directory_writable "directory"`
+
+Reports an error if `directory` is not a writable directory.
+
+[assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/tmp"
+
+  assert_is_directory_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_writable "$directory"
+}
+```
+:::
+
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal.
+
+[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
+## assert_not_contains
+> `assert_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is a substring of `haystack`.
+
+[assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_contains "baz" "foobar"
+}
+
+function test_failure() {
+  assert_not_contains "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_starts_with
+> `assert_string_not_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does starts with `needle`.
+
+[assert_string_starts_with](#assert-string-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_starts_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_starts_with "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_ends_with
+> `assert_string_not_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does ends with `needle`.
+
+[assert_string_ends_with](#assert-string-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_ends_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_ends_with "bar" "foobar"
+}
+```
+:::
+
+## assert_not_empty
+> `assert_not_empty "actual"`
+
+Reports an error if `actual` is empty.
+
+[assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_empty "foo"
+}
+
+function test_failure() {
+  assert_not_empty ""
+}
+```
+:::
+
+## assert_not_matches
+> `assert_not_matches "pattern" "value"`
+
+Reports an error if `value` matches the regular expression `pattern`.
+
+[assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_matches "foo$" "foobar"
+}
+
+function test_failure() {
+  assert_not_matches "bar$" "foobar"
+}
+```
+:::
+
+## assert_array_not_contains
+> `assert_array_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is an element of `haystack`.
+
+[assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "foobar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "baz" "${haystack[@]}"
+}
+```
+:::
+
+## assert_file_not_exists
+> `assert_file_not_exists "file"`
+
+Reports an error if `file` does exists.
+
+[assert_file_exists](#assert-file-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+  rm "$file_path"
+
+  assert_file_not_exists "$file_path"
+}
+
+function test_failed() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_not_exists "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_not_exists
+> `assert_directory_not_exists "directory"`
+
+Reports an error if `directory` exists.
+
+[assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_not_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_directory_not_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_empty
+> `assert_is_directory_not_empty "directory"`
+
+Reports an error if `directory` is empty.
+
+[assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/etc"
+
+  assert_is_directory_not_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_not_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_readable
+> `assert_is_directory_not_readable "directory"`
+
+Reports an error if `directory` is readable.
+
+[assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_not_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_is_directory_not_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_writable
+> `assert_is_directory_not_writable "directory"`
+
+Reports an error if `directory` is writable.
+
+[assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_not_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/tmp"
+
+  assert_is_directory_not_writable "$directory"
+}
+```
+:::
+
+## fail
+> `fail "failure message"`
+
+Unambiguously reports an error message. Useful for reporting specific message
+when testing situations not covered by any `assert_*` functions.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  if [ "$(date +%-H)" -gt 25 ]; then
+    fail "Something is very wrong with your clock"
+  fi
+}
+function test_failure() {
+  if [ "$(date +%-H)" -lt 25 ]; then
+    fail "This test will always fail"
+  fi
+}
+```
+:::

--- a/docs/versions/0.12.0/command-line.md
+++ b/docs/versions/0.12.0/command-line.md
@@ -1,0 +1,218 @@
+# Command line
+
+**bashunit** command accepts options to control its behavior. These options will override the environment [configuration](/configuration), which you can use to make the change permanent.
+
+## Directory or file
+
+> `bashunit "directory|file"`
+
+Specifies the `directory` or `file` containing the tests to be run.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+You can use `DEFAULT_PATH` option in your [configuration](/configuration#default-path)
+to choose where the tests are located by default.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+./bashunit ./tests
+
+# concrete test by full path
+./bashunit ./tests/example_test.sh
+
+# all test matching given wildcard
+./bashunit ./tests/**/*_test.sh
+```
+:::
+
+## Assert
+
+> `bashunit -a|--assert function "arg1" "arg2"`
+
+Run a core assert function standalone without a test context. Read more: [Standalone](/standalone)
+
+::: code-group
+```bash [Example]
+./bashunit --assert equals "foo" "bar"
+```
+```[Output]
+✗ Failed: Main::exec assert
+    Expected 'foo'
+    but got 'bar'
+```
+:::
+
+## Debug
+
+> `bashunit --debug`
+
+Enables a shell mode in which all executed commands are printed to the terminal. Printing every command as executed may help you visualize the script's control flow if it is not working as expected.
+
+::: code-group
+```bash [Example]
+./bashunit --debug
+```
+:::
+
+## Environment
+
+> `bashunit -e|--env "file path"`
+
+Loads a custom env file overriding the `.env` environment variables.
+
+::: code-group
+```bash [Example]
+./bashunit tests --env .env.production
+```
+:::
+
+## Filter
+
+> `bashunit -f|--filter "test name"`
+
+Filters the tests to be run based on the `test name`.
+
+::: code-group
+```bash [Example]
+# run all test functions including "something" in it's name
+./bashunit ./tests --filter "something"
+```
+:::
+
+## Logging
+
+> `bashunit -l|--log-junit <out.xml>`
+
+Creates a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --log-junit log-junit.xml
+```
+:::
+
+## Report
+
+> `bashunit -r|--report-html <out.html>`
+
+Creates a report HTML file that contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --report-html report.html
+```
+:::
+
+## Output
+
+> `bashunit -s|--simple`
+>
+> `bashunit -v|--verbose`
+
+Enables simplified or verbose output to the console.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+This command flag will always take precedence over the environment configuration.
+
+You can use `SIMPLE_OUTPUT` option in your [configuration](/configuration#output)
+to choose the default output display.
+
+::: code-group
+```[Output]
+........
+```
+```bash [Example]
+./bashunit ./tests --simple
+```
+:::
+
+::: code-group
+```[Output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+✓ Passed: Text should contain
+✓ Passed: Text should match a regular expression
+✓ Passed: Text should not contain
+✓ Passed: Text should not match a regular expression
+```
+```bash [Example]
+./bashunit ./tests --verbose
+```
+:::
+
+## Stop on failure
+
+> `bashunit -S|--stop-on-failure`
+
+Force to stop the runner right after encountering one failing test.
+
+You can use `STOP_ON_FAILURE` option in your [configuration](/configuration#stop-on-failure)
+to make this behavior permanent.
+
+::: code-group
+```bash [Example]
+./bashunit --stop-on-failure
+```
+:::
+
+## Version
+
+> `bashunit --version`
+
+Displays the current version of **bashunit**.
+
+::: code-group
+```-vue [Output]
+bashunit - {{ pkg.version }}
+```
+```bash [Example]
+./bashunit --version
+```
+:::
+
+## Upgrade
+
+> `bashunit --upgrade`
+
+Upgrade **bashunit** to latest version.
+
+::: code-group
+```bash [Example]
+./bashunit --upgrade
+```
+:::
+
+## Help
+
+> `bashunit --help`
+
+Displays a help message with all allowed arguments and options.
+
+::: code-group
+```[Output]
+bashunit [arguments] [options]
+
+Arguments:
+  Specifies the directory or file containing [...]
+
+Options:
+  -f|--filter
+    Filters the tests to run based on the test name.
+
+  [...]
+```
+```bash [Example]
+./bashunit --help
+```
+:::
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.12.0/configuration.md
+++ b/docs/versions/0.12.0/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+Environment configuration to control **bashunit** behavior.
+
+It serves to configure the behavior of bashunit in your project.
+You need to create a `.env` file in the root directory,
+but you can give it another name if you pass it as an argument to the command with
+`--env` [option](/command-line#environment).
+
+## Default path
+
+> `DEFAULT_PATH=directory|file`
+
+Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+DEFAULT_PATH=tests
+
+# concrete test by full path
+DEFAULT_PATH=tests/example_test.sh
+
+# all test matching given wildcard
+DEFAULT_PATH=tests/**/*_test.sh
+```
+:::
+
+## Output
+
+> `SIMPLE_OUTPUT=true|false`
+
+Enables simplified output to the console. `false` by default.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+Similar as using `-s|--simple|-v|--verbose` option on the [command line](/command-line#output).
+
+::: code-group
+```bash [Simple output]
+....
+```
+```bash [.env]
+SIMPLE_OUTPUT=true
+```
+:::
+
+::: code-group
+```[Verbose output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+```
+```bash [.env]
+SIMPLE_OUTPUT=false
+```
+:::
+
+## Stop on failure
+
+> `STOP_ON_FAILURE=true|false`
+
+Force to stop the runner right after encountering one failing test. `false` by default.
+
+Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#stop-on-failure).
+
+## Show header
+
+> `SHOW_HEADER=true|false`
+>
+> `HEADER_ASCII_ART=true|false`
+
+Specify if you want to show the bashunit header. `true` by default.
+
+Additionally, you can use the env-var `HEADER_ASCII_ART` to display bashunit in ASCII. `false` by default.
+
+::: code-group
+``` [Without header]
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=false
+```
+:::
+
+::: code-group
+```-vue [Plain header]
+bashunit - {{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+```
+:::
+
+::: code-group
+```-vue [ASCII header]
+__               _                   _    // [!code hl]
+| |__   __ _ ___| |__  __ __ ____ (_) |_  // [!code hl]
+| '_ \ / _' / __| '_ \| | | | '_ \| | __| // [!code hl]
+| |_) | (_| \__ \ | | | |_| | | | | | |_  // [!code hl]
+|_.__/ \__,_|___/_| |_|\___/|_| |_|_|\__| // [!code hl]
+{{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+HEADER_ASCII_ART=true
+```
+:::
+
+## Show execution time
+
+> `SHOW_EXECUTION_TIME=true|false`
+
+Specify if you want to display the execution time after running **bashunit**. `true` by default.
+
+::: warning
+This feature is not available on macOS.
+:::
+
+::: code-group
+```-vue [With execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+Time taken: 14 ms  // [!code hl]
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=true
+```
+:::
+
+::: code-group
+```[Without execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=false
+```
+:::
+
+## Log JUnit
+
+> `LOG_JUNIT=log-junit.xml`
+
+Create a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+## Report HTML
+
+> `REPORT_HTML=report.html`
+
+Create a report HTML file that contains information about the test results of your bashunit tests.
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.12.0/custom-asserts.md
+++ b/docs/versions/0.12.0/custom-asserts.md
@@ -1,0 +1,34 @@
+# Custom asserts
+
+**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+
+:::tip
+Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
+:::
+
+## assertion_failed
+> `bashunit::assertion_failed <expected> <actual> <failure_condition_message?>`
+
+## assertion_passed
+> `bashunit::assertion_passed`
+
+## Example
+
+```bash
+# Your custom assert using the bashunit facade
+function assert_foo() {
+  local actual="$1"
+
+  if [[ "foo" != "$actual" ]]; then
+    bashunit::assertion_failed "foo" "$actual"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+# Your test using your custom assert
+function test_assert_foo_passed() {
+  assert_foo "foo"
+}
+```

--- a/docs/versions/0.12.0/examples.md
+++ b/docs/versions/0.12.0/examples.md
@@ -1,0 +1,28 @@
+# Examples
+
+## Demo example
+
+**bashunit** includes a sample script and its associated test file in the examples folder of its repository.
+In there, you'll find various tests showcasing the file and different **bashunit** functionalities.
+
+[Take a look](https://github.com/TypedDevs/bashunit/tree/main/example).
+
+## Real examples
+
+If you're interested in real-world examples, below is a list of actual projects that use **bashunit** to test their Bash scripts.
+
+::: info
+If your project utilizes **bashunit**, you can add it to this list by submitting a pull request to us.
+:::
+
+### [TypedDevs/bashunit](https://github.com/TypedDevs/bashunit)
+**bashunit** uses itself to test the proper operation of each one of its features.
+
+### [Chemaclass/conventional-commits](https://github.com/Chemaclass/conventional-commits)
+A specification for adding human and machine-readable meaning to commit messages.
+
+### [Tito-Kati/fizzbuzz-bashunit](https://github.com/Tito-Kati/fizzbuzz-bashunit)
+Popular introductory FizzBuzz kata solved in Bash with **bashunit** as the testing framework.
+
+### [phpctl](https://github.com/opencodeco/phpctl)
+It is a Docker (containers) based development environment for PHP.

--- a/docs/versions/0.12.0/index.md
+++ b/docs/versions/0.12.0/index.md
@@ -1,0 +1,85 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: bashunit
+  text: v0.12.0
+  tagline: Test your bash scripts in the fastest and simplest way, discover the most modern bash testing library.
+  image:
+    src: /logo.svg
+    alt: bashunit
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /0.12.0/quickstart
+    - theme: alt
+      text: Assertions
+      link: /0.12.0/assertions
+    - theme: alt
+      text: Blog
+      link: /blog/
+
+features:
+  - icon:
+      src: /flexible.svg
+    title: Flexible
+    details: Robust assertions for comparing, matching, and validating results, ensuring thorough testing of your codebase.
+  - icon:
+      src: /accessible.svg
+    title: Accessible
+    details: An intuitive API and clear documentation for a smooth developer experience, reducing testing complexity.
+  - icon:
+      src: /updated.svg
+    title: Updated
+    details: A vibrant GitHub community for support, collaboration, and continuous library enhancement. Join forces with like-minded developers.
+  - icon:
+      src: /multiplatform.svg
+    title: Multiplatform
+    details: Seamlessly operates on Linux, macOS, and Windows (via WSL), facilitating a consistent testing environment across major platforms.
+---
+
+<ProductHuntBanner />
+
+<h2 class="home__award-title">Honors & Awards</h2>
+
+<div class="home__award-container">
+  <a
+    href="https://twitter.com/getmanfred/status/1737191954289487900"
+    target="_blank"
+  >
+    <img
+      src="/awards/manfred-2023.jpg"
+      alt="The Manfred Awards 2023 - bashunit - Side Project of the Year"
+    />
+  </a>
+</div>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import VanillaTilt from 'vanilla-tilt';
+import ProductHuntBanner from "./ProductHuntBanner.vue";
+
+onMounted(() => {
+  const heroImage = document.querySelector('.VPHero .VPImage');
+
+  VanillaTilt.init(heroImage, {
+    'full-page-listening': true,
+    reverse: true,
+    gyroscope: false
+  });
+});
+</script>
+
+<style scoped>
+.home__award-title {
+  text-align: center;
+  margin: 4rem 0;
+  font-size: 2.75rem;
+}
+
+.home__award-container {
+  display: grid;
+  justify-content: center;
+}
+</style>

--- a/docs/versions/0.12.0/installation.md
+++ b/docs/versions/0.12.0/installation.md
@@ -1,0 +1,100 @@
+# Installation
+
+Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
+you can add **bashunit** as a dependency in your repository according to your preferences.
+
+Here, we provide different options that you can use to install **bashunit** in your application.
+
+## install.sh
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+#### Verify
+
+```bash-vue
+# Verify the sha256sum for latest stable: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}"; FILE="$DIR/bashunit"; [ "$(shasum -a 256 "$FILE" | awk '{ print $1 }')" = "$KNOWN_HASH" ] && echo -e "✓ \033[1mbashunit\033[0m verified." || { echo -e "✗ \033[1mbashunit\033[0m corrupt"; rm "$FILE"; }
+```
+
+:::tip
+You can find the checksum for each version inside [GitHub's releases](https://github.com/TypedDevs/bashunit/releases). E.g.:
+```-vue
+https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checksum
+```
+:::
+
+#### Define custom tag and folder
+
+The installation script can receive two optional arguments:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
+```
+- `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default
+
+::: tip
+You can use `beta` as `[version]` to get the next non-stable preview release.
+We try to keep it stable, but there is no promise that we won't change functions or their signatures without prior notice.
+:::
+
+::: tip
+Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
+:::
+
+## GitHub Actions
+
+```yaml
+# example: .github/workflows/bashunit-tests.yml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install bashunit"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh"
+
+      - name: "Test"
+        run: "./bashunit tests/**/*_test.sh"
+```
+
+::: tip
+Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+:::
+
+## Brew
+
+You can install **bashunit** globally in your macOS (or Linux) using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.12.0/parameterized-tests.md
+++ b/docs/versions/0.12.0/parameterized-tests.md
@@ -1,0 +1,101 @@
+# Parameterized tests
+
+**bashunit** offers two ways to parameterize your test functions:
+- **Multi-invokers**: are the most flexible option, as they allow passing multiple arguments to the test function and permit arguments containing whitespace.
+- **Data providers**: offer a simple alternative for cases when the test function needs to accept only a single word as an argument.
+
+---
+
+Both of these are specified using a special comment before the test function declaration. The comment specifies the name of a separate auxiliary bash function which **bashunit** will invoke prior to the test. This auxiliary function will determine how many times the test function will be invoked, and what arguments will be passed to the test function each time.
+
+The benefit of this is that each of these invocations is a full test itself, and can succeed or fail independently of the other tests. Also, [set_up](/test-files#set-up-function) and [tear_down](/test-files#tear-down-function) are called before and after each invocation of the test function. Using these tools can often result in less code repetition in your test files, and a clearer way to develop a suite of closely related tests quickly.
+
+:::tip
+The same multi-invoker or data provider function can be specified for multiple tests. This allows developing tests for related tools quickly. For example, if you had a tool that creates directories and another which removes directories, you could write one test for each tool and parameterize them to operate on the same set of directories.
+:::
+
+### Multi-invokers
+
+A multi-invoker function is specified as follows:
+
+::: code-group
+```bash [Example]
+# multi_invoker invoker_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The invoker function should call the special function `run_test`, passing any arbitrary arguments to that function. **bashunit** will invoke the original test function each time `run_test` is called, passing the corresponding arguments.
+
+::: code-group
+```bash [Example]
+function invoker_with_args() {
+  run_test arg1 arg2
+  run_test "arg1 with spaces" "arg2 with more spaces" "and even arg3"
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  command_we_want_to_test "$@"
+
+  assert_exit_code "0"
+}
+```
+:::
+
+In this example, the `invoker_with_args` will be executed instead of invoking `test_command_with_args` directly. Each time `invoker_with_args` calls `run_test` with some arguments, **bashunit** will call the original test function with those arguments. In this case the test simply verifies that `command_we_want_to_test` can accept these arguments without raising an error, but it could also verify other behaviors of the command. In this next example, we test that a `mkdir_command` we are developing can create a new directory with specified octal permissions.
+
+::: code-group
+```bash [Example]
+function invoker_for_mkdir() {
+  run_test /tmp/dirA 755
+  run_test "/tmp/private dir" 700
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  local directory="$1"
+  local perms="$2"
+
+  assert_directory_not_exists "$directory"
+  mkdir_command "${directory}" --perms "${perms}"
+  assert_directory_exists "$directory"
+  assert_equals "$perm" "$(stat --format %a "$directory")
+}
+```
+:::
+
+### Data providers
+
+A data provider function is specified as follows:
+
+::: code-group
+```bash [Example]
+# data_provider provider_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The provider function can return a space-separated list of values like `one two three` or a single value `one`. In case of a list of values, the test function will be invoked multiple times, each time being passed a different value from the list.
+
+::: code-group
+```bash [Example]
+function provider_directories() {
+  local directories=("/usr" "/etc" "/var")
+  echo "${directories[@]}"
+}
+
+# data_provider provider_directories
+function test_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of simple strings provided by this function, and the test function will be executed passing each time the current iteration value as the first argument.

--- a/docs/versions/0.12.0/quickstart.md
+++ b/docs/versions/0.12.0/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+**bashunit** is a dedicated testing tool crafted specifically for Bash scripts. It empowers you with tests on your Bash codebase, ensuring that your scripts operate reliably and as intended.
+
+With an intuitive API and documentation, it streamlines the process for developers to implement and manage tests. This is beneficial regardless of the project's size or intricacy in Bash.
+
+Thanks to **bashunit**, verifying and validating your Bash code has never been so easy.
+
+## Installation
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+See more about [installation](/installation).
+
+## Usage
+
+Once **bashunit** is installed, you're ready to get started.
+
+1.  First, create a folder to place your tests:
+    ```bash
+    mkdir tests
+    ```
+
+2.  Next, create your first test file named `example_test.sh` within this folder:
+    ::: code-group
+    ```bash [tests/example_test.sh]
+    #!/bin/bash
+
+    function test_bashunit_is_working() {
+      assert_equals "bashunit is working" "bashunit is working"
+    }
+    ```
+    :::
+
+3.  Finally, run the **bashunit** executable:
+    ```bash
+    ./lib/bashunit ./tests
+    ```
+
+4.  If everything works correctly, you should see an output similar to the following:
+    ```
+    Running tests/example_test.sh
+    ✓ Passed: Bashunit is working
+
+    Tests:      1 passed, 1 total
+    Assertions: 1 passed, 1 total
+    All tests passed
+    Time taken: 100 ms
+    ```
+
+5.  Now you can start testing the functionalities of your own Bash scripts.
+
+## Next steps
+
+Dive deeper into the documentation to discover the options provided by [test files](/test-files),
+[parameterized tests](/parameterized-tests), [test doubles](test-doubles) and [assertions](assertions),
+among many other features.

--- a/docs/versions/0.12.0/skipping-incomplete.md
+++ b/docs/versions/0.12.0/skipping-incomplete.md
@@ -1,0 +1,77 @@
+# Skipping and incomplete tests
+
+There may be various scenarios where the "passed" and "failed" outcomes for a test are not sufficient.
+To address these situations, the following functions are available for your use.
+
+## skip
+> `skip "[reason]"`
+
+Not all tests can be run in every environment; when such situations arise, you can mark a test as skipped.
+
+It reports that the test has been skipped, including the `[reason]` if one was specified.
+
+Skipping tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were skipped in the final output.
+
+::: code-group
+```bash [Example]
+function test_skipped() {
+  if [[ $OS != "GEOS" ]]; then
+    skip
+    return
+  fi
+
+  assert_empty "not reached"
+}
+
+function test_skipped_with_reason() {
+  if [[ $OS != "GEOS" ]]; then
+    skip "Not running under Commodore"
+    return
+  fi
+
+  assert_empty "not reached"
+}
+```
+```[Output]
+↷ Skipped: Skipped
+↷ Skipped: Skipped with reason
+    Not running under Commodore
+
+Tests:      2 skipped, 2 total
+Assertions: 2 skipped, 2 total
+Some tests skipped
+```
+:::
+
+## todo
+> `todo "[pending]"`
+
+You may come up with a test that you'd like to implement later.
+Instead of leaving the test implementation empty —which would mark the test as complete— you can flag it as incomplete.
+
+Reports that the test is incomplete as it is under development, including any `[pending]` to do details if specified.
+
+Incomplete tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were incomplete in the final output.
+
+::: code-group
+```bash [Example]
+function test_incomplete() {
+  todo
+}
+
+function test_incomplete_with_pending_details() {
+  todo "Detailed description of what needs to be done"
+}
+```
+```[Output]
+✒ Incomplete: Incomplete
+✒ Incomplete: Incomplete with pending details
+    Detailed description of what needs to be done
+
+Tests:      2 incomplete, 2 total
+Assertions: 2 incomplete, 2 total
+Some tests incomplete
+```
+:::

--- a/docs/versions/0.12.0/snapshots.md
+++ b/docs/versions/0.12.0/snapshots.md
@@ -1,0 +1,54 @@
+# Snapshots
+
+Snapshot testing is valuable for verifying the output of commands or scripts over time.
+By capturing and comparing the "snapshot" of the output at different stages,
+you can easily spot unintended changes or regressions.
+This way, it helps maintain the expected behavior while modifications are being made,
+making the verification process more efficient and reliable.
+
+## assert_match_snapshot
+> `assert_match_snapshot "actual"`
+
+Reports an error if `actual` does not match the existing snapshot file associated with the current test function.
+If no such file exists, a new one is created with the provided value.
+
+::: tip
+You can update the snapshot by deleting it and running its test again.
+:::
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot "$(ls)"
+}
+
+function test_failure() {
+  assert_match_snapshot "$(date)"
+}
+```
+```[First run]
+Running snapshot_test.sh
+✎ Snapshot: Success
+✎ Snapshot: Failure
+
+Tests:      2 snapshot, 2 total
+Assertions: 2 snapshot, 2 total
+Some snapshots created
+```
+```[Subsequent runs]
+Running snapshot_test.sh
+✓ Passed: Success
+✗ Failed: Failure
+    Expected to match the snapshot
+    Mon Jul 27 [-13:37:46-]{+13:37:49+} UTC 1987
+
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
+Some tests failed
+```
+:::
+
+::: warning
+You need to run the tests for this example twice to see them work.
+The first time you run them, the snapshots will be generated and the second time they will be asserted.
+:::

--- a/docs/versions/0.12.0/standalone.md
+++ b/docs/versions/0.12.0/standalone.md
@@ -1,0 +1,45 @@
+# Standalone
+
+You can use all bashunit assertions outside any tests if you would like to use them in integration or end-to-end tests, for entire applications or executables.
+
+## Executing an assertion
+
+If you want to use the nice assertions syntax of bashunit - without the tests context/functions, but to end-to-end tests executables, you can use the `-a|--assert` option when running `./bashunit` and call the assertion directly from there.
+
+The return exit code will be:
+- `0` success assertion
+- `1` failed assertion
+- `127` non-existing function
+
+::: info
+The prefix `assert_` is optional.
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a equals "foo" "foo"
+```
+```[Output]
+# No output - exit code 0 (success)
+```
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_not_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a not_equals "foo" "foo"
+```
+```[Output]
+✗ Failed: Main::exec not_equals
+    Expected 'foo'
+    but got 'foo'
+```
+:::
+

--- a/docs/versions/0.12.0/support.md
+++ b/docs/versions/0.12.0/support.md
@@ -1,0 +1,17 @@
+# Support
+
+If you encounter any issues, require clarification, or wish to suggest improvements, the primary avenue for support is through [our GitHub repository's issue tracking system](https://github.com/TypedDevs/bashunit/issues).
+How to Get Support:
+
+1.  **Navigate to our Issues Page**:
+    Visit the issues section of our repository.
+2.  **Search for Existing Issues**:
+    Before creating a new issue, please search to ensure that your concern hasn't been addressed already.
+3.  **Create a New Issue**:
+    If your concern isn't previously reported, click on the 'New issue' button.
+    Please provide as much detail as possible, including error messages, steps to reproduce, and expected outcomes.
+4.  **Engage Constructively**:
+    When interacting on issues, please be respectful and constructive, understanding that the community aims to help and enhance the tool collaboratively.
+
+We value our community's feedback and aim to address all concerns in a timely and effective manner.
+Your active participation and constructive feedback play a pivotal role in the continuous improvement of **bashunit**.

--- a/docs/versions/0.12.0/test-doubles.md
+++ b/docs/versions/0.12.0/test-doubles.md
@@ -1,0 +1,133 @@
+# Test doubles
+
+When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
+
+## mock
+> `mock "function" "body"`
+
+Allows you to override the behavior of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  mock ps echo hello world
+
+  assert_equals "hello world" "$(ps)"
+}
+```
+:::
+
+> `mock "function" "output"`
+
+Allows you to override the output of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  function code() {
+    ps a | grep bash
+  }
+
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+}
+```
+:::
+
+## spy
+> `spy "function"`
+
+Overrides the original behavior of a callable to allow you to make various assertions about its calls.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called
+> `assert_have_been_called "spy"`
+
+Reports an error if `spy` is not called.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+
+  assert_have_been_called ps
+}
+
+function test_failure() {
+  spy ps
+
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called_with
+> `assert_have_been_called_with "expected" "spy"`
+
+Reports an error if `callable` is not called with `expected`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps bar foo
+
+  assert_have_been_called_with "foo bar" ps
+}
+```
+:::
+
+## assert_have_been_called_times
+> assert_have_been_called_times "expected" "spy"
+
+Reports an error if `spy` is not called exactly `expected` times.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 2 ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 1 ps
+}
+```
+:::

--- a/docs/versions/0.12.0/test-files.md
+++ b/docs/versions/0.12.0/test-files.md
@@ -1,0 +1,91 @@
+# Test files
+
+**bashunit** offers a range of features for test files.
+In this section, you'll find information about these features along with some helpful tips.
+
+## Test file names
+
+**bashunit** is flexible about how you name your test files.
+
+You can use a directory name, and bashunit will look for all files (ending with `test.sh`) recursively inside that directory, and execute them.
+
+If you're using wildcards for scanning your tests, keep in mind that the initial search can slow down if you don't filter the test files in the wildcard.
+
+To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh`).
+This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
+
+This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.
+
+## Test function names
+
+**bashunit** will search for and execute all test functions it finds within each test file.
+To distinguish test functions from auxiliary functions, the names must be prefixed with the word `test`.
+The function names are case-insensitive.
+Below are some example test function names that would work seamlessly:
+
+::: code-group
+```bash [Example]
+function test_should_validate_an_ok_exit_code() { ... }
+function testRenderAllTestsPassedWhenNotFailedTests { ... }
+test_getFunctionsToRun_with_filter_should_return_matching_functions() { ... }
+```
+:::
+
+::: tip
+You're free to use any of Bash's syntax options to define these functions.
+:::
+
+## `set_up` function
+
+The `set_up` auxiliary function is called, if it is present in the test file, before each test function in the test file is executed.
+This provides a hook to prepare the environment or set initial variables specific to each test case.
+For example, you might want to create temporary directories or files that your test will manipulate.
+
+::: code-group
+```bash [Example]
+function set_up() {
+  touch temp_file.txt
+}
+```
+:::
+
+## `tear_down` function
+
+The `tear_down` auxiliary function is called, if it is present in the test file, immediately after each test function in the test file is executed.
+This auxiliary function offers you a place to clean up any resources allocated or changes made during the `set_up` or test function itself.
+This helps to ensure that each test starts with a fresh state.
+
+::: code-group
+```bash [Example]
+function tear_down() {
+  rm temp_file.txt
+}
+```
+:::
+
+## `set_up_before_script` function
+
+The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
+This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
+
+::: code-group
+```bash [Example]
+function set_up_before_script() {
+  open_database_connection
+}
+```
+:::
+
+## `tear_down_after_script` function
+
+The `tear_down_after_script` auxiliary function is called, if it is present in the test file, only once when all the test functions in the test file have been executed.
+This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
+It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
+
+::: code-group
+```bash [Example]
+function tear_down_after_script() {
+  close_database_connection
+}
+```
+:::

--- a/docs/versions/0.13.0/ProductHuntBanner.vue
+++ b/docs/versions/0.13.0/ProductHuntBanner.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="product-hunt-banner__container">
+    <a
+      href="https://www.producthunt.com/posts/bashunit?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-bashunit"
+      target="_blank"
+      rel="noreferrer"
+      title="bashunit - Product Hunt"
+    >
+      <img
+        class="product-hunt-banner__logo--light"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=light"
+        alt="Product Hunt"
+      />
+      <img
+        class="product-hunt-banner__logo--dark"
+        src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=417750&theme=dark"
+        alt="Product Hunt"
+      />
+    </a>
+  </div>
+</template>
+
+<script>
+export default {}
+</script>
+
+<style>
+.product-hunt-banner__container {
+  text-align: center;
+  margin-top: 4rem;
+}
+
+.product-hunt-banner__logo--light{
+    display: inline-block;
+}
+
+.product-hunt-banner__logo--dark{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--light{
+    display: none;
+}
+
+.dark .product-hunt-banner__logo--dark{
+    display: inline-block;
+}
+</style>

--- a/docs/versions/0.13.0/assertions.md
+++ b/docs/versions/0.13.0/assertions.md
@@ -1,0 +1,900 @@
+# Assertions
+
+When creating tests, you'll need to verify your commands and functions.
+We provide assertions for these checks.
+Below is their documentation.
+
+## assert_equals
+> `assert_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal.
+
+[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals "foo" "foo"
+}
+
+function test_failure() {
+  assert_equals "foo" "bar"
+}
+```
+:::
+
+## assert_equals_ignore_colors
+> `assert_equals_ignore_colors "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_equals_ignore_colors "foo" "\e[31mfoo"
+}
+
+function test_failure() {
+  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
+}
+```
+:::
+
+## assert_contains
+> `assert_contains "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+
+[assert_not_contains](#assert-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains "foo" "foobar"
+}
+
+function test_failure() {
+  assert_contains "baz" "foobar"
+}
+```
+
+:::
+
+## assert_contains_ignore_case
+> `assert_contains_ignore_case "needle" "haystack"`
+
+Reports an error if `needle` is not a substring of `haystack`.
+Differences in casing are ignored when needle is searched for in haystack.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_contains_ignore_case "foo" "FooBar"
+}
+function test_failure() {
+  assert_contains_ignore_case "baz" "FooBar"
+}
+```
+:::
+
+## assert_empty
+> `assert_empty "actual"`
+
+Reports an error if `actual` is not empty.
+
+[assert_not_empty](#assert-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_empty ""
+}
+
+function test_failure() {
+  assert_empty "foo"
+}
+```
+:::
+
+## assert_matches
+> `assert_matches "pattern" "value"`
+
+Reports an error if `value` does not match the regular expression `pattern`.
+
+[assert_not_matches](#assert-not-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_matches "^foo" "foobar"
+}
+
+function test_failure() {
+  assert_matches "^bar" "foobar"
+}
+```
+:::
+
+## assert_string_starts_with
+> `assert_string_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does not starts with `needle`.
+
+[assert_string_not_starts_with](#assert-string-not-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_starts_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_starts_with "baz" "foobar"
+}
+```
+:::
+
+## assert_string_ends_with
+> `assert_string_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does not ends with `needle`.
+
+[assert_string_not_ends_with](#assert-string-not-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_ends_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_ends_with "foo" "foobar"
+}
+```
+:::
+
+## assert_line_count
+> `assert_line_count "count" "haystack"`
+
+Reports an error if `haystack` does not contain `count` lines.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local string="this is line one
+this is line two
+this is line three"
+
+  assert_line_count 3 "$string"
+}
+
+function test_failure() {
+  assert_line_count 2 "foobar"
+}
+```
+:::
+
+## assert_less_than
+> `assert_less_than "expected" "actual"`
+
+Reports an error if `actual` is not less than `expected`.
+
+[assert_greater_than](#assert-greater-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_than "999" "1"
+}
+
+function test_failure() {
+  assert_less_than "1" "999"
+}
+```
+:::
+
+## assert_less_or_equal_than
+> `assert_less_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not less than or equal to `expected`.
+
+[assert_greater_than](#assert-greater-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_less_or_equal_than "999" "1"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_less_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_less_or_equal_than "1" "999"
+}
+```
+:::
+
+## assert_greater_than
+> `assert_greater_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than `expected`.
+
+[assert_less_than](#assert-less-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_than "1" "999"
+}
+
+function test_failure() {
+  assert_greater_than "999" "1"
+}
+```
+:::
+
+## assert_greater_or_equal_than
+> `assert_greater_or_equal_than "expected" "actual"`
+
+Reports an error if `actual` is not greater than or equal to `expected`.
+
+[assert_less_or_equal_than](#assert-less-or-equal-than) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_greater_or_equal_than "1" "999"
+}
+
+function test_success_with_two_equal_numbers() {
+  assert_greater_or_equal_than "999" "999"
+}
+
+function test_failure() {
+  assert_greater_or_equal_than "999" "1"
+}
+```
+:::
+
+## assert_exit_code
+> `assert_exit_code "expected" ["callable"]`
+
+Reports an error if the exit code of `callable` is not equal to `expected`.
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
+are more semantic versions of this assertion, for which you don't need to specify an exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "1" "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_exit_code "1"
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_exit_code "0" "$(foo)"
+}
+```
+:::
+
+## assert_array_contains
+> `assert_array_contains "needle" "haystack"`
+
+Reports an error if `needle` is not an element of `haystack`.
+
+[assert_array_not_contains](#assert-array-not-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "bar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_contains "foobar" "${haystack[@]}"
+}
+```
+:::
+
+## assert_successful_code
+> `assert_successful_code ["callable"]`
+
+Reports an error if the exit code of `callable` is not successful (`0`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 0
+  }
+
+  assert_successful_code "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 0
+  }
+
+  foo # function took instead `callable`
+
+  assert_successful_code
+}
+
+function test_failure() {
+  function foo() {
+    return 1
+  }
+
+  assert_successful_code "$(foo)"
+}
+```
+:::
+
+## assert_general_error
+> `assert_general_error ["callable"]`
+
+Reports an error if the exit code of `callable` is not a general error (`1`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_general_error "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 1
+  }
+
+  foo # function took instead `callable`
+
+  assert_general_error
+}
+
+function test_failure() {
+  function foo() {
+    return 0
+  }
+
+  assert_general_error "$(foo)"
+}
+```
+:::
+
+## assert_command_not_found
+> `assert_general_error ["callable"]`
+
+Reports an error if `callable` exists.
+In other words, if executing `callable` does not return a command not found exit code (`127`).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  assert_command_not_found "$(foo > /dev/null 2>&1)"
+}
+
+function test_success_without_callable() {
+  foo > /dev/null 2>&1
+
+  assert_command_not_found
+}
+
+function test_failure() {
+  assert_command_not_found "$(ls > /dev/null 2>&1)"
+}
+```
+:::
+
+## assert_file_exists
+> `assert_file_exists "file"`
+
+Reports an error if `file` does not exists, or it is a directory.
+
+[assert_file_not_exists](#assert-file-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_exists "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  rm -f $file_path
+
+  assert_file_exists "$file_path"
+}
+```
+:::
+
+## assert_is_file
+> `assert_is_file "file"`
+
+Reports an error if `file` is not a file.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local dir_path="bar"
+  mkdir "$dir_path"
+
+  assert_is_file "$dir_path"
+  rmdir "$dir_path"
+}
+```
+:::
+
+## assert_is_file_empty
+> `assert_is_file_empty "file"`
+
+Reports an error if `file` is not empty.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+
+function test_failure() {
+  local file_path="foo.txt"
+  echo "bar" > "$file_path"
+
+  assert_is_file_empty "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_exists
+> `assert_directory_exists "directory"`
+
+Reports an error if `directory` does not exist.
+
+[assert_directory_not_exists](#assert-directory-not-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_directory_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory
+> `assert_is_directory "directory"`
+
+Reports an error if `directory` is not a directory.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory "$directory"
+}
+
+function test_failure() {
+  local file="/etc/hosts"
+
+  assert_is_directory "$file"
+}
+```
+:::
+
+## assert_is_directory_empty
+> `assert_is_directory_empty "directory"`
+
+Reports an error if `directory` is not an empty directory.
+
+[assert_is_directory_not_empty](#assert-is-directory-not-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/etc"
+
+  assert_is_directory_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_readable
+> `assert_is_directory_readable "directory"`
+
+Reports an error if `directory` is not a readable directory.
+
+[assert_is_directory_not_readable](#assert-is-directory-not-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/var"
+
+  assert_is_directory_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_writable
+> `assert_is_directory_writable "directory"`
+
+Reports an error if `directory` is not a writable directory.
+
+[assert_is_directory_not_writable](#assert-is-directory-not-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/tmp"
+
+  assert_is_directory_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_writable "$directory"
+}
+```
+:::
+
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal.
+
+[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
+## assert_not_contains
+> `assert_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is a substring of `haystack`.
+
+[assert_contains](#assert-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_contains "baz" "foobar"
+}
+
+function test_failure() {
+  assert_not_contains "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_starts_with
+> `assert_string_not_starts_with "needle" "haystack"`
+
+Reports an error if `haystack` does starts with `needle`.
+
+[assert_string_starts_with](#assert-string-starts-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_starts_with "bar" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_starts_with "foo" "foobar"
+}
+```
+:::
+
+## assert_string_not_ends_with
+> `assert_string_not_ends_with "needle" "haystack"`
+
+Reports an error if `haystack` does ends with `needle`.
+
+[assert_string_ends_with](#assert-string-ends-with) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_string_not_ends_with "foo" "foobar"
+}
+
+function test_failure() {
+  assert_string_not_ends_with "bar" "foobar"
+}
+```
+:::
+
+## assert_not_empty
+> `assert_not_empty "actual"`
+
+Reports an error if `actual` is empty.
+
+[assert_empty](#assert-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_empty "foo"
+}
+
+function test_failure() {
+  assert_not_empty ""
+}
+```
+:::
+
+## assert_not_matches
+> `assert_not_matches "pattern" "value"`
+
+Reports an error if `value` matches the regular expression `pattern`.
+
+[assert_matches](#assert-matches) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_matches "foo$" "foobar"
+}
+
+function test_failure() {
+  assert_not_matches "bar$" "foobar"
+}
+```
+:::
+
+## assert_array_not_contains
+> `assert_array_not_contains "needle" "haystack"`
+
+Reports an error if `needle` is an element of `haystack`.
+
+[assert_array_contains](#assert-array-contains) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "foobar" "${haystack[@]}"
+}
+
+function test_failure() {
+  local haystack=(foo bar baz)
+
+  assert_array_not_contains "baz" "${haystack[@]}"
+}
+```
+:::
+
+## assert_file_not_exists
+> `assert_file_not_exists "file"`
+
+Reports an error if `file` does exists.
+
+[assert_file_exists](#assert-file-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local file_path="foo.txt"
+  touch "$file_path"
+  rm "$file_path"
+
+  assert_file_not_exists "$file_path"
+}
+
+function test_failed() {
+  local file_path="foo.txt"
+  touch "$file_path"
+
+  assert_file_not_exists "$file_path"
+  rm "$file_path"
+}
+```
+:::
+
+## assert_directory_not_exists
+> `assert_directory_not_exists "directory"`
+
+Reports an error if `directory` exists.
+
+[assert_directory_exists](#assert-directory-exists) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/nonexistent_directory"
+
+  assert_directory_not_exists "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_directory_not_exists "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_empty
+> `assert_is_directory_not_empty "directory"`
+
+Reports an error if `directory` is empty.
+
+[assert_is_directory_empty](#assert-is-directory-empty) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/etc"
+
+  assert_is_directory_not_empty "$directory"
+}
+
+function test_failure() {
+  local directory="/home/user/empty_directory"
+  mkdir "$directory"
+
+  assert_is_directory_not_empty "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_readable
+> `assert_is_directory_not_readable "directory"`
+
+Reports an error if `directory` is readable.
+
+[assert_is_directory_readable](#assert-is-directory-readable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -r "$directory"
+
+  assert_is_directory_not_readable "$directory"
+}
+
+function test_failure() {
+  local directory="/var"
+
+  assert_is_directory_not_readable "$directory"
+}
+```
+:::
+
+## assert_is_directory_not_writable
+> `assert_is_directory_not_writable "directory"`
+
+Reports an error if `directory` is writable.
+
+[assert_is_directory_writable](#assert-is-directory-writable) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local directory="/home/user/test"
+  chmod -w "$directory"
+
+  assert_is_directory_not_writable "$directory"
+}
+
+function test_failure() {
+  local directory="/tmp"
+
+  assert_is_directory_not_writable "$directory"
+}
+```
+:::
+
+## fail
+> `fail "failure message"`
+
+Unambiguously reports an error message. Useful for reporting specific message
+when testing situations not covered by any `assert_*` functions.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  if [ "$(date +%-H)" -gt 25 ]; then
+    fail "Something is very wrong with your clock"
+  fi
+}
+function test_failure() {
+  if [ "$(date +%-H)" -lt 25 ]; then
+    fail "This test will always fail"
+  fi
+}
+```
+:::

--- a/docs/versions/0.13.0/command-line.md
+++ b/docs/versions/0.13.0/command-line.md
@@ -1,0 +1,218 @@
+# Command line
+
+**bashunit** command accepts options to control its behavior. These options will override the environment [configuration](/configuration), which you can use to make the change permanent.
+
+## Directory or file
+
+> `bashunit "directory|file"`
+
+Specifies the `directory` or `file` containing the tests to be run.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+You can use `DEFAULT_PATH` option in your [configuration](/configuration#default-path)
+to choose where the tests are located by default.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+./bashunit ./tests
+
+# concrete test by full path
+./bashunit ./tests/example_test.sh
+
+# all test matching given wildcard
+./bashunit ./tests/**/*_test.sh
+```
+:::
+
+## Assert
+
+> `bashunit -a|--assert function "arg1" "arg2"`
+
+Run a core assert function standalone without a test context. Read more: [Standalone](/standalone)
+
+::: code-group
+```bash [Example]
+./bashunit --assert equals "foo" "bar"
+```
+```[Output]
+✗ Failed: Main::exec assert
+    Expected 'foo'
+    but got 'bar'
+```
+:::
+
+## Debug
+
+> `bashunit --debug`
+
+Enables a shell mode in which all executed commands are printed to the terminal. Printing every command as executed may help you visualize the script's control flow if it is not working as expected.
+
+::: code-group
+```bash [Example]
+./bashunit --debug
+```
+:::
+
+## Environment
+
+> `bashunit -e|--env "file path"`
+
+Loads a custom env file overriding the `.env` environment variables.
+
+::: code-group
+```bash [Example]
+./bashunit tests --env .env.production
+```
+:::
+
+## Filter
+
+> `bashunit -f|--filter "test name"`
+
+Filters the tests to be run based on the `test name`.
+
+::: code-group
+```bash [Example]
+# run all test functions including "something" in it's name
+./bashunit ./tests --filter "something"
+```
+:::
+
+## Logging
+
+> `bashunit -l|--log-junit <out.xml>`
+
+Creates a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --log-junit log-junit.xml
+```
+:::
+
+## Report
+
+> `bashunit -r|--report-html <out.html>`
+
+Creates a report HTML file that contains information about the test results of your bashunit tests.
+
+::: code-group
+```bash [Example]
+./bashunit ./tests --report-html report.html
+```
+:::
+
+## Output
+
+> `bashunit -s|--simple`
+>
+> `bashunit -v|--verbose`
+
+Enables simplified or verbose output to the console.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+This command flag will always take precedence over the environment configuration.
+
+You can use `SIMPLE_OUTPUT` option in your [configuration](/configuration#output)
+to choose the default output display.
+
+::: code-group
+```[Output]
+........
+```
+```bash [Example]
+./bashunit ./tests --simple
+```
+:::
+
+::: code-group
+```[Output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+✓ Passed: Text should contain
+✓ Passed: Text should match a regular expression
+✓ Passed: Text should not contain
+✓ Passed: Text should not match a regular expression
+```
+```bash [Example]
+./bashunit ./tests --verbose
+```
+:::
+
+## Stop on failure
+
+> `bashunit -S|--stop-on-failure`
+
+Force to stop the runner right after encountering one failing test.
+
+You can use `STOP_ON_FAILURE` option in your [configuration](/configuration#stop-on-failure)
+to make this behavior permanent.
+
+::: code-group
+```bash [Example]
+./bashunit --stop-on-failure
+```
+:::
+
+## Version
+
+> `bashunit --version`
+
+Displays the current version of **bashunit**.
+
+::: code-group
+```-vue [Output]
+bashunit - {{ pkg.version }}
+```
+```bash [Example]
+./bashunit --version
+```
+:::
+
+## Upgrade
+
+> `bashunit --upgrade`
+
+Upgrade **bashunit** to latest version.
+
+::: code-group
+```bash [Example]
+./bashunit --upgrade
+```
+:::
+
+## Help
+
+> `bashunit --help`
+
+Displays a help message with all allowed arguments and options.
+
+::: code-group
+```[Output]
+bashunit [arguments] [options]
+
+Arguments:
+  Specifies the directory or file containing [...]
+
+Options:
+  -f|--filter
+    Filters the tests to run based on the test name.
+
+  [...]
+```
+```bash [Example]
+./bashunit --help
+```
+:::
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.13.0/configuration.md
+++ b/docs/versions/0.13.0/configuration.md
@@ -1,0 +1,171 @@
+# Configuration
+
+Environment configuration to control **bashunit** behavior.
+
+It serves to configure the behavior of bashunit in your project.
+You need to create a `.env` file in the root directory,
+but you can give it another name if you pass it as an argument to the command with
+`--env` [option](/command-line#environment).
+
+## Default path
+
+> `DEFAULT_PATH=directory|file`
+
+Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
+
+If a directory is specified, it will execute tests within files ending in `test.sh`.
+
+If you use wildcards, **bashunit** will run any tests it finds.
+
+::: code-group
+```bash [Example]
+# all tests inside the tests directory
+DEFAULT_PATH=tests
+
+# concrete test by full path
+DEFAULT_PATH=tests/example_test.sh
+
+# all test matching given wildcard
+DEFAULT_PATH=tests/**/*_test.sh
+```
+:::
+
+## Output
+
+> `SIMPLE_OUTPUT=true|false`
+
+Enables simplified output to the console. `false` by default.
+
+Verbose is the default output, but it can be overridden by the environment configuration.
+
+Similar as using `-s|--simple|-v|--verbose` option on the [command line](/command-line#output).
+
+::: code-group
+```bash [Simple output]
+....
+```
+```bash [.env]
+SIMPLE_OUTPUT=true
+```
+:::
+
+::: code-group
+```[Verbose output]
+Running tests/functional/logic_test.sh
+✓ Passed: Other way of using the exit code
+✓ Passed: Should validate a non ok exit code
+✓ Passed: Should validate an ok exit code
+✓ Passed: Text should be equal
+```
+```bash [.env]
+SIMPLE_OUTPUT=false
+```
+:::
+
+## Stop on failure
+
+> `STOP_ON_FAILURE=true|false`
+
+Force to stop the runner right after encountering one failing test. `false` by default.
+
+Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#stop-on-failure).
+
+## Show header
+
+> `SHOW_HEADER=true|false`
+>
+> `HEADER_ASCII_ART=true|false`
+
+Specify if you want to show the bashunit header. `true` by default.
+
+Additionally, you can use the env-var `HEADER_ASCII_ART` to display bashunit in ASCII. `false` by default.
+
+::: code-group
+``` [Without header]
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=false
+```
+:::
+
+::: code-group
+```-vue [Plain header]
+bashunit - {{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+```
+:::
+
+::: code-group
+```-vue [ASCII header]
+__               _                   _    // [!code hl]
+| |__   __ _ ___| |__  __ __ ____ (_) |_  // [!code hl]
+| '_ \ / _' / __| '_ \| | | | '_ \| | __| // [!code hl]
+| |_) | (_| \__ \ | | | |_| | | | | | |_  // [!code hl]
+|_.__/ \__,_|___/_| |_|\___/|_| |_|_|\__| // [!code hl]
+{{ pkg.version }} // [!code hl]
+
+✓ Passed: foo bar
+```
+```bash [.env]
+SHOW_HEADER=true
+HEADER_ASCII_ART=true
+```
+:::
+
+## Show execution time
+
+> `SHOW_EXECUTION_TIME=true|false`
+
+Specify if you want to display the execution time after running **bashunit**. `true` by default.
+
+::: warning
+This feature is not available on macOS.
+:::
+
+::: code-group
+```-vue [With execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+Time taken: 14 ms  // [!code hl]
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=true
+```
+:::
+
+::: code-group
+```[Without execution time]
+✓ Passed: foo bar
+
+Tests:      1 passed, 1 total
+Assertions: 3 passed, 3 total
+All tests passed
+```
+```bash [.env]
+SHOW_EXECUTION_TIMER=false
+```
+:::
+
+## Log JUnit
+
+> `LOG_JUNIT=log-junit.xml`
+
+Create a report XML file that follows the JUnit XML format and contains information about the test results of your bashunit tests.
+
+## Report HTML
+
+> `REPORT_HTML=report.html`
+
+Create a report HTML file that contains information about the test results of your bashunit tests.
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.13.0/custom-asserts.md
+++ b/docs/versions/0.13.0/custom-asserts.md
@@ -1,0 +1,34 @@
+# Custom asserts
+
+**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+
+:::tip
+Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
+:::
+
+## assertion_failed
+> `bashunit::assertion_failed <expected> <actual> <failure_condition_message?>`
+
+## assertion_passed
+> `bashunit::assertion_passed`
+
+## Example
+
+```bash
+# Your custom assert using the bashunit facade
+function assert_foo() {
+  local actual="$1"
+
+  if [[ "foo" != "$actual" ]]; then
+    bashunit::assertion_failed "foo" "$actual"
+    return
+  fi
+
+  bashunit::assertion_passed
+}
+
+# Your test using your custom assert
+function test_assert_foo_passed() {
+  assert_foo "foo"
+}
+```

--- a/docs/versions/0.13.0/examples.md
+++ b/docs/versions/0.13.0/examples.md
@@ -1,0 +1,28 @@
+# Examples
+
+## Demo example
+
+**bashunit** includes a sample script and its associated test file in the examples folder of its repository.
+In there, you'll find various tests showcasing the file and different **bashunit** functionalities.
+
+[Take a look](https://github.com/TypedDevs/bashunit/tree/main/example).
+
+## Real examples
+
+If you're interested in real-world examples, below is a list of actual projects that use **bashunit** to test their Bash scripts.
+
+::: info
+If your project utilizes **bashunit**, you can add it to this list by submitting a pull request to us.
+:::
+
+### [TypedDevs/bashunit](https://github.com/TypedDevs/bashunit)
+**bashunit** uses itself to test the proper operation of each one of its features.
+
+### [Chemaclass/conventional-commits](https://github.com/Chemaclass/conventional-commits)
+A specification for adding human and machine-readable meaning to commit messages.
+
+### [Tito-Kati/fizzbuzz-bashunit](https://github.com/Tito-Kati/fizzbuzz-bashunit)
+Popular introductory FizzBuzz kata solved in Bash with **bashunit** as the testing framework.
+
+### [phpctl](https://github.com/opencodeco/phpctl)
+It is a Docker (containers) based development environment for PHP.

--- a/docs/versions/0.13.0/index.md
+++ b/docs/versions/0.13.0/index.md
@@ -1,0 +1,85 @@
+---
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: bashunit
+  text: v0.13.0
+  tagline: Test your bash scripts in the fastest and simplest way, discover the most modern bash testing library.
+  image:
+    src: /logo.svg
+    alt: bashunit
+  actions:
+    - theme: brand
+      text: Quickstart
+      link: /0.13.0/quickstart
+    - theme: alt
+      text: Assertions
+      link: /0.13.0/assertions
+    - theme: alt
+      text: Blog
+      link: /blog/
+
+features:
+  - icon:
+      src: /flexible.svg
+    title: Flexible
+    details: Robust assertions for comparing, matching, and validating results, ensuring thorough testing of your codebase.
+  - icon:
+      src: /accessible.svg
+    title: Accessible
+    details: An intuitive API and clear documentation for a smooth developer experience, reducing testing complexity.
+  - icon:
+      src: /updated.svg
+    title: Updated
+    details: A vibrant GitHub community for support, collaboration, and continuous library enhancement. Join forces with like-minded developers.
+  - icon:
+      src: /multiplatform.svg
+    title: Multiplatform
+    details: Seamlessly operates on Linux, macOS, and Windows (via WSL), facilitating a consistent testing environment across major platforms.
+---
+
+<ProductHuntBanner />
+
+<h2 class="home__award-title">Honors & Awards</h2>
+
+<div class="home__award-container">
+  <a
+    href="https://twitter.com/getmanfred/status/1737191954289487900"
+    target="_blank"
+  >
+    <img
+      src="/awards/manfred-2023.jpg"
+      alt="The Manfred Awards 2023 - bashunit - Side Project of the Year"
+    />
+  </a>
+</div>
+
+<script setup lang="ts">
+import { onMounted } from 'vue';
+import VanillaTilt from 'vanilla-tilt';
+import ProductHuntBanner from "./ProductHuntBanner.vue";
+
+onMounted(() => {
+  const heroImage = document.querySelector('.VPHero .VPImage');
+
+  VanillaTilt.init(heroImage, {
+    'full-page-listening': true,
+    reverse: true,
+    gyroscope: false
+  });
+});
+</script>
+
+<style scoped>
+.home__award-title {
+  text-align: center;
+  margin: 4rem 0;
+  font-size: 2.75rem;
+}
+
+.home__award-container {
+  display: grid;
+  justify-content: center;
+}
+</style>

--- a/docs/versions/0.13.0/installation.md
+++ b/docs/versions/0.13.0/installation.md
@@ -1,0 +1,100 @@
+# Installation
+
+Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
+you can add **bashunit** as a dependency in your repository according to your preferences.
+
+Here, we provide different options that you can use to install **bashunit** in your application.
+
+## install.sh
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+#### Verify
+
+```bash-vue
+# Verify the sha256sum for latest stable: {{ pkg.version }}
+DIR="lib"; KNOWN_HASH="{{pkg.checksum}}"; FILE="$DIR/bashunit"; [ "$(shasum -a 256 "$FILE" | awk '{ print $1 }')" = "$KNOWN_HASH" ] && echo -e "✓ \033[1mbashunit\033[0m verified." || { echo -e "✗ \033[1mbashunit\033[0m corrupt"; rm "$FILE"; }
+```
+
+:::tip
+You can find the checksum for each version inside [GitHub's releases](https://github.com/TypedDevs/bashunit/releases). E.g.:
+```-vue
+https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checksum
+```
+:::
+
+#### Define custom tag and folder
+
+The installation script can receive two optional arguments:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
+```
+- `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default
+
+::: tip
+You can use `beta` as `[version]` to get the next non-stable preview release.
+We try to keep it stable, but there is no promise that we won't change functions or their signatures without prior notice.
+:::
+
+::: tip
+Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
+:::
+
+## GitHub Actions
+
+```yaml
+# example: .github/workflows/bashunit-tests.yml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    name: "Run tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: "Install bashunit"
+        run: "curl -s https://bashunit.typeddevs.com/install.sh"
+
+      - name: "Test"
+        run: "./bashunit tests/**/*_test.sh"
+```
+
+::: tip
+Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+:::
+
+## Brew
+
+You can install **bashunit** globally in your macOS (or Linux) using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
+<script setup>
+import pkg from '../package.json'
+</script>

--- a/docs/versions/0.13.0/parameterized-tests.md
+++ b/docs/versions/0.13.0/parameterized-tests.md
@@ -1,0 +1,101 @@
+# Parameterized tests
+
+**bashunit** offers two ways to parameterize your test functions:
+- **Multi-invokers**: are the most flexible option, as they allow passing multiple arguments to the test function and permit arguments containing whitespace.
+- **Data providers**: offer a simple alternative for cases when the test function needs to accept only a single word as an argument.
+
+---
+
+Both of these are specified using a special comment before the test function declaration. The comment specifies the name of a separate auxiliary bash function which **bashunit** will invoke prior to the test. This auxiliary function will determine how many times the test function will be invoked, and what arguments will be passed to the test function each time.
+
+The benefit of this is that each of these invocations is a full test itself, and can succeed or fail independently of the other tests. Also, [set_up](/test-files#set-up-function) and [tear_down](/test-files#tear-down-function) are called before and after each invocation of the test function. Using these tools can often result in less code repetition in your test files, and a clearer way to develop a suite of closely related tests quickly.
+
+:::tip
+The same multi-invoker or data provider function can be specified for multiple tests. This allows developing tests for related tools quickly. For example, if you had a tool that creates directories and another which removes directories, you could write one test for each tool and parameterize them to operate on the same set of directories.
+:::
+
+### Multi-invokers
+
+A multi-invoker function is specified as follows:
+
+::: code-group
+```bash [Example]
+# multi_invoker invoker_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The invoker function should call the special function `run_test`, passing any arbitrary arguments to that function. **bashunit** will invoke the original test function each time `run_test` is called, passing the corresponding arguments.
+
+::: code-group
+```bash [Example]
+function invoker_with_args() {
+  run_test arg1 arg2
+  run_test "arg1 with spaces" "arg2 with more spaces" "and even arg3"
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  command_we_want_to_test "$@"
+
+  assert_exit_code "0"
+}
+```
+:::
+
+In this example, the `invoker_with_args` will be executed instead of invoking `test_command_with_args` directly. Each time `invoker_with_args` calls `run_test` with some arguments, **bashunit** will call the original test function with those arguments. In this case the test simply verifies that `command_we_want_to_test` can accept these arguments without raising an error, but it could also verify other behaviors of the command. In this next example, we test that a `mkdir_command` we are developing can create a new directory with specified octal permissions.
+
+::: code-group
+```bash [Example]
+function invoker_for_mkdir() {
+  run_test /tmp/dirA 755
+  run_test "/tmp/private dir" 700
+}
+
+# multi_invoker invoker_with_args
+function test_command_with_args() {
+  local directory="$1"
+  local perms="$2"
+
+  assert_directory_not_exists "$directory"
+  mkdir_command "${directory}" --perms "${perms}"
+  assert_directory_exists "$directory"
+  assert_equals "$perm" "$(stat --format %a "$directory")
+}
+```
+:::
+
+### Data providers
+
+A data provider function is specified as follows:
+
+::: code-group
+```bash [Example]
+# data_provider provider_function_name
+function test_my_test_case() {
+  ...
+}
+```
+:::
+
+The provider function can return a space-separated list of values like `one two three` or a single value `one`. In case of a list of values, the test function will be invoked multiple times, each time being passed a different value from the list.
+
+::: code-group
+```bash [Example]
+function provider_directories() {
+  local directories=("/usr" "/etc" "/var")
+  echo "${directories[@]}"
+}
+
+# data_provider provider_directories
+function test_directory_exists_from_data_provider() {
+  local directory=$1
+
+  assert_directory_exists "$directory"
+}
+```
+:::
+
+In this example, the `provider_directories` function will be executed before running the test. **bashunit** will iterate the list of simple strings provided by this function, and the test function will be executed passing each time the current iteration value as the first argument.

--- a/docs/versions/0.13.0/quickstart.md
+++ b/docs/versions/0.13.0/quickstart.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+**bashunit** is a dedicated testing tool crafted specifically for Bash scripts. It empowers you with tests on your Bash codebase, ensuring that your scripts operate reliably and as intended.
+
+With an intuitive API and documentation, it streamlines the process for developers to implement and manage tests. This is beneficial regardless of the project's size or intricacy in Bash.
+
+Thanks to **bashunit**, verifying and validating your Bash code has never been so easy.
+
+## Installation
+
+There is a tool that will generate an executable with the whole library in a single file:
+
+```bash
+curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+This will create a file inside a lib folder, such as `lib/bashunit`.
+
+See more about [installation](/installation).
+
+## Usage
+
+Once **bashunit** is installed, you're ready to get started.
+
+1.  First, create a folder to place your tests:
+    ```bash
+    mkdir tests
+    ```
+
+2.  Next, create your first test file named `example_test.sh` within this folder:
+    ::: code-group
+    ```bash [tests/example_test.sh]
+    #!/bin/bash
+
+    function test_bashunit_is_working() {
+      assert_equals "bashunit is working" "bashunit is working"
+    }
+    ```
+    :::
+
+3.  Finally, run the **bashunit** executable:
+    ```bash
+    ./lib/bashunit ./tests
+    ```
+
+4.  If everything works correctly, you should see an output similar to the following:
+    ```
+    Running tests/example_test.sh
+    ✓ Passed: Bashunit is working
+
+    Tests:      1 passed, 1 total
+    Assertions: 1 passed, 1 total
+    All tests passed
+    Time taken: 100 ms
+    ```
+
+5.  Now you can start testing the functionalities of your own Bash scripts.
+
+## Next steps
+
+Dive deeper into the documentation to discover the options provided by [test files](/test-files),
+[parameterized tests](/parameterized-tests), [test doubles](test-doubles) and [assertions](assertions),
+among many other features.

--- a/docs/versions/0.13.0/skipping-incomplete.md
+++ b/docs/versions/0.13.0/skipping-incomplete.md
@@ -1,0 +1,77 @@
+# Skipping and incomplete tests
+
+There may be various scenarios where the "passed" and "failed" outcomes for a test are not sufficient.
+To address these situations, the following functions are available for your use.
+
+## skip
+> `skip "[reason]"`
+
+Not all tests can be run in every environment; when such situations arise, you can mark a test as skipped.
+
+It reports that the test has been skipped, including the `[reason]` if one was specified.
+
+Skipping tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were skipped in the final output.
+
+::: code-group
+```bash [Example]
+function test_skipped() {
+  if [[ $OS != "GEOS" ]]; then
+    skip
+    return
+  fi
+
+  assert_empty "not reached"
+}
+
+function test_skipped_with_reason() {
+  if [[ $OS != "GEOS" ]]; then
+    skip "Not running under Commodore"
+    return
+  fi
+
+  assert_empty "not reached"
+}
+```
+```[Output]
+↷ Skipped: Skipped
+↷ Skipped: Skipped with reason
+    Not running under Commodore
+
+Tests:      2 skipped, 2 total
+Assertions: 2 skipped, 2 total
+Some tests skipped
+```
+:::
+
+## todo
+> `todo "[pending]"`
+
+You may come up with a test that you'd like to implement later.
+Instead of leaving the test implementation empty —which would mark the test as complete— you can flag it as incomplete.
+
+Reports that the test is incomplete as it is under development, including any `[pending]` to do details if specified.
+
+Incomplete tests will not cause **bashunit** to exit with an error code;
+however, it will indicate that some tests were incomplete in the final output.
+
+::: code-group
+```bash [Example]
+function test_incomplete() {
+  todo
+}
+
+function test_incomplete_with_pending_details() {
+  todo "Detailed description of what needs to be done"
+}
+```
+```[Output]
+✒ Incomplete: Incomplete
+✒ Incomplete: Incomplete with pending details
+    Detailed description of what needs to be done
+
+Tests:      2 incomplete, 2 total
+Assertions: 2 incomplete, 2 total
+Some tests incomplete
+```
+:::

--- a/docs/versions/0.13.0/snapshots.md
+++ b/docs/versions/0.13.0/snapshots.md
@@ -1,0 +1,54 @@
+# Snapshots
+
+Snapshot testing is valuable for verifying the output of commands or scripts over time.
+By capturing and comparing the "snapshot" of the output at different stages,
+you can easily spot unintended changes or regressions.
+This way, it helps maintain the expected behavior while modifications are being made,
+making the verification process more efficient and reliable.
+
+## assert_match_snapshot
+> `assert_match_snapshot "actual"`
+
+Reports an error if `actual` does not match the existing snapshot file associated with the current test function.
+If no such file exists, a new one is created with the provided value.
+
+::: tip
+You can update the snapshot by deleting it and running its test again.
+:::
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot "$(ls)"
+}
+
+function test_failure() {
+  assert_match_snapshot "$(date)"
+}
+```
+```[First run]
+Running snapshot_test.sh
+✎ Snapshot: Success
+✎ Snapshot: Failure
+
+Tests:      2 snapshot, 2 total
+Assertions: 2 snapshot, 2 total
+Some snapshots created
+```
+```[Subsequent runs]
+Running snapshot_test.sh
+✓ Passed: Success
+✗ Failed: Failure
+    Expected to match the snapshot
+    Mon Jul 27 [-13:37:46-]{+13:37:49+} UTC 1987
+
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
+Some tests failed
+```
+:::
+
+::: warning
+You need to run the tests for this example twice to see them work.
+The first time you run them, the snapshots will be generated and the second time they will be asserted.
+:::

--- a/docs/versions/0.13.0/standalone.md
+++ b/docs/versions/0.13.0/standalone.md
@@ -1,0 +1,45 @@
+# Standalone
+
+You can use all bashunit assertions outside any tests if you would like to use them in integration or end-to-end tests, for entire applications or executables.
+
+## Executing an assertion
+
+If you want to use the nice assertions syntax of bashunit - without the tests context/functions, but to end-to-end tests executables, you can use the `-a|--assert` option when running `./bashunit` and call the assertion directly from there.
+
+The return exit code will be:
+- `0` success assertion
+- `1` failed assertion
+- `127` non-existing function
+
+::: info
+The prefix `assert_` is optional.
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a equals "foo" "foo"
+```
+```[Output]
+# No output - exit code 0 (success)
+```
+:::
+
+::: code-group
+```bash [Example]
+# with `assert_` prefix
+./bashunit -a assert_not_equals "foo" "foo"
+
+# or without prefix
+./bashunit -a not_equals "foo" "foo"
+```
+```[Output]
+✗ Failed: Main::exec not_equals
+    Expected 'foo'
+    but got 'foo'
+```
+:::
+

--- a/docs/versions/0.13.0/support.md
+++ b/docs/versions/0.13.0/support.md
@@ -1,0 +1,17 @@
+# Support
+
+If you encounter any issues, require clarification, or wish to suggest improvements, the primary avenue for support is through [our GitHub repository's issue tracking system](https://github.com/TypedDevs/bashunit/issues).
+How to Get Support:
+
+1.  **Navigate to our Issues Page**:
+    Visit the issues section of our repository.
+2.  **Search for Existing Issues**:
+    Before creating a new issue, please search to ensure that your concern hasn't been addressed already.
+3.  **Create a New Issue**:
+    If your concern isn't previously reported, click on the 'New issue' button.
+    Please provide as much detail as possible, including error messages, steps to reproduce, and expected outcomes.
+4.  **Engage Constructively**:
+    When interacting on issues, please be respectful and constructive, understanding that the community aims to help and enhance the tool collaboratively.
+
+We value our community's feedback and aim to address all concerns in a timely and effective manner.
+Your active participation and constructive feedback play a pivotal role in the continuous improvement of **bashunit**.

--- a/docs/versions/0.13.0/test-doubles.md
+++ b/docs/versions/0.13.0/test-doubles.md
@@ -1,0 +1,133 @@
+# Test doubles
+
+When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
+
+## mock
+> `mock "function" "body"`
+
+Allows you to override the behavior of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  mock ps echo hello world
+
+  assert_equals "hello world" "$(ps)"
+}
+```
+:::
+
+> `mock "function" "output"`
+
+Allows you to override the output of a callable.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  function code() {
+    ps a | grep bash
+  }
+
+  mock ps<<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+
+  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+}
+```
+:::
+
+## spy
+> `spy "function"`
+
+Overrides the original behavior of a callable to allow you to make various assertions about its calls.
+
+::: code-group
+```bash [Example]
+function test_example() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called
+> `assert_have_been_called "spy"`
+
+Reports an error if `spy` is not called.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+
+  assert_have_been_called ps
+}
+
+function test_failure() {
+  spy ps
+
+  assert_have_been_called ps
+}
+```
+:::
+
+## assert_have_been_called_with
+> `assert_have_been_called_with "expected" "spy"`
+
+Reports an error if `callable` is not called with `expected`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps foo bar
+
+  assert_have_been_called_with "foo bar" ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps bar foo
+
+  assert_have_been_called_with "foo bar" ps
+}
+```
+:::
+
+## assert_have_been_called_times
+> assert_have_been_called_times "expected" "spy"
+
+Reports an error if `spy` is not called exactly `expected` times.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 2 ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+  ps
+
+  assert_have_been_called_times 1 ps
+}
+```
+:::

--- a/docs/versions/0.13.0/test-files.md
+++ b/docs/versions/0.13.0/test-files.md
@@ -1,0 +1,91 @@
+# Test files
+
+**bashunit** offers a range of features for test files.
+In this section, you'll find information about these features along with some helpful tips.
+
+## Test file names
+
+**bashunit** is flexible about how you name your test files.
+
+You can use a directory name, and bashunit will look for all files (ending with `test.sh`) recursively inside that directory, and execute them.
+
+If you're using wildcards for scanning your tests, keep in mind that the initial search can slow down if you don't filter the test files in the wildcard.
+
+To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh`).
+This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
+
+This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.
+
+## Test function names
+
+**bashunit** will search for and execute all test functions it finds within each test file.
+To distinguish test functions from auxiliary functions, the names must be prefixed with the word `test`.
+The function names are case-insensitive.
+Below are some example test function names that would work seamlessly:
+
+::: code-group
+```bash [Example]
+function test_should_validate_an_ok_exit_code() { ... }
+function testRenderAllTestsPassedWhenNotFailedTests { ... }
+test_getFunctionsToRun_with_filter_should_return_matching_functions() { ... }
+```
+:::
+
+::: tip
+You're free to use any of Bash's syntax options to define these functions.
+:::
+
+## `set_up` function
+
+The `set_up` auxiliary function is called, if it is present in the test file, before each test function in the test file is executed.
+This provides a hook to prepare the environment or set initial variables specific to each test case.
+For example, you might want to create temporary directories or files that your test will manipulate.
+
+::: code-group
+```bash [Example]
+function set_up() {
+  touch temp_file.txt
+}
+```
+:::
+
+## `tear_down` function
+
+The `tear_down` auxiliary function is called, if it is present in the test file, immediately after each test function in the test file is executed.
+This auxiliary function offers you a place to clean up any resources allocated or changes made during the `set_up` or test function itself.
+This helps to ensure that each test starts with a fresh state.
+
+::: code-group
+```bash [Example]
+function tear_down() {
+  rm temp_file.txt
+}
+```
+:::
+
+## `set_up_before_script` function
+
+The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
+This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
+
+::: code-group
+```bash [Example]
+function set_up_before_script() {
+  open_database_connection
+}
+```
+:::
+
+## `tear_down_after_script` function
+
+The `tear_down_after_script` auxiliary function is called, if it is present in the test file, only once when all the test functions in the test file have been executed.
+This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
+It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
+
+::: code-group
+```bash [Example]
+function tear_down_after_script() {
+  close_database_connection
+}
+```
+:::

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "bashunit-docs",
-  "version": "0.10.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bashunit-docs",
-      "version": "0.10.1",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
-        "vanilla-tilt": "^1.8.1"
+        "@types/node": "^20.14.10",
+        "vanilla-tilt": "^1.8.1",
+        "vitepress-versioning-plugin": "^1.1.0"
       },
       "devDependencies": {
         "vitepress": "^1.0.0-rc.44",
@@ -18,8 +20,8 @@
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
         "@algolia/autocomplete-shared": "1.9.3"
@@ -27,8 +29,8 @@
     },
     "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
       "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -38,8 +40,8 @@
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
       "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -50,133 +52,150 @@
     },
     "node_modules/@algolia/autocomplete-shared": {
       "version": "1.9.3",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.24.0.tgz",
+      "integrity": "sha512-t63W9BnoXVrGy9iYHBgObNXqYXM3tYXCjDSHeNwnsc324r4o5UiVKUiAB4THQ5z9U5hTj6qUvwg/Ez43ZD85ww==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.24.0.tgz",
+      "integrity": "sha512-emi+v+DmVLpMGhp0V9q9h5CdkURsNmFC+cOS6uK9ndeJm9J4TiqSvPYVu+THUP8P/S08rxf5x2P+p3CfID0Y4g=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.24.0.tgz",
+      "integrity": "sha512-gDrt2so19jW26jY3/MkFg5mEypFIPbPoXsQGQWAi6TrCPsNOSEYepBMPlucqWigsmEy/prp5ug2jy/N3PVG/8w==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0"
+        "@algolia/cache-common": "4.24.0"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.24.0.tgz",
+      "integrity": "sha512-adcvyJ3KjPZFDybxlqnf+5KgxJtBjwTPTeyG2aOyoJvx0Y8dUQAEOEVOJ/GBxX0WWNbmaSrhDURMhc+QeevDsA==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.24.0.tgz",
+      "integrity": "sha512-y8jOZt1OjwWU4N2qr8G4AxXAzaa8DBvyHTWlHzX/7Me1LX8OayfgHexqrsL4vSBcoMmVw2XnVW9MhL+Y2ZDJXg==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.24.0.tgz",
+      "integrity": "sha512-bc2ROsNL6w6rqpl5jj/UywlIYC21TwSSoFHKl01lYirGMW+9Eek6r02Tocg4gZ8HAw3iBvu6XQiM3BEbmEMoiA==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.24.0.tgz",
+      "integrity": "sha512-l5FRFm/yngztweU0HdUzz1rC4yoWCFo3IF+dVIVTfEPg906eZg5BOd1k0K6rZx5JzyyoP4LdmOikfkfGsKVE9w==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.24.0.tgz",
+      "integrity": "sha512-uRW6EpNapmLAD0mW47OXqTP8eiIx5F6qN9/x/7HHO6owL3N1IXqydGwW5nhDFBrV+ldouro2W1VX3XlcUXEFCA==",
       "dependencies": {
-        "@algolia/client-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/client-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.24.0.tgz",
+      "integrity": "sha512-LLUNjkahj9KtKYrQhFKCzMx0BY3RnNP4FEtO+sBybCjJ73E8jNdaKJ/Dd8A/VA4imVHP5tADZ8pn5B8Ga/wTMA=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.24.0.tgz",
+      "integrity": "sha512-X4C8IoHgHfiUROfoRCV+lzSy+LHMgkoEEU1BbKcsfnV0i0S20zyy0NLww9dwVHUWNfPPxdMU+/wKmLGYf96yTg==",
       "dependencies": {
-        "@algolia/logger-common": "4.20.0"
+        "@algolia/logger-common": "4.24.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.24.0.tgz",
+      "integrity": "sha512-P9kcgerfVBpfYHDfVZDvvdJv0lEoCvzNlOy2nykyt5bK8TyieYyiD0lguIJdRZZYGre03WIAFf14pgE+V+IBlw==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.24.0.tgz",
+      "integrity": "sha512-Z2NxZMb6+nVXSjF13YpjYTdvV3032YTBSGm2vnYvYPA6mMxzM3v5rsCiSspndn9rzIW4Qp1lPHBvuoKJV6jnAA==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.24.0.tgz",
+      "integrity": "sha512-k3CXJ2OVnvgE3HMwcojpvY6d9kgKMPRxs/kVohrwF5WMr2fnqojnycZkxPoEg+bXm8fi5BBfFmOqgYztRtHsQA=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.24.0.tgz",
+      "integrity": "sha512-JF18yTjNOVYvU/L3UosRcvbPMGT9B+/GQWNWnenIImglzNVGpyzChkXLnrSf6uxwVNO6ESGu6oN8MqcGQcjQJw==",
       "dependencies": {
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.24.0.tgz",
+      "integrity": "sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==",
       "dependencies": {
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/requester-common": "4.20.0"
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/requester-common": "4.24.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.24.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.0.tgz",
-      "integrity": "sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==",
-      "dev": true,
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
+      "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -185,27 +204,27 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.5.2",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
+      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
     },
     "node_modules/@docsearch/js": {
-      "version": "3.5.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.6.0.tgz",
+      "integrity": "sha512-QujhqINEElrkIfKwyyyTfbsfMAYCkylInLYMRqHy7PHc8xTBQCow73tlo/Kc7oIwBrCLf0P3YhjlOeV4v8hevQ==",
       "dependencies": {
-        "@docsearch/react": "3.5.2",
+        "@docsearch/react": "3.6.0",
         "preact": "^10.0.0"
       }
     },
     "node_modules/@docsearch/react": {
-      "version": "3.5.2",
-      "dev": true,
-      "license": "MIT",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
+      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.5.2",
+        "@docsearch/css": "3.6.0",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -230,13 +249,12 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.19.12.tgz",
-      "integrity": "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -246,13 +264,12 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.12.tgz",
-      "integrity": "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -262,13 +279,12 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.12.tgz",
-      "integrity": "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -278,13 +294,12 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.12.tgz",
-      "integrity": "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -294,13 +309,12 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.12.tgz",
-      "integrity": "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -310,13 +324,12 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.12.tgz",
-      "integrity": "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -326,13 +339,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.12.tgz",
-      "integrity": "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -342,13 +354,12 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.12.tgz",
-      "integrity": "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -358,13 +369,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.12.tgz",
-      "integrity": "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -374,13 +384,12 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.12.tgz",
-      "integrity": "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -390,13 +399,12 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.12.tgz",
-      "integrity": "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -406,13 +414,12 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.12.tgz",
-      "integrity": "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -422,13 +429,12 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.12.tgz",
-      "integrity": "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -438,13 +444,12 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.12.tgz",
-      "integrity": "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -454,13 +459,12 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.12.tgz",
-      "integrity": "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -470,13 +474,12 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.12.tgz",
-      "integrity": "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -486,13 +489,12 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.12.tgz",
-      "integrity": "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -502,13 +504,12 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -518,13 +519,12 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.12.tgz",
-      "integrity": "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -534,13 +534,12 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.12.tgz",
-      "integrity": "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -550,13 +549,12 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.12.tgz",
-      "integrity": "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -566,13 +564,12 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.12.tgz",
-      "integrity": "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -582,13 +579,12 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.12.tgz",
-      "integrity": "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -598,234 +594,277 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.12.0.tgz",
-      "integrity": "sha512-+ac02NL/2TCKRrJu2wffk1kZ+RyqxVUlbjSagNgPm94frxtr+XDL12E5Ll1enWskLrtrZ2r8L3wED1orIibV/w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.18.1.tgz",
+      "integrity": "sha512-lncuC4aHicncmbORnx+dUaAgzee9cm/PbIqgWz1PpXuwc+sa1Ct83tnqUDy/GFKleLiN7ZIeytM6KJ4cAn1SxA==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.12.0.tgz",
-      "integrity": "sha512-OBqcX2BMe6nvjQ0Nyp7cC90cnumt8PXmO7Dp3gfAju/6YwG0Tj74z1vKrfRz7qAv23nBcYM8BCbhrsWqO7PzQQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.18.1.tgz",
+      "integrity": "sha512-F/tkdw0WSs4ojqz5Ovrw5r9odqzFjb5LIgHdHZG65dFI1lWTWRVy32KDJLKRISHgJvqUeUhdIvy43fX41znyDg==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.12.0.tgz",
-      "integrity": "sha512-X64tZd8dRE/QTrBIEs63kaOBG0b5GVEd3ccoLtyf6IdXtHdh8h+I56C2yC3PtC9Ucnv0CpNFJLqKFVgCYe0lOQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.18.1.tgz",
+      "integrity": "sha512-vk+ma8iC1ebje/ahpxpnrfVQJibTMyHdWpOGZ3JpQ7Mgn/3QNHmPq7YwjZbIE7km73dH5M1e6MRRsnEBW7v5CQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.12.0.tgz",
-      "integrity": "sha512-cc71KUZoVbUJmGP2cOuiZ9HSOP14AzBAThn3OU+9LcA1+IUqswJyR1cAJj3Mg55HbjZP6OLAIscbQsQLrpgTOg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.18.1.tgz",
+      "integrity": "sha512-IgpzXKauRe1Tafcej9STjSSuG0Ghu/xGYH+qG6JwsAUxXrnkvNHcq/NL6nz1+jzvWAnQkuAJ4uIwGB48K9OCGA==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.12.0.tgz",
-      "integrity": "sha512-a6w/Y3hyyO6GlpKL2xJ4IOh/7d+APaqLYdMf86xnczU3nurFTaVN9s9jOXQg97BE4nYm/7Ga51rjec5nfRdrvA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.18.1.tgz",
+      "integrity": "sha512-P9bSiAUnSSM7EmyRK+e5wgpqai86QOSv8BwvkGjLwYuOpaeomiZWifEos517CwbG+aZl1T4clSE1YqqH2JRs+g==",
       "cpu": [
         "arm"
       ],
-      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.18.1.tgz",
+      "integrity": "sha512-5RnjpACoxtS+aWOI1dURKno11d7krfpGDEn19jI8BuWmSBbUC4ytIADfROM1FZrFhQPSoP+KEa3NlEScznBTyQ==",
+      "cpu": [
+        "arm"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.12.0.tgz",
-      "integrity": "sha512-0fZBq27b+D7Ar5CQMofVN8sggOVhEtzFUwOwPppQt0k+VR+7UHMZZY4y+64WJ06XOhBTKXtQB/Sv0NwQMXyNAA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.18.1.tgz",
+      "integrity": "sha512-8mwmGD668m8WaGbthrEYZ9CBmPug2QPGWxhJxh/vCgBjro5o96gL04WLlg5BA233OCWLqERy4YUzX3bJGXaJgQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.12.0.tgz",
-      "integrity": "sha512-eTvzUS3hhhlgeAv6bfigekzWZjaEX9xP9HhxB0Dvrdbkk5w/b+1Sxct2ZuDxNJKzsRStSq1EaEkVSEe7A7ipgQ==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.18.1.tgz",
+      "integrity": "sha512-dJX9u4r4bqInMGOAQoGYdwDP8lQiisWb9et+T84l2WXk41yEej8v2iGKodmdKimT8cTAYt0jFb+UEBxnPkbXEQ==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.18.1.tgz",
+      "integrity": "sha512-V72cXdTl4EI0x6FNmho4D502sy7ed+LuVW6Ym8aI6DRQ9hQZdp5sj0a2usYOlqvFBNKQnLQGwmYnujo2HvjCxQ==",
+      "cpu": [
+        "ppc64"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.12.0.tgz",
-      "integrity": "sha512-ix+qAB9qmrCRiaO71VFfY8rkiAZJL8zQRXveS27HS+pKdjwUfEhqo2+YF2oI+H/22Xsiski+qqwIBxVewLK7sw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.18.1.tgz",
+      "integrity": "sha512-f+pJih7sxoKmbjghrM2RkWo2WHUW8UbfxIQiWo5yeCaCM0TveMEuAzKJte4QskBp1TIinpnRcxkquY+4WuY/tg==",
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.18.1.tgz",
+      "integrity": "sha512-qb1hMMT3Fr/Qz1OKovCuUM11MUNLUuHeBC2DPPAWUYYUAOFWaxInaTwTQmc7Fl5La7DShTEpmYwgdt2hG+4TEg==",
+      "cpu": [
+        "s390x"
+      ],
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.12.0.tgz",
-      "integrity": "sha512-TenQhZVOtw/3qKOPa7d+QgkeM6xY0LtwzR8OplmyL5LrgTWIXpTQg2Q2ycBf8jm+SFW2Wt/DTn1gf7nFp3ssVA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.18.1.tgz",
+      "integrity": "sha512-7O5u/p6oKUFYjRbZkL2FLbwsyoJAjyeXHCU3O4ndvzg2OFO2GinFPSJFGbiwFDaCFc+k7gs9CF243PwdPQFh5g==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.12.0.tgz",
-      "integrity": "sha512-LfFdRhNnW0zdMvdCb5FNuWlls2WbbSridJvxOvYWgSBOYZtgBfW9UGNJG//rwMqTX1xQE9BAodvMH9tAusKDUw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.18.1.tgz",
+      "integrity": "sha512-pDLkYITdYrH/9Cv/Vlj8HppDuLMDUBmgsM0+N+xLtFd18aXgM9Nyqupb/Uw+HeidhfYg2lD6CXvz6CjoVOaKjQ==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.12.0.tgz",
-      "integrity": "sha512-JPDxovheWNp6d7AHCgsUlkuCKvtu3RB55iNEkaQcf0ttsDU/JZF+iQnYcQJSk/7PtT4mjjVG8N1kpwnI9SLYaw==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.18.1.tgz",
+      "integrity": "sha512-W2ZNI323O/8pJdBGil1oCauuCzmVd9lDmWBBqxYZcOqWD6aWqJtVBQ1dFrF4dYpZPks6F+xCZHfzG5hYlSHZ6g==",
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.12.0.tgz",
-      "integrity": "sha512-fjtuvMWRGJn1oZacG8IPnzIV6GF2/XG+h71FKn76OYFqySXInJtseAqdprVTDTyqPxQOG9Exak5/E9Z3+EJ8ZA==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.18.1.tgz",
+      "integrity": "sha512-ELfEX1/+eGZYMaCIbK4jqLxO1gyTSOIlZr6pbC4SRYFaSIDVKOnZNMdoZ+ON0mrFDp4+H5MhwNC1H/AhE3zQLg==",
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.12.0.tgz",
-      "integrity": "sha512-ZYmr5mS2wd4Dew/JjT0Fqi2NPB/ZhZ2VvPp7SmvPZb4Y1CG/LRcS6tcRo2cYU7zLK5A7cdbhWnnWmUjoI4qapg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.18.1.tgz",
+      "integrity": "sha512-yjk2MAkQmoaPYCSu35RLJ62+dz358nE83VfTePJRp8CG7aMg25mEJYpXFiD+NcevhX8LxD5OP5tktPXnXN7GDw==",
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@shikijs/core": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.1.7.tgz",
-      "integrity": "sha512-gTYLUIuD1UbZp/11qozD3fWpUTuMqPSf3svDMMrL0UmlGU7D9dPw/V1FonwAorCUJBltaaESxq90jrSjQyGixg==",
-      "dev": true
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.10.3.tgz",
+      "integrity": "sha512-D45PMaBaeDHxww+EkcDQtDAtzv00Gcsp72ukBtaLSmqRvh0WgGMq3Al0rl1QQBZfuneO75NXMIzEZGFitThWbg==",
+      "dependencies": {
+        "@types/hast": "^3.0.4"
+      }
     },
     "node_modules/@shikijs/transformers": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.1.7.tgz",
-      "integrity": "sha512-lXz011ao4+rvweps/9h3CchBfzb1U5OtP5D51Tqc9lQYdLblWMIxQxH6Ybe1GeGINcEVM4goMyPrI0JvlIp4UQ==",
-      "dev": true,
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.10.3.tgz",
+      "integrity": "sha512-MNjsyye2WHVdxfZUSr5frS97sLGe6G1T+1P41QjyBFJehZphMcr4aBlRLmq6OSPBslYe9byQPVvt/LJCOfxw8Q==",
       "dependencies": {
-        "shiki": "1.1.7"
+        "shiki": "1.10.3"
       }
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/linkify-it": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
-      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.6.tgz",
+      "integrity": "sha512-OpXEVoCKSS3lQqjx9GGGOapBeuW5eUboYHRlHP9urXPX25IKZ6AnP5ZRxtVf63iieUbsHxLn8NQ5Nlftc6yzAA=="
     },
     "node_modules/@types/markdown-it": {
-      "version": "13.0.7",
-      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.7.tgz",
-      "integrity": "sha512-U/CBi2YUUcTHBt5tjO2r5QV/x0Po6nsYwQU4Y04fBS6vfoImaiZ6f8bi3CjTCxBPQSO1LMyUqkByzi8AidyxfA==",
-      "dev": true,
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-4NpsnpYl2Gt1ljyBGrKMxFYAYvpqbnnkgP/i/g+NLpjEUa3obn1XJCur9YbEXKDAkaXqsR1LbDnGEJ0MmKFxfg==",
       "dependencies": {
-        "@types/linkify-it": "*",
-        "@types/mdurl": "*"
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
       }
     },
     "node_modules/@types/mdurl": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
-      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==",
-      "dev": true
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
+      "integrity": "sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ=="
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
-      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-      "dev": true
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="
     },
     "node_modules/@vitejs/plugin-vue": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.4.tgz",
-      "integrity": "sha512-WS3hevEszI6CEVEx28F8RjTX97k3KsrcY6kvTg7+Whm5y3oYvcqzVeGCU3hxSAn4uY2CLCkeokkGKpoctccilQ==",
-      "dev": true,
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.0.5.tgz",
+      "integrity": "sha512-LOjm7XeIimLBZyzinBQ6OSm3UBCNVCpLkxGC0oWmm2YPzVZoxMsdvNVimLTBzpAnR9hl/yn1SHGuRfe6/Td9rQ==",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       },
@@ -835,158 +874,144 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.21.tgz",
-      "integrity": "sha512-MjXawxZf2SbZszLPYxaFCjxfibYrzr3eYbKxwpLR9EQN+oaziSu3qKVbwBERj1IFIB8OLUewxB5m/BFzi613og==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.31.tgz",
+      "integrity": "sha512-skOiodXWTV3DxfDhB4rOf3OGalpITLlgCeOwb+Y9GJpfQ8ErigdBUHomBzvG78JoVE8MJoQsb+qhZiHfKeNeEg==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.7",
+        "@vue/shared": "3.4.31",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.0.2"
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.21.tgz",
-      "integrity": "sha512-IZC6FKowtT1sl0CR5DpXSiEB5ayw75oT2bma1BEhV7RRR1+cfwLrxc2Z8Zq/RGFzJ8w5r9QtCOvTjQgdn0IKmA==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.31.tgz",
+      "integrity": "sha512-wK424WMXsG1IGMyDGyLqB+TbmEBFM78hIsOJ9QwUVLGrcSk0ak6zYty7Pj8ftm7nEtdU/DGQxAXp0/lM/2cEpQ==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-core": "3.4.31",
+        "@vue/shared": "3.4.31"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.21.tgz",
-      "integrity": "sha512-me7epoTxYlY+2CUM7hy9PCDdpMPfIwrOvAXud2Upk10g4YLv9UBW7kL798TvMeDhPthkZ0CONNrK2GoeI1ODiQ==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.31.tgz",
+      "integrity": "sha512-einJxqEw8IIJxzmnxmJBuK2usI+lJonl53foq+9etB2HAzlPjAS/wa7r0uUpXw5ByX3/0uswVSrjNb17vJm1kQ==",
       "dependencies": {
-        "@babel/parser": "^7.23.9",
-        "@vue/compiler-core": "3.4.21",
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@babel/parser": "^7.24.7",
+        "@vue/compiler-core": "3.4.31",
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/compiler-ssr": "3.4.31",
+        "@vue/shared": "3.4.31",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.7",
-        "postcss": "^8.4.35",
-        "source-map-js": "^1.0.2"
+        "magic-string": "^0.30.10",
+        "postcss": "^8.4.38",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.21.tgz",
-      "integrity": "sha512-M5+9nI2lPpAsgXOGQobnIueVqc9sisBFexh5yMIMRAPYLa7+5wEJs8iqOZc1WAa9WQbx9GR2twgznU8LTIiZ4Q==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.31.tgz",
+      "integrity": "sha512-RtefmITAje3fJ8FSg1gwgDhdKhZVntIVbwupdyZDSifZTRMiWxWehAOTCc8/KZDnBOcYQ4/9VWxsTbd3wT0hAA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/shared": "3.4.31"
       }
     },
     "node_modules/@vue/devtools-api": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.0.16.tgz",
-      "integrity": "sha512-fZG2CG8624qphMf4aj59zNHckMx1G3lxODUuyM9USKuLznXCh66TP+tEbPOCcml16hA0GizJ4D8w6F34hrfbcw==",
-      "dev": true,
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.3.6.tgz",
+      "integrity": "sha512-z6cKyxdXrIGgA++eyGBfquj6dCplRdgjt+I18fJx8hjWTXDTIyeQvryyEBMchnfZVyvUTjK3QjGjDpLCnJxPjw==",
       "dependencies": {
-        "@vue/devtools-kit": "^7.0.16"
+        "@vue/devtools-kit": "^7.3.6"
       }
     },
     "node_modules/@vue/devtools-kit": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.0.16.tgz",
-      "integrity": "sha512-IA8SSGiZbNgOi4wLT3mRvd71Q9KE0KvMfGk6haa2GZ6bL2K/xMA8Fvvj3o1maspfUXrGcCXutaqbLqbGx/espQ==",
-      "dev": true,
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.3.6.tgz",
+      "integrity": "sha512-5Ym9V3fkJenEoptqKoo+cgY5RTVwrSssFdzRsuyIgaeiskCT+rRJeQdwoo81tyrQ1mfS7Er1rYZlSzr3Y3L/ew==",
       "dependencies": {
-        "@vue/devtools-shared": "^7.0.16",
+        "@vue/devtools-shared": "^7.3.6",
+        "birpc": "^0.2.17",
         "hookable": "^5.5.3",
         "mitt": "^3.0.1",
         "perfect-debounce": "^1.0.0",
-        "speakingurl": "^14.0.1"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.1"
       }
     },
     "node_modules/@vue/devtools-shared": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.0.16.tgz",
-      "integrity": "sha512-Lew4FrGjDjmanaUWSueNE1Rre83k7jQpttc17MaoVw0eARWU5DgZ1F/g9GNUMZXVjbP9rwE+LL3gd9XfXCfkvA==",
-      "dev": true,
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.3.6.tgz",
+      "integrity": "sha512-R/FOmdJV+hhuwcNoxp6e87RRkEeDMVhWH+nOsnHUrwjjsyeXJ2W1475Ozmw+cbZhejWQzftkHVKO28Fuo1yqCw==",
       "dependencies": {
-        "rfdc": "^1.3.1"
+        "rfdc": "^1.4.1"
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.21.tgz",
-      "integrity": "sha512-UhenImdc0L0/4ahGCyEzc/pZNwVgcglGy9HVzJ1Bq2Mm9qXOpP8RyNTjookw/gOCUlXSEtuZ2fUg5nrHcoqJcw==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.31.tgz",
+      "integrity": "sha512-VGkTani8SOoVkZNds1PfJ/T1SlAIOf8E58PGAhIOUDYPC4GAmFA2u/E14TDAFcf3vVDKunc4QqCe/SHr8xC65Q==",
       "dependencies": {
-        "@vue/shared": "3.4.21"
+        "@vue/shared": "3.4.31"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.21.tgz",
-      "integrity": "sha512-pQthsuYzE1XcGZznTKn73G0s14eCJcjaLvp3/DKeYWoFacD9glJoqlNBxt3W2c5S40t6CCcpPf+jG01N3ULyrA==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.31.tgz",
+      "integrity": "sha512-LDkztxeUPazxG/p8c5JDDKPfkCDBkkiNLVNf7XZIUnJ+66GVGkP+TIh34+8LtPisZ+HMWl2zqhIw0xN5MwU1cw==",
       "dependencies": {
-        "@vue/reactivity": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/reactivity": "3.4.31",
+        "@vue/shared": "3.4.31"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.21.tgz",
-      "integrity": "sha512-gvf+C9cFpevsQxbkRBS1NpU8CqxKw0ebqMvLwcGQrNpx6gqRDodqKqA+A2VZZpQ9RpK2f9yfg8VbW/EpdFUOJw==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.31.tgz",
+      "integrity": "sha512-2Auws3mB7+lHhTFCg8E9ZWopA6Q6L455EcU7bzcQ4x6Dn4cCPuqj6S2oBZgN2a8vJRS/LSYYxwFFq2Hlx3Fsaw==",
       "dependencies": {
-        "@vue/runtime-core": "3.4.21",
-        "@vue/shared": "3.4.21",
+        "@vue/reactivity": "3.4.31",
+        "@vue/runtime-core": "3.4.31",
+        "@vue/shared": "3.4.31",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.21.tgz",
-      "integrity": "sha512-aV1gXyKSN6Rz+6kZ6kr5+Ll14YzmIbeuWe7ryJl5muJ4uwSwY/aStXTixx76TwkZFJLm1aAlA/HSWEJ4EyiMkg==",
-      "dev": true,
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.31.tgz",
+      "integrity": "sha512-D5BLbdvrlR9PE3by9GaUp1gQXlCNadIZytMIb8H2h3FMWJd4oUfkUTEH2wAr3qxoRz25uxbTcbqd3WKlm9EHQA==",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@vue/compiler-ssr": "3.4.31",
+        "@vue/shared": "3.4.31"
       },
       "peerDependencies": {
-        "vue": "3.4.21"
+        "vue": "3.4.31"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.21.tgz",
-      "integrity": "sha512-PuJe7vDIi6VYSinuEbUIQgMIRZGgM8e4R+G+/dQTk0X1NEdvgvvgv7m+rfmDH1gZzyA1OjjoWskvHlfRNfQf3g==",
-      "dev": true
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.31.tgz",
+      "integrity": "sha512-Yp3wtJk//8cO4NItOPpi3QkLExAr/aLBGZMmTtW9WpdwBCJpRM6zj9WgWktXAl8IDIozwNMByT45JP3tO3ACWA=="
     },
     "node_modules/@vueuse/core": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.9.0.tgz",
-      "integrity": "sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==",
-      "dev": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.11.0.tgz",
+      "integrity": "sha512-x3sD4Mkm7PJ+pcq3HX8PLPBadXCAlSDR/waK87dz0gQE+qJnaaFhc/dZVfJz+IUYzTMVGum2QlR7ImiJQN4s6g==",
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20",
-        "@vueuse/metadata": "10.9.0",
-        "@vueuse/shared": "10.9.0",
-        "vue-demi": ">=0.14.7"
+        "@vueuse/metadata": "10.11.0",
+        "@vueuse/shared": "10.11.0",
+        "vue-demi": ">=0.14.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/core/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -1009,31 +1034,30 @@
       }
     },
     "node_modules/@vueuse/integrations": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.9.0.tgz",
-      "integrity": "sha512-acK+A01AYdWSvL4BZmCoJAcyHJ6EqhmkQEXbQLwev1MY7NBnS+hcEMx/BzVoR9zKI+UqEPMD9u6PsyAuiTRT4Q==",
-      "dev": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-10.11.0.tgz",
+      "integrity": "sha512-Pp6MtWEIr+NDOccWd8j59Kpjy5YDXogXI61Kb1JxvSfVBO8NzFQkmrKmSZz47i+ZqHnIzxaT38L358yDHTncZg==",
       "dependencies": {
-        "@vueuse/core": "10.9.0",
-        "@vueuse/shared": "10.9.0",
-        "vue-demi": ">=0.14.7"
+        "@vueuse/core": "10.11.0",
+        "@vueuse/shared": "10.11.0",
+        "vue-demi": ">=0.14.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "async-validator": "*",
-        "axios": "*",
-        "change-case": "*",
-        "drauu": "*",
-        "focus-trap": "*",
-        "fuse.js": "*",
-        "idb-keyval": "*",
-        "jwt-decode": "*",
-        "nprogress": "*",
-        "qrcode": "*",
-        "sortablejs": "*",
-        "universal-cookie": "*"
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^4",
+        "drauu": "^0.3",
+        "focus-trap": "^7",
+        "fuse.js": "^6",
+        "idb-keyval": "^6",
+        "jwt-decode": "^3",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^6"
       },
       "peerDependenciesMeta": {
         "async-validator": {
@@ -1075,10 +1099,9 @@
       }
     },
     "node_modules/@vueuse/integrations/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -1101,31 +1124,28 @@
       }
     },
     "node_modules/@vueuse/metadata": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.9.0.tgz",
-      "integrity": "sha512-iddNbg3yZM0X7qFY2sAotomgdHK7YJ6sKUvQqbvwnf7TmaVPxS4EJydcNsVejNdS8iWCtDk+fYXr7E32nyTnGA==",
-      "dev": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.11.0.tgz",
+      "integrity": "sha512-kQX7l6l8dVWNqlqyN3ePW3KmjCQO3ZMgXuBMddIu83CmucrsBfXlH+JoviYyRBws/yLTQO8g3Pbw+bdIoVm4oQ==",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.9.0.tgz",
-      "integrity": "sha512-Uud2IWncmAfJvRaFYzv5OHDli+FbOzxiVEQdLCKQKLyhz94PIyFC3CHcH7EDMwIn8NPtD06+PNbC/PiO0LGLtw==",
-      "dev": true,
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.11.0.tgz",
+      "integrity": "sha512-fyNoIXEq3PfX1L3NkNhtVQUSRtqYwJtJg+Bp9rIzculIZWHTkKSysujrOk2J+NrRulLTQH9+3gGSfYLWSEWU1A==",
       "dependencies": {
-        "vue-demi": ">=0.14.7"
+        "vue-demi": ">=0.14.8"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@vueuse/shared/node_modules/vue-demi": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
-      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
-      "dev": true,
+      "version": "0.14.8",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.8.tgz",
+      "integrity": "sha512-Uuqnk9YE9SsWeReYqK2alDI5YzciATE0r2SkA6iMAtuXvNTMNACJLJEXNXaEy94ECuBe4Sk6RzRU80kjdbIo1Q==",
       "hasInstallScript": true,
       "bin": {
         "vue-demi-fix": "bin/vue-demi-fix.js",
@@ -1148,37 +1168,85 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.20.0",
-      "dev": true,
-      "license": "MIT",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.24.0.tgz",
+      "integrity": "sha512-bf0QV/9jVejssFBmz2HQLxUadxk574t4iwjCKp5E7NBzwKkrDEhKPISIIjAU/p6K5qDx3qoeh4+26zWN1jmw3g==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.20.0",
-        "@algolia/cache-common": "4.20.0",
-        "@algolia/cache-in-memory": "4.20.0",
-        "@algolia/client-account": "4.20.0",
-        "@algolia/client-analytics": "4.20.0",
-        "@algolia/client-common": "4.20.0",
-        "@algolia/client-personalization": "4.20.0",
-        "@algolia/client-search": "4.20.0",
-        "@algolia/logger-common": "4.20.0",
-        "@algolia/logger-console": "4.20.0",
-        "@algolia/requester-browser-xhr": "4.20.0",
-        "@algolia/requester-common": "4.20.0",
-        "@algolia/requester-node-http": "4.20.0",
-        "@algolia/transporter": "4.20.0"
+        "@algolia/cache-browser-local-storage": "4.24.0",
+        "@algolia/cache-common": "4.24.0",
+        "@algolia/cache-in-memory": "4.24.0",
+        "@algolia/client-account": "4.24.0",
+        "@algolia/client-analytics": "4.24.0",
+        "@algolia/client-common": "4.24.0",
+        "@algolia/client-personalization": "4.24.0",
+        "@algolia/client-search": "4.24.0",
+        "@algolia/logger-common": "4.24.0",
+        "@algolia/logger-console": "4.24.0",
+        "@algolia/recommend": "4.24.0",
+        "@algolia/requester-browser-xhr": "4.24.0",
+        "@algolia/requester-common": "4.24.0",
+        "@algolia/requester-node-http": "4.24.0",
+        "@algolia/transporter": "4.24.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-0.2.17.tgz",
+      "integrity": "sha512-+hkTxhot+dWsLpp3gia5AkVHIsKlZybNT5gIYiDlNzJrmYPcTM9k5/w2uaj3IPpd7LlEYpmCj4Jj1nC41VhDFg==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/cli-color": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.4.tgz",
+      "integrity": "sha512-zlnpg0jNcibNrO7GG9IeHH7maWFeCz+Ja1wx/7tZNU5ASSSSZ+/qZciM0/LHCYxSdqv5h2sdbQ/PXYdOuetXvA==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.64",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
+      "dependencies": {
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
       }
     },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -1186,11 +1254,58 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dependencies": {
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
+    },
     "node_modules/esbuild": {
-      "version": "0.19.12",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
-      "integrity": "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==",
-      "dev": true,
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -1199,42 +1314,71 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.19.12",
-        "@esbuild/android-arm": "0.19.12",
-        "@esbuild/android-arm64": "0.19.12",
-        "@esbuild/android-x64": "0.19.12",
-        "@esbuild/darwin-arm64": "0.19.12",
-        "@esbuild/darwin-x64": "0.19.12",
-        "@esbuild/freebsd-arm64": "0.19.12",
-        "@esbuild/freebsd-x64": "0.19.12",
-        "@esbuild/linux-arm": "0.19.12",
-        "@esbuild/linux-arm64": "0.19.12",
-        "@esbuild/linux-ia32": "0.19.12",
-        "@esbuild/linux-loong64": "0.19.12",
-        "@esbuild/linux-mips64el": "0.19.12",
-        "@esbuild/linux-ppc64": "0.19.12",
-        "@esbuild/linux-riscv64": "0.19.12",
-        "@esbuild/linux-s390x": "0.19.12",
-        "@esbuild/linux-x64": "0.19.12",
-        "@esbuild/netbsd-x64": "0.19.12",
-        "@esbuild/openbsd-x64": "0.19.12",
-        "@esbuild/sunos-x64": "0.19.12",
-        "@esbuild/win32-arm64": "0.19.12",
-        "@esbuild/win32-ia32": "0.19.12",
-        "@esbuild/win32-x64": "0.19.12"
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
     },
     "node_modules/focus-trap": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
       "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
-      "dev": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -1243,7 +1387,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1256,43 +1399,92 @@
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
-      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
-      "dev": true
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="
     },
-    "node_modules/magic-string": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.7.tgz",
-      "integrity": "sha512-8vBuFF/I/+OSLRmdf2wwFCJCz+nSn0m6DPvGH1fS/KiQoSaR+sETbov0eIk9KhEKy8CYqIkIAnbohxT/4H0kuA==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "node_modules/is-what": {
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.10",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
+      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+      "integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+      "dependencies": {
+        "d": "^1.0.2",
+        "es5-ext": "^0.10.64",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
     },
     "node_modules/minisearch": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-6.3.0.tgz",
-      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ==",
-      "dev": true
+      "integrity": "sha512-ihFnidEeU8iXzcVHy74dhkxh/dn8Dc08ERl0xwoMMGqp4+LvRSCgicb+zGqWthVokQKvCSxITlh3P08OzdTYCQ=="
     },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
-      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "dev": true
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
       "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1306,23 +1498,25 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+    },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
-      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
-      "dev": true
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/postcss": {
-      "version": "8.4.35",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-      "integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
-      "dev": true,
+      "version": "8.4.39",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.39.tgz",
+      "integrity": "sha512-0vzE+lAiG7hZl1/9I8yzKLx3aR9Xbof3fBHKunvMfOCYAtMhrsnccJY2iTURb9EZd5+pLuiNV9/c/GZJOHsgIw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1339,33 +1533,31 @@
       ],
       "dependencies": {
         "nanoid": "^3.3.7",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/preact": {
-      "version": "10.18.1",
-      "dev": true,
-      "license": "MIT",
+      "version": "10.22.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.1.tgz",
+      "integrity": "sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/rfdc": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.1.tgz",
-      "integrity": "sha512-r5a3l5HzYlIC68TpmYKlxWjmOP6wiPJ1vWv2HeLhNsRZMrCkxeqxiHlQ21oXmQ4F3SiryXBHhAD7JZqvOJjFmg==",
-      "dev": true
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rollup": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.12.0.tgz",
-      "integrity": "sha512-wz66wn4t1OHIJw3+XU7mJJQV/2NAfw5OAk6G6Hoo3zcvz/XOfQ52Vgi+AN4Uxoxi0KBBwk2g8zPrTDA4btSB/Q==",
-      "dev": true,
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.18.1.tgz",
+      "integrity": "sha512-Elx2UT8lzxxOXMpy5HWQGZqkrQOtrVDDa/bm9l10+U4rQnVzbL/LgZ4NOM1MPIDyHk69W4InuYDF5dzRh4Kw1A==",
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -1377,43 +1569,44 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.12.0",
-        "@rollup/rollup-android-arm64": "4.12.0",
-        "@rollup/rollup-darwin-arm64": "4.12.0",
-        "@rollup/rollup-darwin-x64": "4.12.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.12.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.12.0",
-        "@rollup/rollup-linux-arm64-musl": "4.12.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-gnu": "4.12.0",
-        "@rollup/rollup-linux-x64-musl": "4.12.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.12.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.12.0",
-        "@rollup/rollup-win32-x64-msvc": "4.12.0",
+        "@rollup/rollup-android-arm-eabi": "4.18.1",
+        "@rollup/rollup-android-arm64": "4.18.1",
+        "@rollup/rollup-darwin-arm64": "4.18.1",
+        "@rollup/rollup-darwin-x64": "4.18.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.18.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.18.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.18.1",
+        "@rollup/rollup-linux-arm64-musl": "4.18.1",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.18.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.18.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.18.1",
+        "@rollup/rollup-linux-x64-gnu": "4.18.1",
+        "@rollup/rollup-linux-x64-musl": "4.18.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.18.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.18.1",
+        "@rollup/rollup-win32-x64-msvc": "4.18.1",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/search-insights": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
-      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
-      "dev": true,
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.15.0.tgz",
+      "integrity": "sha512-ch2sPCUDD4sbPQdknVl9ALSi9H7VyoeVbsxznYz6QV55jJ8CI3EtwpO1i84keN4+hF5IeHWIeGvc08530JkVXQ==",
       "peer": true
     },
     "node_modules/shiki": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.1.7.tgz",
-      "integrity": "sha512-9kUTMjZtcPH3i7vHunA6EraTPpPOITYTdA5uMrvsJRexktqP0s7P3s9HVK80b4pP42FRVe03D7fT3NmJv2yYhw==",
-      "dev": true,
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.10.3.tgz",
+      "integrity": "sha512-eneCLncGuvPdTutJuLyUGS8QNPAVFO5Trvld2wgEq1e002mwctAhJKeMGWtWVXOIEzmlcLRqcgPSorR6AVzOmQ==",
       "dependencies": {
-        "@shikijs/core": "1.1.7"
+        "@shikijs/core": "1.10.3",
+        "@types/hast": "^3.0.4"
       }
     },
     "node_modules/source-map-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1422,30 +1615,60 @@
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
       "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.1.tgz",
+      "integrity": "sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==",
+      "dependencies": {
+        "copy-anything": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "dev": true
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/vanilla-tilt": {
       "version": "1.8.1",
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.1.4.tgz",
-      "integrity": "sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==",
-      "dev": true,
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.3.tgz",
+      "integrity": "sha512-NPQdeCU0Dv2z5fu+ULotpuq5yfCS1BzKUIPhNbP3YBfAMGJXbt2nS+sbTFu+qchaqWTD+H3JK++nRwr6XIcp6A==",
       "dependencies": {
-        "esbuild": "^0.19.3",
-        "postcss": "^8.4.35",
-        "rollup": "^4.2.0"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.39",
+        "rollup": "^4.13.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1493,33 +1716,33 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.44",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.44.tgz",
-      "integrity": "sha512-tO5taxGI7fSpBK1D8zrZTyJJERlyU9nnt0jHSt3fywfq3VKn977Hg0wUuTkEmwXlFYwuW26+6+3xorf4nD3XvA==",
-      "dev": true,
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.2.3.tgz",
+      "integrity": "sha512-GvEsrEeNLiDE1+fuwDAYJCYLNZDAna+EtnXlPajhv/MYeTjbNK6Bvyg6NoTdO1sbwuQJ0vuJR99bOlH53bo6lg==",
       "dependencies": {
-        "@docsearch/css": "^3.5.2",
-        "@docsearch/js": "^3.5.2",
-        "@shikijs/core": "^1.1.5",
-        "@shikijs/transformers": "^1.1.5",
-        "@types/markdown-it": "^13.0.7",
-        "@vitejs/plugin-vue": "^5.0.4",
-        "@vue/devtools-api": "^7.0.14",
-        "@vueuse/core": "^10.7.2",
-        "@vueuse/integrations": "^10.7.2",
+        "@docsearch/css": "^3.6.0",
+        "@docsearch/js": "^3.6.0",
+        "@shikijs/core": "^1.6.2",
+        "@shikijs/transformers": "^1.6.2",
+        "@types/markdown-it": "^14.1.1",
+        "@vitejs/plugin-vue": "^5.0.5",
+        "@vue/devtools-api": "^7.2.1",
+        "@vue/shared": "^3.4.27",
+        "@vueuse/core": "^10.10.0",
+        "@vueuse/integrations": "^10.10.0",
         "focus-trap": "^7.5.4",
         "mark.js": "8.11.1",
         "minisearch": "^6.3.0",
-        "shiki": "^1.1.5",
-        "vite": "^5.1.3",
-        "vue": "^3.4.19"
+        "shiki": "^1.6.2",
+        "vite": "^5.2.12",
+        "vue": "^3.4.27"
       },
       "bin": {
         "vitepress": "bin/vitepress.js"
       },
       "peerDependencies": {
-        "markdown-it-mathjax3": "^4.3.2",
-        "postcss": "^8.4.35"
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
       },
       "peerDependenciesMeta": {
         "markdown-it-mathjax3": {
@@ -1530,17 +1753,29 @@
         }
       }
     },
-    "node_modules/vue": {
-      "version": "3.4.21",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.21.tgz",
-      "integrity": "sha512-5hjyV/jLEIKD/jYl4cavMcnzKwjMKohureP8ejn3hhEjwhWIhWeuzL2kJAjzl/WyVsgPY56Sy4Z40C3lVshxXA==",
-      "dev": true,
+    "node_modules/vitepress-versioning-plugin": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vitepress-versioning-plugin/-/vitepress-versioning-plugin-1.1.0.tgz",
+      "integrity": "sha512-tstqH/lpdqDsjU1Lq0tffcVetbQ0ETDB2SLTfIcZnMX6xXbU0/dCxC36ZuPM2++y4iU7ZO2D9Uu/4z0DenE6SA==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.21",
-        "@vue/compiler-sfc": "3.4.21",
-        "@vue/runtime-dom": "3.4.21",
-        "@vue/server-renderer": "3.4.21",
-        "@vue/shared": "3.4.21"
+        "@types/lodash": "^4.17.5",
+        "cli-color": "^2.0.4",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.21",
+        "vite": "^5.3.1",
+        "vitepress": "1.2.3"
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.4.31",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.31.tgz",
+      "integrity": "sha512-njqRrOy7W3YLAlVqSKpBebtZpDVg21FPoaq1I7f/+qqBThK9ChAIjkRWgeP6Eat+8C+iia4P3OYqpATP21BCoQ==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.4.31",
+        "@vue/compiler-sfc": "3.4.31",
+        "@vue/runtime-dom": "3.4.31",
+        "@vue/server-renderer": "3.4.31",
+        "@vue/shared": "3.4.31"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "docs:preview": "vitepress preview docs"
   },
   "dependencies": {
-    "vanilla-tilt": "^1.8.1"
+    "@types/node": "^20.14.10",
+    "vanilla-tilt": "^1.8.1",
+    "vitepress-versioning-plugin": "^1.1.0"
   },
   "devDependencies": {
     "vitepress": "^1.0.0-rc.44",


### PR DESCRIPTION
## 📚 Description

Implements multiple versions to bashunit.

This will help the users to see which specific functionalities are available on the specific version they are using.

I am using the following external library: https://github.com/IMB11/vitepress-versioning-plugin/tree/master
Whose documentation is: https://vvp.imb11.dev/

## 🔖 Changes

Add a new button on top to let the users pick the desired version

<img width="806" alt="image" src="https://github.com/user-attachments/assets/3e888b53-c643-4bfc-94eb-18f5c4f1a5a7">

## Caveats

- [ ] Show the elements in the sidebar (not sure how to do it at the moment)
- [ ] Store the current version in a variable, then, when we click on the logo, we will go to `home/{version}`
  - right now, when you press the logo, you go to `home` independently the version you were before
- [ ] If you typed some URL (eg: `home/asserts`), redirect to the latest version (eg: `home/0.14.0/asserts`)
- [ ] Mark the currently selected version as `green` in the dropdown when we are not on the homepage (eg: if we go to `/x.xx.xx/asserts`, the version is not selected anymore)
<img width="845" alt="image" src="https://github.com/user-attachments/assets/a93fd95e-47fb-4f37-a650-5b7908e89fed">
