### PR TITLE
Ignore output colors when TERM is dumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add assertions to log file
 - Improve UX by Removing trailing slashes `/` from the test directories naming output.
+- Ignore output colors when TERM is dumb
 
 ## [0.14.0](https://github.com/TypedDevs/bashunit/compare/0.13.0...0.14.0) - 2024-07-14
 

--- a/src/colors.sh
+++ b/src/colors.sh
@@ -6,15 +6,22 @@
 #   https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters
 # Credit:
 #   https://superuser.com/a/1119396
-sgr() {
-  local codes=${1:-0}
+function sgr() {
+  local codes return
+  codes=${1:-0}
   shift
 
   for c in "$@"; do
     codes="$codes;$c"
   done
 
-  echo $'\e'"[${codes}m"
+  return=$'\e'"[${codes}m"
+
+  if [[ $TERM == 'dumb' ]]; then
+    return=""
+  fi
+
+  echo "$return"
 }
 
 _COLOR_BOLD="$(sgr 1)"

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -64,36 +64,36 @@ function console_results::render_result() {
   printf " %s total\n" "$total_assertions"
 
   if [[ "$(state::get_tests_failed)" -gt 0 ]]; then
-    printf "\n%s%s%s\n" "$_COLOR_RETURN_ERROR" " Some tests failed " "$_COLOR_DEFAULT"
+    printf "\n%s%s%s\n" "$_COLOR_RETURN_ERROR" "Some tests failed" "$_COLOR_DEFAULT"
     console_results::print_execution_time
     return 1
   fi
 
   if [[ "$(state::get_tests_incomplete)" -gt 0 ]]; then
-    printf "\n%s%s%s\n" "$_COLOR_RETURN_INCOMPLETE" " Some tests incomplete " "$_COLOR_DEFAULT"
+    printf "\n%s%s%s\n" "$_COLOR_RETURN_INCOMPLETE" "Some tests incomplete" "$_COLOR_DEFAULT"
     console_results::print_execution_time
     return 0
   fi
 
   if [[ "$(state::get_tests_skipped)" -gt 0 ]]; then
-    printf "\n%s%s%s\n" "$_COLOR_RETURN_SKIPPED" " Some tests skipped " "$_COLOR_DEFAULT"
+    printf "\n%s%s%s\n" "$_COLOR_RETURN_SKIPPED" "Some tests skipped" "$_COLOR_DEFAULT"
     console_results::print_execution_time
     return 0
   fi
 
   if [[ "$(state::get_tests_snapshot)" -gt 0 ]]; then
-    printf "\n%s%s%s\n" "$_COLOR_RETURN_SNAPSHOT" " Some snapshots created " "$_COLOR_DEFAULT"
+    printf "\n%s%s%s\n" "$_COLOR_RETURN_SNAPSHOT" "Some snapshots created" "$_COLOR_DEFAULT"
     console_results::print_execution_time
     return 0
   fi
 
   if [[ $total_tests -eq 0 ]]; then
-    printf "\n%s%s%s\n" "$_COLOR_RETURN_ERROR" " No tests found " "$_COLOR_DEFAULT"
+    printf "\n%s%s%s\n" "$_COLOR_RETURN_ERROR" "No tests found" "$_COLOR_DEFAULT"
     console_results::print_execution_time
     return 1
   fi
 
-  printf "\n%s%s%s\n" "$_COLOR_RETURN_SUCCESS" " All tests passed " "$_COLOR_DEFAULT"
+  printf "\n%s%s%s\n" "$_COLOR_RETURN_SUCCESS" "All tests passed" "$_COLOR_DEFAULT"
   console_results::print_execution_time
   return 0
 }

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -2,12 +2,20 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_MULTILINE_STR="first line
   \n
 four line
 find me with \n a regular expression"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_direct_fn_call_passes() {

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_MULTILINE_STR="first line
   \n

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_SIMPLE="tests/acceptance/fixtures/.env.simple"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_when_a_test_fail_verbose_output_env() {

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_SIMPLE="tests/acceptance/fixtures/.env.simple"
 }

--- a/tests/acceptance/bashunit_find_tests_command_line_test.sh
+++ b/tests/acceptance/bashunit_find_tests_command_line_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
 }
 

