### PR TITLE
Add assert_same and improve assert_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 - Fixed `--filter|-f` to work with `test_*` matching function name input.
 - Improved `--filter|-f` to match function name with input string irrespective with location to `test` prefix.
-- Add assertions to log file
-- Improve UX by
+- Added assertions to log file
+- Added `assert_same`, it checks special chars
+    - Changed `assert_equals` to ignore special chars
+    - Removed `assert_equals_ignore_colors`
+- Improved UX by
     - Removing trailing slashes `/` from the test directories naming output.
     - Align "Expected" and "but got" on `assert_*` fails message.
 - Data providers support multiple arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,12 @@
 - Fixed `--filter|-f` to work with `test_*` matching function name input.
 - Improved `--filter|-f` to match function name with input string irrespective with location to `test` prefix.
 - Added assertions to log file
-- Added `assert_same`, it checks special chars
-    - Changed `assert_equals` to ignore special chars
-    - Removed `assert_equals_ignore_colors`
-- Improved UX by
-    - Removing trailing slashes `/` from the test directories naming output.
-    - Align "Expected" and "but got" on `assert_*` fails message.
+- Rename the current `assert_equals` to `assert_same`
+- Rename `assert_equals_ignore_colors` to `assert_equals` and ignore all special chars
 - Data providers support multiple arguments
-    - Remove `multi-invokers` in favor of `data providers`
+- Remove `multi-invokers` in favor of `data providers`
+- Removing trailing slashes `/` from the test directories naming output.
+- Align "Expected" and "but got" on `assert_*` fails message.
 - Add `BASHUNIT_` suffix to all .env config keys
     - BASHUNIT_SHOW_HEADER
     - BASHUNIT_HEADER_ASCII_ART

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -4,38 +4,41 @@ When creating tests, you'll need to verify your commands and functions.
 We provide assertions for these checks.
 Below is their documentation.
 
-## assert_equals
-> `assert_equals "expected" "actual"`
+## assert_same
+> `assert_same "expected" "actual"`
 
-Reports an error if the two variables `expected` and `actual` are not equal.
+Reports an error if the `expected` and `actual` are not the same - including special chars.
 
