### PR TITLE
Use -v for version and -vvv for verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Remove `multi-invokers` in favor of `data providers`
 - Removing trailing slashes `/` from the test directories naming output.
 - Align "Expected" and "but got" on `assert_*` fails message.
+- Change `-v` as shortcut for `--version`
+- Add `-vvv` as shortcut for `--verbose`
 - Add `BASHUNIT_` suffix to all .env config keys
     - BASHUNIT_SHOW_HEADER
     - BASHUNIT_HEADER_ASCII_ART

--- a/bashunit
+++ b/bashunit
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
     -s|--simple)
       export BASHUNIT_SIMPLE_OUTPUT=true
       ;;
-    -v|--verbose)
+    -vvv|--verbose)
       export BASHUNIT_SIMPLE_OUTPUT=false
       ;;
     --debug)
@@ -65,7 +65,7 @@ while [[ $# -gt 0 ]]; do
       export BASHUNIT_REPORT_HTML="$2";
       shift
       ;;
-    --version)
+    -v|--version)
       console_header::print_version
       trap '' EXIT && exit 0
       ;;

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -110,7 +110,7 @@ Creates a report HTML file that contains information about the test results of y
 
 > `bashunit -s|--simple`
 >
-> `bashunit -v|--verbose`
+> `bashunit -vvv|--verbose`
 
 Enables simplified or verbose output to the console.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Enables simplified output to the console. `false` by default.
 
 Verbose is the default output, but it can be overridden by the environment configuration.
 
-Similar as using `-s|--simple|-v|--verbose` option on the [command line](/command-line#output).
+Similar as using `-s|--simple | -vvv|--verbose` option on the [command line](/command-line#output).
 
 ::: code-group
 ```bash [Simple output]


### PR DESCRIPTION
## 📚 Description

The `-v` is commonly used for `--version` while for verbose is more common to use `-vvv`

## 🔖 Changes

- Little change affecting the command shortcuts for version (-v) and verbose (-vvv)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
