### PR TITLE
Fix clock::now() Can't locate Time/HiRes.pm

### DIFF
--- a/src/clock.sh
+++ b/src/clock.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function clock::now() {
-  if perl --version > /dev/null 2>&1; then
+  if perl -MTime::HiRes -e "" > /dev/null 2>&1; then
     perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)'
   elif [[ "$_OS" != "OSX" ]]; then
     date +%s%N


### PR DESCRIPTION
## 📚 Description

Fix: #318 

bashunit will throw an error when Perl Time::Hires is not available. This requires a minor fix to the clock::now() function.

## 🔖 Changes
```
function clock::now() {
  if perl -MTime::HiRes -e "" > /dev/null 2>&1; then
    perl -MTime::HiRes -e 'printf("%.0f\n",Time::HiRes::time()*1000)'
  elif [[ "$_OS" != "OSX" ]]; then
    date +%s%N
  else
    echo ""
  fi
}
```
## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
