### PR TITLE
Add assertions to log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.14.0...main)
 
-- Nothing yet...
+- Add assertions to log file
 
 ## [0.14.0](https://github.com/TypedDevs/bashunit/compare/0.13.0...0.14.0) - 2024-07-14
 

--- a/src/logger.sh
+++ b/src/logger.sh
@@ -39,7 +39,7 @@ function logger::log() {
   TEST_FILES+=("$file")
   TEST_NAMES+=("$test_name")
   TEST_STATUSES+=("$status")
-  TEST_ASSERTIONS+=("assertions")
+  TEST_ASSERTIONS+=("$assertions")
   TEST_DURATIONS+=("$duration")
 }
 

--- a/src/logger.sh
+++ b/src/logger.sh
@@ -1,34 +1,36 @@
 #!/bin/bash
 
+TEST_FILES=()
 TEST_NAMES=()
 TEST_STATUSES=()
 TEST_DURATIONS=()
 
 function logger::test_snapshot() {
-  logger::log "$1" "$2" "$3" "snapshot"
+  logger::log "$1" "$2" "$3" "$4" "snapshot"
 }
 
 function logger::test_incomplete() {
-  logger::log "$1" "$2" "$3" "incomplete"
+  logger::log "$1" "$2" "$3" "$4" "incomplete"
 }
 
 function logger::test_skipped() {
-  logger::log "$1" "$2" "$3" "skipped"
+  logger::log "$1" "$2" "$3" "$4" "skipped"
 }
 
 function logger::test_passed() {
-  logger::log "$1" "$2" "$3" "passed"
+  logger::log "$1" "$2" "$3" "$4" "passed"
 }
 
 function logger::test_failed() {
-  logger::log "$1" "$2" "$3" "failed"
+  logger::log "$1" "$2" "$3" "$4" "failed"
 }
 
 function logger::log() {
   local file="$1"
   local test_name="$2"
   local start_time="$3"
-  local status="$4"
+  local assertions="$4"
+  local status="$5"
 
   local end_time
   end_time=$(clock::now)
@@ -37,6 +39,7 @@ function logger::log() {
   TEST_FILES+=("$file")
   TEST_NAMES+=("$test_name")
   TEST_STATUSES+=("$status")
+  TEST_ASSERTIONS+=("assertions")
   TEST_DURATIONS+=("$duration")
 }
 
@@ -66,12 +69,14 @@ function logger::generate_junit_xml() {
     for i in "${!TEST_NAMES[@]}"; do
       local file="${TEST_FILES[$i]}"
       local name="${TEST_NAMES[$i]}"
+      local assertions="${TEST_ASSERTIONS[$i]}"
       local status="${TEST_STATUSES[$i]}"
       local test_time="${TEST_DURATIONS[$i]}"
 
       echo "    <testcase file=\"$file\""
       echo "        name=\"$name\""
       echo "        status=\"$status\""
+      echo "        assertions=\"$assertions\""
       echo "        time=\"$test_time\">"
       echo "    </testcase>"
     done

--- a/src/logger.sh
+++ b/src/logger.sh
@@ -4,6 +4,7 @@ TEST_FILES=()
 TEST_NAMES=()
 TEST_STATUSES=()
 TEST_DURATIONS=()
+TEST_ASSERTIONS=()
 
 function logger::test_snapshot() {
   logger::log "$1" "$2" "$3" "$4" "snapshot"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -189,17 +189,19 @@ function runner::run_test() {
     tail -n 1 |\
     sed -E -e 's/(.*)##ASSERTIONS_FAILED=.*/\1/g'\
   )
+  local total_assertions
+  total_assertions="$(state::calculate_total_assertions "$test_execution_result")"
 
   if [[ -n $runtime_error ]]; then
     state::add_tests_failed
     console_results::print_error_test "$function_name" "$runtime_error"
-    logger::test_failed "$test_file" "$function_name" "$start_time"
+    logger::test_failed "$test_file" "$function_name" "$start_time" "$total_assertions"
     return
   fi
 
   if [[ "$current_assertions_failed" != "$(state::get_assertions_failed)" ]]; then
     state::add_tests_failed
-    logger::test_failed "$test_file" "$function_name" "$start_time"
+    logger::test_failed "$test_file" "$function_name" "$start_time" "$total_assertions"
 
     if [ "$STOP_ON_FAILURE" = true ]; then
       exit 1
@@ -211,19 +213,19 @@ function runner::run_test() {
   if [[ "$current_assertions_snapshot" != "$(state::get_assertions_snapshot)" ]]; then
     state::add_tests_snapshot
     console_results::print_snapshot_test "$function_name"
-    logger::test_snapshot "$test_file" "$function_name" "$start_time"
+    logger::test_snapshot "$test_file" "$function_name" "$start_time" "$total_assertions"
     return
   fi
 
   if [[ "$current_assertions_incomplete" != "$(state::get_assertions_incomplete)" ]]; then
     state::add_tests_incomplete
-    logger::test_incomplete "$test_file" "$function_name" "$start_time"
+    logger::test_incomplete "$test_file" "$function_name" "$start_time" "$total_assertions"
     return
   fi
 
   if [[ "$current_assertions_skipped" != "$(state::get_assertions_skipped)" ]]; then
     state::add_tests_skipped
-    logger::test_skipped "$test_file" "$function_name" "$start_time"
+    logger::test_skipped "$test_file" "$function_name" "$start_time" "$total_assertions"
     return
   fi
 
@@ -232,7 +234,7 @@ function runner::run_test() {
 
   console_results::print_successful_test "${label}" "$@"
   state::add_tests_passed
-  logger::test_passed "$test_file" "$function_name" "$start_time"
+  logger::test_passed "$test_file" "$function_name" "$start_time" "$total_assertions"
 }
 
 function runner::run_set_up() {

--- a/src/state.sh
+++ b/src/state.sh
@@ -141,3 +141,16 @@ function state::export_assertions_count() {
 ##ASSERTIONS_SNAPSHOT=$_ASSERTIONS_SNAPSHOT\
 ##"
 }
+
+function state::calculate_total_assertions() {
+  local input="$1"
+  local total=0
+
+  numbers=$(echo "$input" | grep -oE '[^=]+=([0-9]+)' | awk -F= '{print $2}')
+
+  for number in $numbers; do
+    total=$((total + number))
+  done
+
+  echo $total
+}

--- a/src/state.sh
+++ b/src/state.sh
@@ -146,10 +146,11 @@ function state::calculate_total_assertions() {
   local input="$1"
   local total=0
 
-  numbers=$(echo "$input" | grep -oE '[^=]+=([0-9]+)' | awk -F= '{print $2}')
+  local numbers
+  numbers=$(echo "$input" | grep -oE '##ASSERTIONS_\w+=[0-9]+' | grep -oE '[0-9]+')
 
   for number in $numbers; do
-    total=$((total + number))
+    ((total += number))
   done
 
   echo $total

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -278,7 +278,11 @@ ASSERTIONS_SNAPSHOT=33##"\
 }
 
 function test_calculate_total_assertions() {
-  local input="##ASSERTIONS_FAILED=1##ASSERTIONS_PASSED=2##ASSERTIONS_SKIPPED=3##ASSERTIONS_INCOMPLETE=4##ASSERTIONS_SNAPSHOT=5##"
+  local input="##ASSERTIONS_FAILED=1\
+  ##ASSERTIONS_PASSED=2\
+  ##ASSERTIONS_SKIPPED=3\
+  ##ASSERTIONS_INCOMPLETE=4\
+  ##ASSERTIONS_SNAPSHOT=5##"
 
   assert_equals 15 "$(state::calculate_total_assertions "$input")"
 }

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -276,3 +276,9 @@ ASSERTIONS_INCOMPLETE=12##\
 ASSERTIONS_SNAPSHOT=33##"\
     "$export_assertions_count"
 }
+
+function test_calculate_total_assertions() {
+  local input="##ASSERTIONS_FAILED=1##ASSERTIONS_PASSED=2##ASSERTIONS_SKIPPED=3##ASSERTIONS_INCOMPLETE=4##ASSERTIONS_SNAPSHOT=5##"
+
+  assert_equals 15 "$(state::calculate_total_assertions "$input")"
+}


### PR DESCRIPTION
## 📚 Description

Closes https://github.com/TypedDevs/bashunit/issues/288 

## 🔖 Changes

- Add a new property for each testsuite like assertions="\d" with the total of assertions passed for each test.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

## Demo


![Screenshot 2024-07-16 at 18 04 29](https://github.com/user-attachments/assets/a070d4da-251e-42dd-8642-2b1bca4bea3e)