-[assert_not_equals](#assert-not-equals) is the inverse of this assertion and takes the same arguments.
+- [assert_not_same](#assert-not-same) is the inverse of this assertion and takes the same arguments.
+- [assert_equals](#assert-equals) is similar but ignoring the special chars.
 
 ::: code-group
 ```bash [Example]
 function test_success() {
-  assert_equals "foo" "foo"
+  assert_same "foo" "foo"
 }
 
 function test_failure() {
-  assert_equals "foo" "bar"
+  assert_same "foo" "bar"
 }
 ```
 :::
 
-## assert_equals_ignore_colors
-> `assert_equals_ignore_colors "expected" "actual"`
+## assert_equals
+> `assert_equals "expected" "actual"`
 
-Reports an error if the two variables `expected` and `actual` are not equal ignoring the colors ONLY from `actual`.
+Reports an error if the two variables `expected` and `actual` are not equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
+
+- [assert_same](#assert-same) is similar but including special chars.
 
 ::: code-group
 ```bash [Example]
 function test_success() {
-  assert_equals_ignore_colors "foo" "\e[31mfoo"
+  assert_equals "foo" "\e[31mfoo"
 }
 
 function test_failure() {
-  assert_equals_ignore_colors "\e[31mfoo" "\e[31mfoo"
+  assert_equals "\e[31mfoo" "\e[31mfoo"
 }
 ```
 :::
@@ -619,21 +622,21 @@ function test_failure() {
 ```
 :::
 
-## assert_not_equals
-> `assert_not_equals "expected" "actual"`
+## assert_not_same
+> `assert_not_same "expected" "actual"`
 
-Reports an error if the two variables `expected` and `actual` are equal.
+Reports an error if the two variables `expected` and `actual` are the same value.
 
-[assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+[assert_same](#assert-same) is the inverse of this assertion and takes the same arguments.
 
 ::: code-group
 ```bash [Example]
 function test_success() {
-  assert_not_equals "foo" "bar"
+  assert_not_same "foo" "bar"
 }
 
 function test_failure() {
-  assert_not_equals "foo" "foo"
+  assert_not_same "foo" "foo"
 }
 ```
 :::

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,7 @@ Once **bashunit** is installed, you're ready to get started.
     #!/bin/bash
 
     function test_bashunit_is_working() {
-      assert_equals "bashunit is working" "bashunit is working"
+      assert_same "bashunit is working" "bashunit is working"
     }
     ```
     :::

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -18,7 +18,7 @@ The prefix `assert_` is optional.
 ::: code-group
 ```bash [Example]
 # with `assert_` prefix
-./bashunit -a assert_equals "foo" "foo"
+./bashunit -a assert_same "foo" "foo"
 
 # or without prefix
 ./bashunit -a equals "foo" "foo"

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -12,7 +12,7 @@ Allows you to override the behavior of a callable.
 function test_example() {
   mock ps echo hello world
 
-  assert_equals "hello world" "$(ps)"
+  assert_same "hello world" "$(ps)"
 }
 ```
 :::
@@ -34,7 +34,7 @@ PID TTY          TIME CMD
 24162 pts/7    00:00:00 ps
 EOF
 
-  assert_equals "13525 pts/7    00:00:01 bash" "$(code)"
+  assert_same "13525 pts/7    00:00:01 bash" "$(code)"
 }
 ```
 :::

--- a/example/custom_functions_test.sh
+++ b/example/custom_functions_test.sh
@@ -6,9 +6,9 @@ function set_up() {
 }
 
 function test_say_hi_Alice() {
-  assert_equals "Hi, Alice!" "$(say_hi "Alice")"
+  assert_same "Hi, Alice!" "$(say_hi "Alice")"
 }
 
 function test_say_hi_Bob() {
-  assert_equals "Hi, Bob!" "$(say_hi "Bob")"
+  assert_same "Hi, Bob!" "$(say_hi "Bob")"
 }

--- a/example/script_logic_test.sh
+++ b/example/script_logic_test.sh
@@ -6,9 +6,9 @@ function set_up() {
 }
 
 function test_script_123() {
-  assert_equals "expected 123" "$($SCRIPT "123")"
+  assert_same "expected 123" "$($SCRIPT "123")"
 }
 
 function test_script_456() {
-  assert_equals "expected 456" "$($SCRIPT "456")"
+  assert_same "expected 456" "$($SCRIPT "456")"
 }

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -28,14 +28,21 @@ function assert_equals() {
   local expected="$1"
   local actual="$2"
 
-  local actual_without_colors
-  actual_without_colors=$(echo -e "$actual" | sed "s/\x1B\[[0-9;]*[JKmsu]//g")
+  # Remove ANSI escape sequences (color codes)
+  local actual_cleaned
+  actual_cleaned=$(echo -e "$actual" | sed -r "s/\x1B\[[0-9;]*[mK]//g")
+  local expected_cleaned
+  expected_cleaned=$(echo -e "$expected" | sed -r "s/\x1B\[[0-9;]*[mK]//g")
 
-  if [[ "$expected" != "$actual_without_colors" ]]; then
+  # Remove all control characters and whitespace (optional, depending on your needs)
+  actual_cleaned=$(echo "$actual_cleaned" | tr -d '[:cntrl:]')
+  expected_cleaned=$(echo "$expected_cleaned" | tr -d '[:cntrl:]')
+
+  if [[ "$expected_cleaned" != "$actual_cleaned" ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "but got " "${actual_without_colors}"
+    console_results::print_failed_test "${label}" "${expected_cleaned}" "but got " "${actual_cleaned}"
     return
   fi
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -9,7 +9,7 @@ function fail() {
   console_results::print_failure_message "${label}" "$message"
 }
 
-function assert_equals() {
+function assert_same() {
   local expected="$1"
   local actual="$2"
 
@@ -24,7 +24,7 @@ function assert_equals() {
   state::add_assertions_passed
 }
 
-function assert_equals_ignore_colors() {
+function assert_equals() {
   local expected="$1"
   local actual="$2"
 

--- a/src/bashunit.sh
+++ b/src/bashunit.sh
@@ -7,7 +7,7 @@
 function bashunit::assertion_failed() {
   local expected=$1
   local actual=$2
-  local failure_condition_message=${3:-"but got"}
+  local failure_condition_message=${3:-"but got "}
 
   local label
   label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"

--- a/src/deprecated_assert.sh
+++ b/src/deprecated_assert.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# Deprecated: Please use assert_equals instead.
+# Deprecated: Please use assert_same instead.
 function assertEquals() {
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  assert_equals "$1" "$2" "$label"
+  assert_same "$1" "$2" "$label"
 }
 
 # Deprecated: Please use assert_empty instead.

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -72,7 +72,7 @@ function assert_have_been_called_with() {
 
   if [[ "$expected" != "${!actual}" ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "but got" "${!actual}"
+    console_results::print_failed_test "${label}" "${expected}" "but got " "${!actual}"
     return
   fi
 

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -13,7 +13,7 @@ function test_bashunit_direct_fn_call_passes() {
   local expected="foo"
   local actual="foo"
 
-  ./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual
+  ./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual
   assert_successful_code
 }
 
@@ -74,8 +74,8 @@ function test_bashunit_direct_fn_call_failure() {
   local expected="foo"
   local actual="bar"
 
-  assert_match_snapshot "$(./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual)"
-  assert_general_error "$(./bashunit -a assert_equals --env "$TEST_ENV_FILE" "$expected" $actual)"
+  assert_match_snapshot "$(./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual)"
+  assert_general_error "$(./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual)"
 }
 
 function test_bashunit_direct_fn_call_non_existing_fn() {

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -18,7 +18,7 @@ function test_do_not_upgrade_when_latest() {
   local output
   output="$($TMP_BIN --upgrade)"
 
-  assert_equals "> You are already on latest version" "$output"
+  assert_same "> You are already on latest version" "$output"
   assert_string_ends_with "$LATEST_VERSION" "$($TMP_BIN --version --env "$TEST_ENV_FILE")"
 }
 
@@ -54,6 +54,6 @@ function test_do_not_update_on_consecutive_calls() {
   local output
   output="$($TMP_BIN --upgrade)"
 
-  assert_equals "> You are already on latest version" "$output"
+  assert_same "> You are already on latest version" "$output"
   assert_string_ends_with "$LATEST_VERSION" "$($TMP_BIN --version --env "$TEST_ENV_FILE")"
 }

--- a/tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-function test_assert_equals() {
-  assert_equals 1 1
+function test_assert_same() {
+  assert_same 1 1
 }
 
 function test_assert_contains() {
@@ -10,7 +10,7 @@ function test_assert_contains() {
 }
 
 function test_assert_failing() {
-  assert_equals 1 0
+  assert_same 1 0
 }
 
 function test_assert_greater_and_less_than() {

--- a/tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-function test_assert_equals() {
-  assert_equals 1 1
+function test_assert_same() {
+  assert_same 1 1
 }
 
 function test_assert_contains() {

--- a/tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 function test_success() {
-  assert_equals 1 1
+  assert_same 1 1
 }
 
 function test_failure() {
-  assert_equals 2 3
+  assert_same 2 3
 }

--- a/tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_report_html.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function test_success() {
-  assert_equals 1 1
+  assert_same 1 1
 }
 
 function test_fail() {

--- a/tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 function test_a_success() {
-  assert_equals 1 1
+  assert_same 1 1
 }
 function test_b_error() {
-  assert_equals 1 1
-  assert_equals 1 2 # error
-  assert_equals 2 2
+  assert_same 1 1
+  assert_same 1 2 # error
+  assert_same 2 2
 }
 
 function test_c_not_executed() {
-  assert_equals 2 2
+  assert_same 2 2
 }

--- a/tests/acceptance/fixtures/tests_path/other_test.sh
+++ b/tests/acceptance/fixtures/tests_path/other_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-function test_assert_equals() {
-  assert_equals 1 1
+function test_assert_same() {
+  assert_same 1 1
 }
 
 function test_assert_contains() {

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -44,12 +44,12 @@ function test_install_downloads_the_given_version() {
 
   output="$(./install.sh lib 0.9.0)"
 
-  assert_equals\
+  assert_same\
     "$(printf "> Downloading a concrete version: '0.9.0'\n> bashunit has been installed in the 'lib' folder")"\
     "$output"
   assert_file_exists "$installed_bashunit"
 
-  assert_equals\
+  assert_same\
     "$(printf "\e[1m\e[32mbashunit\e[0m - 0.9.0")"\
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
 }
@@ -70,6 +70,6 @@ function test_install_downloads_the_non_stable_beta_version() {
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
   assert_directory_not_exists "./deps/temp_bashunit"
   file_count_of_deps_directory=$(find ./deps -mindepth 1 -maxdepth 1 -print | wc -l | tr -d ' ')
-  assert_equals "$file_count_of_deps_directory" "1"
-  assert_equals "$(find ./deps -name 'bashunit')" "./deps/bashunit"
+  assert_same "$file_count_of_deps_directory" "1"
+  assert_same "$(find ./deps -name 'bashunit')" "./deps/bashunit"
 }

--- a/tests/acceptance/mock_test.sh
+++ b/tests/acceptance/mock_test.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #
 function test_runner_clear_mocks_first() {
   mock ls echo foo
-  assert_equals "foo" "$(ls)"
+  assert_same "foo" "$(ls)"
 
   spy ps
   ps foo bar

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing
     [2mExpected[0m [1m'1'[0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing
     [2mExpected[0m [1m'1'[0m

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -2,7 +2,7 @@ Running ./tests/acceptance/fixtures/tests_path/a_test.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 Running ./tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
 [2mTests:     [0m [32m4 passed[0m, 4 total

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -2,7 +2,7 @@ Running ./tests/acceptance/fixtures/tests_path/a_test.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 Running ./tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
 [2mTests:     [0m [32m4 passed[0m, 4 total

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
@@ -1,5 +1,5 @@
 Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -2,7 +2,7 @@ Running tests/acceptance/fixtures/tests_path/a_test.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 Running tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
 [2mTests:     [0m [32m4 passed[0m, 4 total

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -2,7 +2,7 @@ Running tests/acceptance/fixtures/tests_path/a_test.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 Running tests/acceptance/fixtures/tests_path/other_test.sh
-[32m✓ Passed[0m: Assert equals
+[32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
 [2mTests:     [0m [32m4 passed[0m, 4 total

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -11,8 +11,8 @@ function test_assert_foo_passed() {
 }
 
 function test_assert_foo_failed() {
-  assert_equals\
-    "$(console_results::print_failed_test "Assert foo" "foo" "but got" "bar")"\
+  assert_same\
+    "$(console_results::print_failed_test "Assert foo" "foo" "but got " "bar")"\
     "$(assert_foo "bar")"
 }
 
@@ -21,7 +21,7 @@ function test_assert_positive_number_passed() {
 }
 
 function test_assert_positive_number_failed() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Assert positive number" "positive number" "got" "0")"\
     "$(assert_positive_number "0")"
 }

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 SCRIPT="$ROOT_DIR/logic.sh"
 
 function test_text_should_be_equal() {
-  assert_equals "expected 123" "$($SCRIPT "123")"
+  assert_same "expected 123" "$($SCRIPT "123")"
 }
 
 function test_text_should_contain() {

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -40,13 +40,13 @@ function test_single_values_from_data_provider() {
 
   case $current_iteration in
     1)
-      assert_equals "one" "$current_data"
+      assert_same "one" "$current_data"
       ;;
     2)
-      assert_equals "two" "$current_data"
+      assert_same "two" "$current_data"
       ;;
     3)
-      assert_equals "three" "$current_data"
+      assert_same "three" "$current_data"
       ;;
     *)
       fail
@@ -64,7 +64,7 @@ function provide_single_values() {
 function test_single_value_from_data_provider() {
   local current_data="$1"
 
-  assert_equals "one" "$current_data"
+  assert_same "one" "$current_data"
 }
 
 function provide_single_value() {

--- a/tests/unit/assert_snapshot_test.sh
+++ b/tests/unit/assert_snapshot_test.sh
@@ -12,9 +12,9 @@ function test_creates_a_snapshot() {
 
   assert_match_snapshot "Expected snapshot"
 
-  assert_equals "$expected" "$_ASSERTIONS_SNAPSHOT"
+  assert_same "$expected" "$_ASSERTIONS_SNAPSHOT"
   assert_file_exists $snapshot_file_path
-  assert_equals "Expected snapshot" "$(cat $snapshot_file_path)"
+  assert_same "Expected snapshot" "$(cat $snapshot_file_path)"
 
   rm $snapshot_file_path
 }
@@ -28,5 +28,5 @@ function test_unsuccessful_assert_match_snapshot() {
   local actual
   actual="$(assert_match_snapshot "Expected snapshot")"
 
-  assert_equals_ignore_colors "$expected" "$actual"
+  assert_equals "$expected" "$actual"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -5,19 +5,19 @@ function test_successful_fail() {
 }
 
 function test_unsuccessful_fail() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failure_message "Unsuccessful fail" "Failure message")"\
     "$(fail "Failure message")"
 }
 
-function test_successful_assert_equals() {
-  assert_empty "$(assert_equals "1" "1")"
+function test_successful_assert_same() {
+  assert_empty "$(assert_same "1" "1")"
 }
 
-function test_unsuccessful_assert_equals() {
-  assert_equals\
-    "$(console_results::print_failed_test "Unsuccessful assert equals" "1" "but got " "2")"\
-    "$(assert_equals "1" "2")"
+function test_unsuccessful_assert_same() {
+  assert_same\
+    "$(console_results::print_failed_test "Unsuccessful assert same" "1" "but got " "2")"\
+    "$(assert_same "1" "2")"
 }
 
 function test_successful_assert_empty() {
@@ -25,7 +25,7 @@ function test_successful_assert_empty() {
 }
 
 function test_unsuccessful_assert_empty() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert empty" "to be empty" "but got " "1")"\
     "$(assert_empty "1")"
 }
@@ -35,7 +35,7 @@ function test_successful_assert_not_empty() {
 }
 
 function test_unsuccessful_assert_not_empty() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert not empty" "to not be empty" "but got " "")"\
     "$(assert_not_empty "")"
 }
@@ -45,7 +45,7 @@ function test_successful_assert_not_equals() {
 }
 
 function test_unsuccessful_assert_not_equals() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert not equals" "1" "but got " "1")"\
     "$(assert_not_equals "1" "1")"
 }
@@ -55,7 +55,7 @@ function test_successful_assert_contains_ignore_case() {
 }
 
 function test_unsuccessful_assert_contains_ignore_case() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert contains ignore case" "GNU/LINUX" "to contain" "Unix")"\
     "$(assert_contains_ignore_case "Unix" "GNU/LINUX")"
 }
@@ -65,7 +65,7 @@ function test_successful_assert_contains() {
 }
 
 function test_unsuccessful_assert_contains() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert contains" "GNU/Linux" "to contain" "Unix")"\
     "$(assert_contains "Unix" "GNU/Linux")"
 }
@@ -75,7 +75,7 @@ function test_successful_assert_not_contains() {
 }
 
 function test_unsuccessful_assert_not_contains() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert not contains" "GNU/Linux" "to not contain" "Linux")"\
     "$(assert_not_contains "Linux" "GNU/Linux")"
 }
@@ -85,7 +85,7 @@ function test_successful_assert_matches() {
 }
 
 function test_unsuccessful_assert_matches() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert matches" "GNU/Linux" "to match" ".*Pinux*")"\
     "$(assert_matches ".*Pinux*" "GNU/Linux")"
 }
@@ -95,7 +95,7 @@ function test_successful_assert_not_matches() {
 }
 
 function test_unsuccessful_assert_not_matches() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert not matches" "GNU/Linux" "to not match" ".*Linu*")"\
     "$(assert_not_matches ".*Linu*" "GNU/Linux")"
 }
@@ -113,7 +113,7 @@ function test_unsuccessful_assert_exit_code() {
     exit 1
   }
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert exit code" "1" "to be" "0")"\
     "$(assert_exit_code "0" "$(fake_function)")"
 }
@@ -149,7 +149,7 @@ function test_unsuccessful_assert_successful_code() {
     return 2
   }
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert successful code" "2" "to be exactly" "0")"\
     "$(assert_successful_code "$(fake_function)")"
 }
@@ -167,7 +167,7 @@ function test_unsuccessful_assert_general_error() {
     return 2
   }
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert general error" "2" "to be exactly" "1")"\
     "$(assert_general_error "$(fake_function)")"
 }
@@ -181,7 +181,7 @@ function test_unsuccessful_assert_command_not_found() {
     return 0
   }
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert command not found" "0" "to be exactly" "127")"\
     "$(assert_command_not_found "$(fake_function)")"
 }
@@ -195,7 +195,7 @@ function test_successful_assert_array_contains() {
 function test_unsuccessful_assert_array_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert array contains"\
       "Ubuntu 123 Linux Mint"\
@@ -213,7 +213,7 @@ function test_successful_assert_array_not_contains() {
 function test_unsuccessful_assert_array_not_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert array not contains" "Ubuntu 123 Linux Mint" "to not contain" "123")"\
     "$(assert_array_not_contains "123" "${distros[@]}")"
@@ -224,7 +224,7 @@ function test_successful_assert_string_starts_with() {
 }
 
 function test_unsuccessful_assert_string_starts_with() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert string starts with" "pause" "to start with" "hou")"\
     "$(assert_string_starts_with "hou" "pause")"
@@ -235,7 +235,7 @@ function test_successful_assert_string_not_starts_with() {
 }
 
 function test_unsuccessful_assert_string_not_starts_with() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert string not starts with" "house" "to not start with" "ho")"\
     "$(assert_string_not_starts_with "ho" "house")"
@@ -246,7 +246,7 @@ function test_successful_assert_string_ends_with() {
 }
 
 function test_unsuccessful_assert_string_ends_with() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert string ends with" "foobar" "to end with" "foo")"\
     "$(assert_string_ends_with "foo" "foobar")"
@@ -258,7 +258,7 @@ function test_successful_assert_string_not_ends_with() {
 }
 
 function test_unsuccessful_assert_string_not_ends_with() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert string not ends with" "foobar" "to not end with" "bar")"\
     "$(assert_string_not_ends_with "bar" "foobar")"
@@ -269,7 +269,7 @@ function test_successful_assert_less_than() {
 }
 
 function test_unsuccessful_assert_less_than() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert less than" "3" "to be less than" "1")"\
     "$(assert_less_than "1" "3")"
@@ -284,7 +284,7 @@ function test_successful_assert_less_or_equal_than_with_an_equal_number() {
 }
 
 function test_unsuccessful_assert_less_or_equal_than() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert less or equal than" "3" "to be less or equal than" "1")"\
     "$(assert_less_or_equal_than "1" "3")"
@@ -295,7 +295,7 @@ function test_successful_assert_greater_than() {
 }
 
 function test_unsuccessful_assert_greater_than() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert greater than" "1" "to be greater than" "3")"\
     "$(assert_greater_than "3" "1")"
@@ -310,28 +310,28 @@ function test_successful_assert_greater_or_equal_than_with_an_equal_number() {
 }
 
 function test_unsuccessful_assert_greater_or_equal_than() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert greater or equal than" "1" "to be greater or equal than" "3")"\
     "$(assert_greater_or_equal_than "3" "1")"
 }
 
-function test_successful_assert_equals_ignore_colors() {
-  assert_equals_ignore_colors\
+function test_successful_assert_equals() {
+  assert_equals\
     "✗ Failed foo"\
     "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 }
 
-function test_unsuccessful_assert_equals_ignore_colors() {
+function test_unsuccessful_assert_equals() {
   local string="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
-      "Unsuccessful assert equals ignore colors"\
+      "Unsuccessful assert equals"\
       "$string"\
       "but got "\
       "✗ Failed foo")"\
-    "$(assert_equals_ignore_colors "$string" "$string")"
+    "$(assert_equals "$string" "$string")"
 }
 
 function test_successful_assert_line_count_empty_str() {
@@ -365,7 +365,7 @@ function test_successful_assert_line_count_multiline_with_new_lines() {
 }
 
 function test_unsuccessful_assert_line_count() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert line count" "one_line_string" "to contain number of lines equal to" "10" "but found" "1")"\
     "$(assert_line_count 10 "one_line_string")"

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -322,16 +322,23 @@ function test_successful_assert_equals() {
     "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 }
 
-function test_unsuccessful_assert_equals() {
+function test_successful_assert_equals_with_special_chars() {
   local string="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
 
+  assert_equals "$string" "$string"
+}
+
+function test_unsuccessful_assert_equals() {
+  local str1="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} str1"
+  local str2="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} str2"
+
   assert_same\
-    "$(console_results::print_failed_test\
+    "$(console_results::print_failed_test \
       "Unsuccessful assert equals"\
-      "$string"\
+      "✗ Failed str1"\
       "but got "\
-      "✗ Failed foo")"\
-    "$(assert_equals "$string" "$string")"
+      "✗ Failed str2")"\
+    "$(assert_equals "$str1" "$str2")"
 }
 
 function test_successful_assert_line_count_empty_str() {

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -17,7 +17,7 @@ function mock_non_existing_fn() {
 function test_now_with_perl() {
   mock perl echo "1720705883457"
 
-  assert_equals "1720705883457" "$(clock::now)"
+  assert_same "1720705883457" "$(clock::now)"
 }
 
 function test_now_on_linux_without_perl() {
@@ -25,21 +25,21 @@ function test_now_on_linux_without_perl() {
   mock perl mock_non_existing_fn
   mock date echo "1720705883457"
 
-  assert_equals "1720705883457" "$(clock::now)"
+  assert_same "1720705883457" "$(clock::now)"
 }
 function test_now_on_windows_without_perl() {
   export _OS="Windows"
   mock perl mock_non_existing_fn
   mock date echo "1720705883457"
 
-  assert_equals "1720705883457" "$(clock::now)"
+  assert_same "1720705883457" "$(clock::now)"
 }
 
 function test_now_on_osx_without_perl() {
   export _OS="OSX"
   mock perl mock_non_existing_fn
 
-  assert_equals "" "$(clock::now)"
+  assert_same "" "$(clock::now)"
 }
 
 function test_runtime_in_milliseconds_when_not_empty_time() {

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -499,7 +499,7 @@ function test_print_successful_test_output_no_args() {
   local actual
   actual=$(console_results::print_successful_test "$test_name")
 
-  assert_equals_ignore_colors "✓ Passed: $test_name" "$actual"
+  assert_equals "✓ Passed: $test_name" "$actual"
   export BASHUNIT_SIMPLE_OUTPUT=$original_simple_output
 }
 
@@ -511,6 +511,6 @@ function test_print_successful_test_output_with_args() {
   local actual
   actual=$(console_results::print_successful_test "$test_name" "$data")
 
-  assert_equals_ignore_colors "✓ Passed: $test_name ($data)" "$actual"
+  assert_equals "✓ Passed: $test_name ($data)" "$actual"
   export BASHUNIT_SIMPLE_OUTPUT=$original_simple_output
 }

--- a/tests/unit/debug_test.sh
+++ b/tests/unit/debug_test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function test_dump() {
-  assert_equals_ignore_colors \
+  assert_equals \
     "[DUMP] tests/unit/debug_test.sh:6: hi, debugging"\
     "$(dump "hi, debugging")"
 }

--- a/tests/unit/directory_test.sh
+++ b/tests/unit/directory_test.sh
@@ -10,7 +10,7 @@ function test_successful_assert_directory_exists() {
 function test_unsuccessful_assert_directory_exists() {
   local a_directory="a_random_directory_that_will_not_exist"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert directory exists" "$a_directory" "to exist but" "do not exist")"\
     "$(assert_directory_exists "$a_directory")"
@@ -20,7 +20,7 @@ function test_assert_directory_exists_should_not_work_with_files() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Assert directory exists should not work with files" "$a_file" "to exist but" "do not exist")"\
     "$(assert_directory_exists "$a_file")"
@@ -36,7 +36,7 @@ function test_unsuccessful_assert_directory_not_exists() {
   local a_directory
   a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert directory not exists" "$a_directory" "to not exist but" "the directory exists")"\
     "$(assert_directory_not_exists "$a_directory")"
@@ -52,7 +52,7 @@ function test_successful_assert_is_directory() {
 function test_unsuccessful_assert_is_directory() {
   local a_directory="a_random_directory_that_will_not_exist"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory" "$a_directory" "to be a directory" "but is not a directory")"\
     "$(assert_is_directory "$a_directory")"
@@ -62,7 +62,7 @@ function test_unsuccessful_assert_is_directory_when_a_file_is_given() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is directory when a file is given" "$a_file" "to be a directory" "but is not a directory")"\
     "$(assert_is_directory "$a_file")"
@@ -81,7 +81,7 @@ function test_unsuccessful_assert_is_directory_empty() {
   local a_directory
   a_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory empty" "$a_directory" "to be empty" "but is not empty")"\
     "$(assert_is_directory_empty "$a_directory")"
@@ -98,7 +98,7 @@ function test_unsuccessful_assert_is_directory_not_empty() {
   local a_directory
   a_directory=$(mktemp -d)
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory not empty" "$a_directory" "to not be empty" "but is empty")"\
     "$(assert_is_directory_not_empty "$a_directory")"
@@ -119,7 +119,7 @@ function test_unsuccessful_assert_is_directory_readable_when_a_file_is_given() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is directory readable when a file is given" \
       "$a_file" "to be readable" "but is not readable")"\
@@ -135,7 +135,7 @@ function test_unsuccessful_assert_is_directory_readable_without_execution_permis
   a_directory=$(mktemp -d)
   chmod a-x "$a_directory"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory readable without execution permission" \
       "$a_directory" "to be readable" "but is not readable")"\
@@ -153,7 +153,7 @@ function test_unsuccessful_assert_is_directory_readable_without_read_permission(
   a_directory=$(mktemp -d)
   chmod a-r "$a_directory"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory readable without read permission" \
       "$a_directory" "to be readable" "but is not readable")"\
@@ -194,7 +194,7 @@ function test_unsuccessful_assert_is_directory_not_readable() {
   local a_directory
   a_directory=$(mktemp -d)
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory not readable" "$a_directory" "to be not readable" "but is readable")"\
     "$(assert_is_directory_not_readable "$a_directory")"
@@ -220,7 +220,7 @@ function test_unsuccessful_assert_is_directory_writable() {
   a_directory=$(mktemp -d)
   chmod a-w "$a_directory"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory writable" "$a_directory" "to be writable" "but is not writable")"\
     "$(assert_is_directory_writable "$a_directory")"
@@ -232,7 +232,7 @@ function test_unsuccessful_assert_is_directory_writable_when_a_file_is_given() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is directory writable when a file is given" \
       "$a_file" "to be writable" "but is not writable")"\
@@ -257,7 +257,7 @@ function test_unsuccessful_assert_is_directory_not_writable() {
   local a_directory
   a_directory=$(mktemp -d)
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is directory not writable" \
       "$a_directory" "to be not writable" "but is writable")"\

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -10,7 +10,7 @@ function test_successful_assert_file_exists() {
 function test_unsuccessful_assert_file_exists() {
   local a_file="a_random_file_that_will_not_exist"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert file exists" "$a_file" "to exist but" "do not exist")"\
     "$(assert_file_exists "$a_file")"
 }
@@ -19,7 +19,7 @@ function test_assert_file_exists_should_not_work_with_folders() {
   local a_dir
   a_dir="$(dirname "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test \
       "Assert file exists should not work with folders" "$a_dir" "to exist but" "do not exist")"\
     "$(assert_file_exists "$a_dir")"
@@ -35,7 +35,7 @@ function test_unsuccessful_assert_file_not_exists() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert file not exists" "$a_file" "to not exist but" "the file exists")"\
     "$(assert_file_not_exists "$a_file")"
@@ -51,7 +51,7 @@ function test_successful_assert_is_file() {
 function test_unsuccessful_assert_is_file() {
   local a_file="a_random_file_that_will_not_exist"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert is file" "$a_file" "to be a file" "but is not a file")"\
     "$(assert_is_file "$a_file")"
 }
@@ -60,7 +60,7 @@ function test_unsuccessful_assert_is_file_when_a_folder_is_given() {
   local a_folder
   a_folder="$(dirname "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is file when a folder is given" "$a_folder" "to be a file" "but is not a file")"\
     "$(assert_is_file "$a_folder")"
@@ -79,7 +79,7 @@ function test_unsuccessful_assert_is_file_empty() {
   local a_file
   a_file="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is file empty" "$a_file" "to be empty" "but is not empty")"\
     "$(assert_is_file_empty "$a_file")"

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -13,25 +13,25 @@ function dummy_function() {
 }
 
 function test_normalize_test_function_name_empty() {
-  assert_equals "" "$(helper::normalize_test_function_name)"
+  assert_same "" "$(helper::normalize_test_function_name)"
 }
 
 function test_normalize_test_function_name_one_word() {
-  assert_equals "Word" "$(helper::normalize_test_function_name "word")"
+  assert_same "Word" "$(helper::normalize_test_function_name "word")"
 }
 
 function test_normalize_test_function_name_snake_case() {
-  assert_equals "Some logic" "$(helper::normalize_test_function_name "test_some_logic")"
+  assert_same "Some logic" "$(helper::normalize_test_function_name "test_some_logic")"
 }
 
 function test_normalize_test_function_name_camel_case() {
-  assert_equals "SomeLogic" "$(helper::normalize_test_function_name "testSomeLogic")"
+  assert_same "SomeLogic" "$(helper::normalize_test_function_name "testSomeLogic")"
 }
 
 function test_get_functions_to_run_no_filter_should_return_all_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assert_equals\
+  assert_same\
     "prefix_function1 prefix_function2 prefix_function3"\
     "$(helper::get_functions_to_run "prefix" "" "${functions[*]}")"
 }
@@ -39,13 +39,13 @@ function test_get_functions_to_run_no_filter_should_return_all_functions() {
 function test_get_functions_to_run_with_filter_should_return_matching_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assert_equals "prefix_function1" "$(helper::get_functions_to_run "prefix" "function1" "${functions[*]}")"
+  assert_same "prefix_function1" "$(helper::get_functions_to_run "prefix" "function1" "${functions[*]}")"
 }
 
 function test_get_functions_to_run_filter_no_matching_functions_should_return_empty() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 
-  assert_equals "" "$(helper::get_functions_to_run "prefix" "nonexistent" "${functions[*]}")"
+  assert_same "" "$(helper::get_functions_to_run "prefix" "nonexistent" "${functions[*]}")"
 }
 
 function test_get_functions_to_run_fail_when_duplicates() {
@@ -57,7 +57,7 @@ function test_get_functions_to_run_fail_when_duplicates() {
 function test_dummy_function_is_executed_with_execute_function_if_exists() {
   local function_name='dummy_function'
 
-  assert_equals "dummy_function executed" "$(helper::execute_function_if_exists "$function_name")"
+  assert_same "dummy_function executed" "$(helper::execute_function_if_exists "$function_name")"
 }
 
 function test_no_function_is_executed_with_execute_function_if_exists() {
@@ -94,16 +94,16 @@ function test_check_duplicate_functions_without_duplicates() {
 }
 
 function test_normalize_variable_name() {
-  assert_equals "valid_name123" "$(helper::normalize_variable_name "valid_name123")"
-  assert_equals "non_valid_symbols__________" "$(helper::normalize_variable_name "non_valid_symbols!@#$%^&*()")"
-  assert_equals "_123_starting_with_numbers" "$(helper::normalize_variable_name "123_starting_with_numbers")"
-  assert_equals "variable_name_with_spaces" "$(helper::normalize_variable_name "variable name with spaces")"
-  assert_equals "variable_name_with_hyphens" "$(helper::normalize_variable_name "variable-name-with-hyphens")"
-  assert_equals "_123_variable_name_" "$(helper::normalize_variable_name "123 variable-name!")"
-  assert_equals "_" "$(helper::normalize_variable_name "")"
-  assert_equals "variable_name_with_underscores" "$(helper::normalize_variable_name "variable_name_with_underscores")"
-  assert_equals "_variable" "$(helper::normalize_variable_name "_variable")"
-  assert_equals "__________" "$(helper::normalize_variable_name "!@#$%^&*()")"
+  assert_same "valid_name123" "$(helper::normalize_variable_name "valid_name123")"
+  assert_same "non_valid_symbols__________" "$(helper::normalize_variable_name "non_valid_symbols!@#$%^&*()")"
+  assert_same "_123_starting_with_numbers" "$(helper::normalize_variable_name "123_starting_with_numbers")"
+  assert_same "variable_name_with_spaces" "$(helper::normalize_variable_name "variable name with spaces")"
+  assert_same "variable_name_with_hyphens" "$(helper::normalize_variable_name "variable-name-with-hyphens")"
+  assert_same "_123_variable_name_" "$(helper::normalize_variable_name "123 variable-name!")"
+  assert_same "_" "$(helper::normalize_variable_name "")"
+  assert_same "variable_name_with_underscores" "$(helper::normalize_variable_name "variable_name_with_underscores")"
+  assert_same "_variable" "$(helper::normalize_variable_name "_variable")"
+  assert_same "__________" "$(helper::normalize_variable_name "!@#$%^&*()")"
 }
 
 function fake_provider_data_string() {
@@ -117,7 +117,7 @@ function test_get_provider_data() {
     return 0
   }
 
-  assert_equals "data_provided" "$(helper::get_provider_data "fake_function_get_provider_data" "${BASH_SOURCE[0]}")"
+  assert_same "data_provided" "$(helper::get_provider_data "fake_function_get_provider_data" "${BASH_SOURCE[0]}")"
 }
 
 function fake_provider_data_array() {
@@ -132,7 +132,7 @@ function test_get_provider_data_array() {
     return 0
   }
 
-  assert_equals \
+  assert_same \
     "one two three" \
     "$(helper::get_provider_data "fake_function_get_provider_data_array" "${BASH_SOURCE[0]}")"
 }
@@ -144,19 +144,19 @@ function test_get_provider_data_should_returns_empty_when_not_exists_provider_fu
     return 0
   }
 
-  assert_equals "" "$(helper::get_provider_data "fake_function_get_not_existing_provider_data" "${BASH_SOURCE[0]}")"
+  assert_same "" "$(helper::get_provider_data "fake_function_get_not_existing_provider_data" "${BASH_SOURCE[0]}")"
 }
 
 function test_left_trim() {
-  assert_equals "foo" "$(helper::trim "       foo")"
+  assert_same "foo" "$(helper::trim "       foo")"
 }
 
 function test_right_trim() {
-  assert_equals "foo" "$(helper::trim "foo       ")"
+  assert_same "foo" "$(helper::trim "foo       ")"
 }
 
 function test_trim() {
-  assert_equals "foo" "$(helper::trim "    foo   ")"
+  assert_same "foo" "$(helper::trim "    foo   ")"
 }
 
 function test_find_files_recursive_given_file() {
@@ -166,7 +166,7 @@ function test_find_files_recursive_given_file() {
   local result
   result=$(helper::find_files_recursive "$path")
 
-  assert_equals "tests/unit/fixtures/tests/example1_test.sh" "$result"
+  assert_same "tests/unit/fixtures/tests/example1_test.sh" "$result"
 }
 
 function test_find_files_recursive_given_dir() {
@@ -176,7 +176,7 @@ function test_find_files_recursive_given_dir() {
   local result
   result=$(helper::find_files_recursive "$path")
 
-  assert_equals "tests/unit/fixtures/tests/example1_test.sh
+  assert_same "tests/unit/fixtures/tests/example1_test.sh
 tests/unit/fixtures/tests/example2_test.sh"\
   "$result"
 }
@@ -188,7 +188,7 @@ function test_find_files_recursive_given_wildcard() {
   local result
   result=$(helper::find_files_recursive "$path")
 
-  assert_equals "tests/unit/fixtures/tests/example2_test.sh" "$result"
+  assert_same "tests/unit/fixtures/tests/example2_test.sh" "$result"
 }
 
 function test_get_latest_tag() {
@@ -199,17 +199,17 @@ a17e6816669ec8d0f18ed8c6d5564df9fc699bf9        refs/tags/0.10.0
 b546c693198870dd75d1a102b94f4ddad6f4f3ea        refs/tags/0.2.0
 732ea5e8b16c3c05f0a6977b794ed7098e1839e2        refs/tags/0.3.0
 EOF
-  assert_equals "0.10.1" "$(helpers::get_latest_tag)"
+  assert_same "0.10.1" "$(helpers::get_latest_tag)"
   unset -f git # remove the mock
 }
 
 function test_to_run_with_filter_matching_string_in_function_name() {
   local functions=("test_my_awesome_function" "test_your_awesome_function" "test_so_lala_function")
 
-  assert_equals\
+  assert_same\
     "test_your_awesome_function" "$(helper::get_functions_to_run "test" "test_your_awesome_function" "${functions[*]}")"
 
-  assert_equals\
+  assert_same\
     "test_my_awesome_function test_your_awesome_function"\
     "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
 }

--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -15,7 +15,7 @@ function test_redirect_error_with_log() {
 
   local error_output
   error_output=$(<$_ERROR_LOG)
-  assert_equals "arg1 arg2" "$error_output"
+  assert_same "arg1 arg2" "$error_output"
 }
 
 function test_redirect_error_without_log() {

--- a/tests/unit/setup_teardown_test.sh
+++ b/tests/unit/setup_teardown_test.sh
@@ -19,9 +19,9 @@ function tear_down_after_script() {
 }
 
 function test_counter_is_incremented_after_setup_before_script_and_setup() {
-  assert_equals "3" "$TEST_COUNTER"
+  assert_same "3" "$TEST_COUNTER"
 }
 
 function test_counter_is_decremented_and_incremented_after_teardown_and_setup() {
-  assert_equals "3" "$TEST_COUNTER"
+  assert_same "3" "$TEST_COUNTER"
 }

--- a/tests/unit/skip_todo_test.sh
+++ b/tests/unit/skip_todo_test.sh
@@ -1,25 +1,25 @@
 #!/bin/bash
 
 function test_skip_output() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_skipped_test "Skip output")"\
     "$(skip)"
 }
 
 function test_skip_output_with_reason() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_skipped_test "Skip output with reason" "Skipped because is skippable")"\
     "$(skip "Skipped because is skippable")"
 }
 
 function test_todo_output() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_incomplete_test "Todo output")"\
     "$(todo)"
 }
 
 function test_todo_output_with_pending_details() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_incomplete_test "Todo output with pending details" "Incomplete because pending details")"\
     "$(todo "Incomplete because pending details")"
 }

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -11,7 +11,7 @@ function test_add_and_get_tests_passed() {
     state::get_tests_passed
   )
 
-  assert_equals "1" "$tests_passed"
+  assert_same "1" "$tests_passed"
 }
 
 function test_add_and_get_tests_failed() {
@@ -23,7 +23,7 @@ function test_add_and_get_tests_failed() {
     state::get_tests_failed
   )
 
-  assert_equals "1" "$tests_failed"
+  assert_same "1" "$tests_failed"
 }
 
 function test_add_and_get_tests_skipped() {
@@ -35,7 +35,7 @@ function test_add_and_get_tests_skipped() {
     state::get_tests_skipped
   )
 
-  assert_equals "1" "$tests_skipped"
+  assert_same "1" "$tests_skipped"
 }
 
 function test_add_and_get_tests_incomplete() {
@@ -47,7 +47,7 @@ function test_add_and_get_tests_incomplete() {
     state::get_tests_incomplete
   )
 
-  assert_equals "1" "$tests_incomplete"
+  assert_same "1" "$tests_incomplete"
 }
 
 function test_add_and_get_tests_snapshot() {
@@ -59,7 +59,7 @@ function test_add_and_get_tests_snapshot() {
     state::get_tests_snapshot
   )
 
-  assert_equals "1" "$tests_snapshot"
+  assert_same "1" "$tests_snapshot"
 }
 
 function test_add_twice_and_get_tests_snapshot() {
@@ -72,7 +72,7 @@ function test_add_twice_and_get_tests_snapshot() {
     state::get_tests_snapshot
   )
 
-  assert_equals "2" "$tests_snapshot"
+  assert_same "2" "$tests_snapshot"
 }
 
 function test_add_and_get_assertions_passed() {
@@ -84,7 +84,7 @@ function test_add_and_get_assertions_passed() {
     state::get_assertions_passed
   )
 
-  assert_equals "1" "$assertions_passed"
+  assert_same "1" "$assertions_passed"
 }
 
 function test_add_and_get_assertions_failed() {
@@ -96,7 +96,7 @@ function test_add_and_get_assertions_failed() {
     state::get_assertions_failed
   )
 
-  assert_equals "1" "$assertions_failed"
+  assert_same "1" "$assertions_failed"
 }
 
 function test_add_and_get_assertions_skipped() {
@@ -108,7 +108,7 @@ function test_add_and_get_assertions_skipped() {
     state::get_assertions_skipped
   )
 
-  assert_equals "1" "$assertions_skipped"
+  assert_same "1" "$assertions_skipped"
 }
 
 function test_add_and_get_assertions_incomplete() {
@@ -120,7 +120,7 @@ function test_add_and_get_assertions_incomplete() {
     state::get_assertions_incomplete
   )
 
-  assert_equals "1" "$assertions_incomplete"
+  assert_same "1" "$assertions_incomplete"
 }
 
 function test_add_and_get_assertions_snapshot() {
@@ -132,7 +132,7 @@ function test_add_and_get_assertions_snapshot() {
     state::get_assertions_snapshot
   )
 
-  assert_equals "1" "$assertions_snapshot"
+  assert_same "1" "$assertions_snapshot"
 }
 
 function test_add_twice_and_get_assertions_snapshot() {
@@ -145,7 +145,7 @@ function test_add_twice_and_get_assertions_snapshot() {
     state::get_assertions_snapshot
   )
 
-  assert_equals "2" "$assertions_snapshot"
+  assert_same "2" "$assertions_snapshot"
 }
 
 function test_set_and_is_duplicated_test_functions_found() {
@@ -157,7 +157,7 @@ function test_set_and_is_duplicated_test_functions_found() {
     state::is_duplicated_test_functions_found
   )
 
-  assert_equals "true" "$duplicated_test_functions_found"
+  assert_same "true" "$duplicated_test_functions_found"
 }
 
 function test_set_and_get_file_with_duplicated_function_names() {
@@ -169,7 +169,7 @@ function test_set_and_get_file_with_duplicated_function_names() {
     state::get_file_with_duplicated_function_names
   )
 
-  assert_equals "test_path/file_name_test.sh" "$file_with_duplicated_function_names"
+  assert_same "test_path/file_name_test.sh" "$file_with_duplicated_function_names"
 }
 
 function test_set_and_get_duplicated_function_names_one_name() {
@@ -181,7 +181,7 @@ function test_set_and_get_duplicated_function_names_one_name() {
     state::get_duplicated_function_names
   )
 
-  assert_equals "duplicated_test_name" "$duplicated_function_names"
+  assert_same "duplicated_test_name" "$duplicated_function_names"
 }
 
 function test_set_and_get_duplicated_function_names_multiply_names() {
@@ -197,7 +197,7 @@ duplicated_test_function3"
     state::get_duplicated_function_names
   )
 
-  assert_equals "$test_names" "$duplicated_function_names"
+  assert_same "$test_names" "$duplicated_function_names"
 }
 
 function test_set_duplicated_functions_merged() {
@@ -211,7 +211,7 @@ function test_set_duplicated_functions_merged() {
     state::is_duplicated_test_functions_found
   )
 
-  assert_equals "true" "$duplicated_test_functions_found"
+  assert_same "true" "$duplicated_test_functions_found"
 
   local duplicated_function_names
   duplicated_function_names=$(
@@ -220,7 +220,7 @@ function test_set_duplicated_functions_merged() {
     state::set_duplicated_functions_merged "$test_file_name" "$test_function_name"
     state::get_duplicated_function_names
   )
-  assert_equals "$test_function_name" "$duplicated_function_names"
+  assert_same "$test_function_name" "$duplicated_function_names"
 
   local file_with_duplicated_function_names
   file_with_duplicated_function_names=$(
@@ -230,7 +230,7 @@ function test_set_duplicated_functions_merged() {
     state::get_file_with_duplicated_function_names
   )
 
-  assert_equals "$test_file_name" "$file_with_duplicated_function_names"
+  assert_same "$test_file_name" "$file_with_duplicated_function_names"
 }
 
 function test_initialize_assertions_count() {
@@ -246,7 +246,7 @@ function test_initialize_assertions_count() {
     state::export_assertions_count
   )
 
-  assert_equals\
+  assert_same\
     "##ASSERTIONS_FAILED=0\
 ##ASSERTIONS_PASSED=0\
 ##ASSERTIONS_SKIPPED=0\
@@ -268,7 +268,7 @@ function test_export_assertions_count() {
     state::export_assertions_count
   )
 
-  assert_equals\
+  assert_same\
     "##ASSERTIONS_FAILED=5##\
 ASSERTIONS_PASSED=10##\
 ASSERTIONS_SKIPPED=42##\
@@ -284,5 +284,5 @@ function test_calculate_total_assertions() {
   ##ASSERTIONS_INCOMPLETE=4\
   ##ASSERTIONS_SNAPSHOT=5##"
 
-  assert_equals 15 "$(state::calculate_total_assertions "$input")"
+  assert_same 15 "$(state::calculate_total_assertions "$input")"
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -26,7 +26,7 @@ EOF
 
 function test_successful_override_ps_with_echo_with_mock() {
   mock ps echo hello world
-  assert_equals "hello world" "$(ps)"
+  assert_same "hello world" "$(ps)"
 }
 
 function test_successful_spy() {
@@ -40,7 +40,7 @@ function test_successful_spy() {
 function test_unsuccessful_spy_called() {
   spy ps
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful spy called" "ps" "to has been called" "once")"\
     "$(assert_have_been_called ps)"
 }
@@ -61,7 +61,7 @@ function test_unsuccessful_spy_called_times() {
   ps
   ps
 
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful spy called times" "ps" "to has been called" "1 times")"\
     "$(assert_have_been_called_times 1 ps)"
 }


### PR DESCRIPTION
## 📚 Description

There is currently no option to assert two values ignoring special chars.

## 🔖 Changes

- Rename the current `assert_equals` to `assert_same`
- Rename `assert_equals_ignore_colors` to `assert_equals` and ignore all special chars (not just colors)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes

## 🖼️ Screenshots

![Screenshot 2024-09-01 at 12 54 09](https://github.com/user-attachments/assets/4344a544-4858-4a71-936a-0977c94cd293)
