### PR TITLE
Fix wrong commit id when installing beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Align "Expected" and "but got" on `assert_*` fails message.
 - Change `-v` as shortcut for `--version`
 - Add `-vvv` as shortcut for `--verbose`
+- Fix wrong commit id when installing beta
 - Add `BASHUNIT_` suffix to all .env config keys
     - BASHUNIT_SHOW_HEADER
     - BASHUNIT_HEADER_ASCII_ART

--- a/install.sh
+++ b/install.sh
@@ -24,10 +24,9 @@ function build_and_install_beta() {
   git clone --depth 1 --no-tags https://github.com/TypedDevs/bashunit temp_bashunit 2>/dev/null
   cd temp_bashunit
   ./build.sh >/dev/null
-  cd ..
-
   local latest_commit
-  latest_commit=$(git rev-parse --short=8 HEAD);
+  latest_commit=$(git rev-parse --short=8 HEAD)
+  cd ..
 
   local beta_version
   beta_version='(non-stable) beta after '"$LATEST_BASHUNIT_VERSION"' ['"$(date +'%Y-%m-%d')"'] 🐍 #'"$latest_commit"


### PR DESCRIPTION
## 📚 Description

Closes #315

The commit displayed when checking the bashunit version should be from the last commit from bashunit, not the proyect installing bashunit.

## 🔖 Changes

- List individual changes in more detail

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

