### PR TITLE
Fix filter matching pattern with and without `test` prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.14.0...main)
 
+- Fixed `--filter|-f` to work with `test_*` matching function name input.
+- Improved `--filter|-f` to match function name with input string irrespective with location to `test` prefix.
 - Add assertions to log file
 - Improve UX by Removing trailing slashes `/` from the test directories naming output.
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -52,13 +52,13 @@ function helper::check_duplicate_functions() {
 #
 function helper::get_functions_to_run() {
   local prefix=$1
-  local filter="${2:-"test"}"
+  local filter=${2/test_/}
   local function_names=$3
 
   local filtered_functions=""
 
   for fn in $function_names; do
-    if [[ $fn == ${prefix}_*${filter}* || $fn == *${filter}*  ]]; then
+    if [[ $fn == ${prefix}_*${filter}* ]]; then
       if [[ $filtered_functions == *" $fn"* ]]; then
         return 1
       fi
@@ -74,7 +74,7 @@ function helper::get_functions_to_run() {
 #
 function helper::execute_function_if_exists() {
   if [[ "$(type -t "$1")" == "function" ]]; then
-    "$1" 2>/dev/null
+    "$1"
   fi
 }
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -52,7 +52,7 @@ function helper::check_duplicate_functions() {
 #
 function helper::get_functions_to_run() {
   local prefix=$1
-  local filter=$2
+  local filter="${2:-"test"}"
   local function_names=$3
 
   local filtered_functions=""

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -58,7 +58,7 @@ function helper::get_functions_to_run() {
   local filtered_functions=""
 
   for fn in $function_names; do
-    if [[ $fn == ${prefix}_${filter}* ]]; then
+    if [[ $fn == ${prefix}_*${filter}* || $fn == *${filter}*  ]]; then
       if [[ $filtered_functions == *" $fn"* ]]; then
         return 1
       fi

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -74,7 +74,7 @@ function helper::get_functions_to_run() {
 #
 function helper::execute_function_if_exists() {
   if [[ "$(type -t "$1")" == "function" ]]; then
-    "$1"
+    "$1" 2>/dev/null
   fi
 }
 

--- a/tests/functional/multi_invoker_test.sh
+++ b/tests/functional/multi_invoker_test.sh
@@ -56,6 +56,7 @@ function test_multi_invoker_whitespace() {
 
   assert_equals "this arg" "$first_arg"
 
+  ## Iteration (1,2,3) are from invoker_test_numbers & (4,5) are from invoker_test_whitespace
   case $current_iteration in
     4)
       assert_equals "has spaces" "$second_arg"
@@ -64,7 +65,7 @@ function test_multi_invoker_whitespace() {
       assert_equals "$(printf "has\na newline")" "$second_arg"
       ;;
     *)
-      fail
+      fail "Unexpected results with inputs: $current_iteration"
       ;;
   esac
 }

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -227,3 +227,10 @@ EOF
   assert_equals "0.10.1" "$(helpers::get_latest_tag)"
   unset -f git # remove the mock
 }
+
+function test_to_run_with_filter_matching_string_in_function_name() {
+  local functions=("test_my_awesome_function" "test_your_awesome_function" "test_so_lala_function")
+
+  assert_equals "test_your_awesome_function" "$(helper::get_functions_to_run "test" "test_your_awesome_function" "${functions[*]}")"
+  assert_equals "test_my_awesome_function test_your_awesome_function" "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -231,6 +231,10 @@ EOF
 function test_to_run_with_filter_matching_string_in_function_name() {
   local functions=("test_my_awesome_function" "test_your_awesome_function" "test_so_lala_function")
 
-  assert_equals "test_your_awesome_function" "$(helper::get_functions_to_run "test" "test_your_awesome_function" "${functions[*]}")"
-  assert_equals "test_my_awesome_function test_your_awesome_function" "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
+  assert_equals\
+    "test_your_awesome_function" "$(helper::get_functions_to_run "test" "test_your_awesome_function" "${functions[*]}")"
+
+  assert_equals\
+    "test_my_awesome_function test_your_awesome_function"\
+    "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
 }


### PR DESCRIPTION
## 📚 Description

- fixes #299 

## 🔖 Changes

I added `*` in `${prefix}_*${filter}`  within function `helper::get_functions_to_run` to keep the match more dynamic even if it's not exactly after the prefix (test). 

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes

---

## Additional Notes For Reviewer

Ran Tests Locally to verify changes within the scope of [`state_test`](https://github.com/TypedDevs/bashunit/blob/main/tests/unit/state_test.sh) file.


1.  Test with a matching string `assertions`  inside the function name (9 functions have it) ✅ 
```bash
╰─$  ./bashunit tests/unit/state_test.sh -f assertions                                                         
bashunit - 0.14.0
Running tests/unit/state_test.sh
✓ Passed: Add and get assertions passed
✓ Passed: Add and get assertions failed
✓ Passed: Add and get assertions skipped
✓ Passed: Add and get assertions incomplete
✓ Passed: Add and get assertions snapshot
✓ Passed: Add twice and get assertions snapshot
✓ Passed: Initialize assertions count
✓ Passed: Export assertions count
✓ Passed: Calculate total assertions

Tests:      9 passed, 9 total
Assertions: 9 passed, 9 total

 All tests passed 
Time taken: 628 ms
```

2. Test with prefix `test` core issue reported with #299 ✅ 

```bash
╰─$ ./bashunit tests/unit/state_test.sh -f test_calculate
bashunit - 0.14.0
Running tests/unit/state_test.sh
✓ Passed: Calculate total assertions

Tests:      1 passed, 1 total
Assertions: 1 passed, 1 total

 All tests passed 
Time taken: 123 ms
```

3. Test without prefix and partial matching string in the function name ✅ (similar to [1])

```bash
╰─$ ./bashunit tests/unit/state_test.sh -f calculate_total                   
bashunit - 0.14.0
Running tests/unit/state_test.sh
✓ Passed: Calculate total assertions

Tests:      1 passed, 1 total
Assertions: 1 passed, 1 total

 All tests passed 
Time taken: 125 ms
```
