### PR TITLE
Fixed failing tests with command not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.15.0...main)
 
 - Fix clock::now can't locate Time when is not available.
-- Docs: updated github actions installation steps
+- Docs: updated GitHub actions installation steps
+- Fixed failing tests with command not found
 
 ## [0.15.0](https://github.com/TypedDevs/bashunit/compare/0.14.0...0.15.0) - 2024-09-01
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -171,7 +171,7 @@ function runner::run_test() {
     state::export_assertions_count
   )
 
-  # Closes FD 3, which was used temporarily to hold the original std-output.
+  # Closes FD 3, which was used temporarily to hold the original stdout.
   exec 3>&-
 
   runner::parse_execution_result "$test_execution_result"
@@ -182,6 +182,13 @@ function runner::run_test() {
     tail -n 1 |\
     sed -E -e 's/(.*)##ASSERTIONS_FAILED=.*/\1/g'\
   )
+
+  local error_msg
+  error_msg="${test_execution_result%%##ASSERTIONS*}"
+  if [[ "$error_msg" == *"command not found"* ]]; then
+    runtime_error=$(echo "${error_msg#*: }" | tr -d '\n')
+  fi
+
   local total_assertions
   total_assertions="$(state::calculate_total_assertions "$test_execution_result")"
 


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/309 by @mkonig

Right now, when using a not found command in a test, this is ignored and makes the test pass as all good... This makes TDD impossible by definition. 

> We need to allow starting with a failing test writing what we want to have before having it.

![Screenshot 2024-09-13 at 22 27 13](https://github.com/user-attachments/assets/7941ee3c-d008-48d2-8d5f-2cc859281d09)

This should fail! 🙃 

## 🔖 Changes

- Check in the test_execution_result if contains "command not found" in such a case extract the error msg and render it as a failing test

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

![Screenshot 2024-09-13 at 22 12 22](https://github.com/user-attachments/assets/c26f25d4-6440-4a31-8f86-2f6bf17f2a5b)