--- a/tests/acceptance/bashunit_find_tests_command_line_test.sh
+++ b/tests/acceptance/bashunit_find_tests_command_line_test.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_all_tests_files_within_a_directory() {

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -1,9 +1,17 @@
 #!/bin/bash
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_LOG_JUNIT="tests/acceptance/fixtures/.env.log_junit"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_when_log_junit_option() {

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_LOG_JUNIT="tests/acceptance/fixtures/.env.log_junit"
 }

--- a/tests/acceptance/bashunit_pass_test.sh
+++ b/tests/acceptance/bashunit_pass_test.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_SIMPLE="tests/acceptance/fixtures/.env.simple"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_when_a_test_passes_verbose_output_env() {

--- a/tests/acceptance/bashunit_pass_test.sh
+++ b/tests/acceptance/bashunit_pass_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_SIMPLE="tests/acceptance/fixtures/.env.simple"
 }

--- a/tests/acceptance/bashunit_path_test.sh
+++ b/tests/acceptance/bashunit_path_test.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_WITH_PATH="tests/acceptance/fixtures/.env.with_path"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_without_path_env_nor_argument() {

--- a/tests/acceptance/bashunit_path_test.sh
+++ b/tests/acceptance/bashunit_path_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_WITH_PATH="tests/acceptance/fixtures/.env.with_path"
 }

--- a/tests/acceptance/bashunit_report_html_test.sh
+++ b/tests/acceptance/bashunit_report_html_test.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_REPORT_HTML="tests/acceptance/fixtures/.env.report_html"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_when_report_html_option() {

--- a/tests/acceptance/bashunit_report_html_test.sh
+++ b/tests/acceptance/bashunit_report_html_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_REPORT_HTML="tests/acceptance/fixtures/.env.report_html"
 }

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -2,9 +2,17 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_STOP_ON_FAILURE="tests/acceptance/fixtures/.env.stop_on_failure"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_when_stop_on_failure_option() {

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
   TEST_ENV_FILE_STOP_ON_FAILURE="tests/acceptance/fixtures/.env.stop_on_failure"
 }

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -2,12 +2,13 @@
 set -euo pipefail
 
 function set_up_before_script() {
+  TERM=dumb
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
 }
 
 function test_bashunit_should_display_version() {
   local fixture
-  fixture=$(printf "\e[1m\e[32mbashunit\e[0m - %s" "$BASHUNIT_VERSION")
+  fixture=$(printf "bashunit - %s" "$BASHUNIT_VERSION")
 
   todo "Add snapshots with regex to assert this test (part of the output changes every version)"
   assert_contains "$fixture" "$(./bashunit --env "$TEST_ENV_FILE" --version)"

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -2,8 +2,16 @@
 set -euo pipefail
 
 function set_up_before_script() {
-  TERM=dumb
+  ORIGINAL_TERM=$TERM
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function set_up() {
+  TERM=dumb
+}
+
+function tear_down() {
+  TERM=$ORIGINAL_TERM
 }
 
 function test_bashunit_should_display_version() {

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
-[31m✗ Failed[0m: Main::exec assert
-    [2mExpected[0m [1m'foo'[0m
-    [2mbut got[0m [1m'bar'[0m
+✗ Failed: Main::exec assert
+    Expected 'foo'
+    but got 'bar'

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -10,4 +10,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
 Tests:      4 passed, 1 failed, 5 total
 Assertions: 6 passed, 1 failed, 7 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -1,13 +1,13 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
-[31m✗ Failed[0m: Assert failing
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got[0m [1m'0'[0m
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert equals
+✓ Passed: Assert contains
+✗ Failed: Assert failing
+    Expected '1'
+    but got '0'
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+Tests:      4 passed, 1 failed, 5 total
+Assertions: 6 passed, 1 failed, 7 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -10,4 +10,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
 Tests:      4 passed, 1 failed, 5 total
 Assertions: 6 passed, 1 failed, 7 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -1,13 +1,13 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
-[31m✗ Failed[0m: Assert failing
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got[0m [1m'0'[0m
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert equals
+✓ Passed: Assert contains
+✗ Failed: Assert failing
+    Expected '1'
+    but got '0'
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+Tests:      4 passed, 1 failed, 5 total
+Assertions: 6 passed, 1 failed, 7 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -1,11 +1,11 @@
 Running ./tests/acceptance/fixtures/tests_path/a_test.sh
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 Running ./tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
+✓ Passed: Assert equals
+✓ Passed: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -8,4 +8,4 @@ Running ./tests/acceptance/fixtures/tests_path/other_test.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -1,11 +1,11 @@
 Running ./tests/acceptance/fixtures/tests_path/a_test.sh
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 Running ./tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
+✓ Passed: Assert equals
+✓ Passed: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -8,4 +8,4 @@ Running ./tests/acceptance/fixtures/tests_path/other_test.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
@@ -1,8 +1,8 @@
 Running ./tests/acceptance/fixtures/tests_path/a_test.sh
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 
-[2mTests:     [0m [32m2 passed[0m, 2 total
-[2mAssertions:[0m [32m3 passed[0m, 3 total
+Tests:      2 passed, 2 total
+Assertions: 3 passed, 3 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
@@ -5,4 +5,4 @@ Running ./tests/acceptance/fixtures/tests_path/a_test.sh
 Tests:      2 passed, 2 total
 Assertions: 3 passed, 3 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -7,4 +7,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
 Tests:      1 passed, 1 failed, 2 total
 Assertions: 1 passed, 1 failed, 2 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -1,10 +1,10 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
-[32m✓ Passed[0m: Success
-[31m✗ Failed[0m: Failure
-    [2mExpected[0m [1m'2'[0m
-    [2mbut got[0m [1m'3'[0m
+✓ Passed: Success
+✗ Failed: Failure
+    Expected '2'
+    but got '3'
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -7,4 +7,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
 Tests:      1 passed, 1 failed, 2 total
 Assertions: 1 passed, 1 failed, 2 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -1,10 +1,10 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
-[32m✓ Passed[0m: Success
-[31m✗ Failed[0m: Failure
-    [2mExpected[0m [1m'2'[0m
-    [2mbut got[0m [1m'3'[0m
+✓ Passed: Success
+✗ Failed: Failure
+    Expected '2'
+    but got '3'
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+Tests:      1 passed, 1 failed, 2 total
+Assertions: 1 passed, 1 failed, 2 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
@@ -1,5 +1,0 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
-[32m✓ Passed[0m: A success
-[31m✗ Failed[0m: B error
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got[0m [1m'2'[0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
@@ -1,5 +1,5 @@
 ....
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
@@ -2,4 +2,4 @@
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
@@ -1,5 +1,5 @@
 ....
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
@@ -2,4 +2,4 @@
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
@@ -7,4 +7,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
@@ -1,10 +1,10 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert equals
+✓ Passed: Assert contains
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
@@ -7,4 +7,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
@@ -1,10 +1,10 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert equals
+✓ Passed: Assert contains
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
@@ -2,4 +2,4 @@
 Tests:      0 total
 Assertions: 0 total
 
- No tests found 
+No tests found

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
@@ -1,5 +1,5 @@
 
-[2mTests:     [0m 0 total
-[2mAssertions:[0m 0 total
+Tests:      0 total
+Assertions: 0 total
 
-[41m[30m[1m No tests found [0m
+ No tests found 

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -8,4 +8,4 @@ Running tests/acceptance/fixtures/tests_path/other_test.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -1,11 +1,11 @@
 Running tests/acceptance/fixtures/tests_path/a_test.sh
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 Running tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
+✓ Passed: Assert equals
+✓ Passed: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -8,4 +8,4 @@ Running tests/acceptance/fixtures/tests_path/other_test.sh
 Tests:      4 passed, 4 total
 Assertions: 6 passed, 6 total
 
- All tests passed 
+All tests passed

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -1,11 +1,11 @@
 Running tests/acceptance/fixtures/tests_path/a_test.sh
-[32m✓ Passed[0m: Assert greater and less than
-[32m✓ Passed[0m: Assert empty
+✓ Passed: Assert greater and less than
+✓ Passed: Assert empty
 Running tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
-[32m✓ Passed[0m: Assert contains
+✓ Passed: Assert equals
+✓ Passed: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+Tests:      4 passed, 4 total
+Assertions: 6 passed, 6 total
 
-[42m[30m[1m All tests passed [0m
+ All tests passed 

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_without_path_env_nor_argument.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_without_path_env_nor_argument.snapshot
@@ -1,4 +1,4 @@
-[31mError: At least one file path is required.[0m
+Error: At least one file path is required.
 bashunit [arguments] [options]
 
 Arguments:

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -9,4 +9,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
 Tests:      1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 Assertions: 1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -1,12 +1,12 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
-[32m✓ Passed[0m: Success
-[31m✗ Failed[0m: Fail
-    [2mExpected[0m [1m'to be empty'[0m
-    [2mbut got[0m [1m'non empty'[0m
-[33m↷ Skipped[0m: Skipped
-[36m✒ Incomplete[0m: Todo
+✓ Passed: Success
+✗ Failed: Fail
+    Expected 'to be empty'
+    but got 'non empty'
+↷ Skipped: Skipped
+✒ Incomplete: Todo
 
-[2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
-[2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+Tests:      1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
+Assertions: 1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -9,4 +9,4 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
 Tests:      1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 Assertions: 1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 
- Some tests failed 
+Some tests failed

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -1,12 +1,12 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
-[32m✓ Passed[0m: Success
-[31m✗ Failed[0m: Fail
-    [2mExpected[0m [1m'to be empty'[0m
-    [2mbut got[0m [1m'non empty'[0m
-[33m↷ Skipped[0m: Skipped
-[36m✒ Incomplete[0m: Todo
+✓ Passed: Success
+✗ Failed: Fail
+    Expected 'to be empty'
+    but got 'non empty'
+↷ Skipped: Skipped
+✒ Incomplete: Todo
 
-[2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
-[2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+Tests:      1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
+Assertions: 1 passed, 1 skipped, 1 incomplete, 1 failed, 4 total
 
-[41m[30m[1m Some tests failed [0m
+ Some tests failed 

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
-[32m✓ Passed[0m: A success
-[31m✗ Failed[0m: B error
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got[0m [1m'2'[0m
+✓ Passed: A success
+✗ Failed: B error
+    Expected '1'
+    but got '2'

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
-[32m✓ Passed[0m: A success
-[31m✗ Failed[0m: B error
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got[0m [1m'2'[0m
+✓ Passed: A success
+✗ Failed: B error
+    Expected '1'
+    but got '2'


### PR DESCRIPTION
## 📚 Description

Original idea: https://github.com/TypedDevs/bashunit/issues/247#issuecomment-1989603768 by @h0adp0re

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix


> I am not 100% sure I like the changes. I think it's good to have the colors in the snapshots... any other thoughts?
