### PR TITLE
fix: Double `/` on Running script #293 using bash parameter expansion

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -86,7 +86,8 @@ function helper::unset_if_exists() {
 }
 
 function helper::find_files_recursive() {
-  local path="$1"
+  ## Remove trailing slash using parameter expansion
+  local path="${1%%/}"
 
   if [[ "$path" == *"*"* ]]; then
     eval find "$path" -type f -name '*[tT]est.sh' | sort | uniq


### PR DESCRIPTION
## 📚 Description

fixes #293 

## 🔖 Changes

- Introduce bash parameter expansion to remove trailing slash from the directories path if explicitly added in the values of the arguments.

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes

## Additional Notes For Reviewer 

- Passed explicit `/` in the argument input.
```bash
─$ ./bin/bashunit example/                                            
bashunit - 0.14.1
Running example/custom_functions_test.sh
✓ Passed: Say hi Alice
✓ Passed: Say hi Bob
Running example/script_logic_test.sh
✓ Passed: Script 123
✓ Passed: Script 456

Tests:      4 passed, 4 total
Assertions: 4 passed, 4 total

 All tests passed 
Time taken: 498 ms
```