### PR TITLE
Added assert_files_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.15.0...main)
 
-- Fix clock::now can't locate Time when is not available.
-- Docs: updated GitHub actions installation steps
-- Fixed failing tests with command not found
+- Fixed clock::now can't locate Time when is not available.
+- Docs updated GitHub actions installation steps
+- Fixed failing tests when
+    - command not found
+    - unbound variable
+- Added `assert_files_equals`, `assert_files_not_equals`
 
 ## [0.15.0](https://github.com/TypedDevs/bashunit/compare/0.14.0...0.15.0) - 2024-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.15.0...main)
 
-- Fix clock::now can't locate Time when is not available.
-- Docs: updated GitHub actions installation steps
+- Fixed clock::now can't locate Time when is not available.
+- Docs updated GitHub actions installation steps
 - Fixed failing tests with command not found
+- Added `assert_files_equals`
 
 ## [0.15.0](https://github.com/TypedDevs/bashunit/compare/0.14.0...0.15.0) - 2024-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 
 ## [Unreleased](https://github.com/TypedDevs/bashunit/compare/0.15.0...main)
 
-- Fixed clock::now can't locate Time when is not available.
-- Docs updated GitHub actions installation steps
+- Fix clock::now can't locate Time when is not available.
+- Docs: updated GitHub actions installation steps
 - Fixed failing tests with command not found
-- Added `assert_files_equals`
 
 ## [0.15.0](https://github.com/TypedDevs/bashunit/compare/0.14.0...0.15.0) - 2024-09-01
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -622,6 +622,46 @@ function test_failure() {
 ```
 :::
 
+## assert_files_equals
+> `assert_files_equals "expected" "actual"`
+
+Reports an error if `expected` and `actual` are not equals.
+
+[assert_files_not_equals](#assert-files-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "file content" > "$actual"
+
+  assert_files_equals "$expected" "$actual"
+}
+
+function test_failure() {
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "different content" > "$actual"
+
+  assert_files_equals "$expected" "$actual"
+}
+```
+```[Output]
+✓ Passed: Success
+✗ Failed: Failure
+    Expected '/tmp/file1.txt'
+    Compared '/tmp/file2.txt'
+    Diff '@@ -1 +1 @@
+-file content
++different content'
+```
+:::
+
 ## assert_not_same
 > `assert_not_same "expected" "actual"`
 
@@ -878,6 +918,46 @@ function test_failure() {
 
   assert_is_directory_not_writable "$directory"
 }
+```
+:::
+
+
+## assert_files_not_equals
+> `assert_files_not_equals "expected" "actual"`
+
+Reports an error if `expected` and `actual` are not equals.
+
+[assert_files_equals](#assert-files-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "different content" > "$actual"
+
+  assert_files_not_equals "$expected" "$actual"
+}
+
+function test_failure() {
+
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "file content" > "$actual"
+
+  assert_files_not_equals "$expected" "$actual"
+}
+```
+```[Output]
+✓ Passed: Success
+✗ Failed: Failure
+    Expected '/tmp/file1.txt'
+    Compared '/tmp/file2.txt'
+    Diff 'Files are equals'
 ```
 :::
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -622,6 +622,46 @@ function test_failure() {
 ```
 :::
 
+## assert_files_equals
+> `assert_files_equals "expected" "actual"`
+
+Reports an error if `expected` and `actual` are not equals.
+
+[assert_files_not_equals](#assert-files-not-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "file content" > "$actual"
+
+  assert_files_equals "$expected" "$actual"
+}
+
+function test_failure() {
+  local expected="/tmp/file1.txt"
+  local actual="/tmp/file2.txt"
+
+  echo "file content" > "$expected"
+  echo "different content" > "$actual"
+
+  assert_files_equals "$expected" "$actual"
+}
+```
+```[Output]
+✓ Passed: Success
+✗ Failed: Failure
+    Expected '/tmp/file1.txt'
+    Compared '/tmp/file2.txt'
+    Diff '@@ -1 +1 @@
+-file content
++different content'
+```
+:::
+
 ## assert_not_same
 > `assert_not_same "expected" "actual"`
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -622,46 +622,6 @@ function test_failure() {
 ```
 :::
 
-## assert_files_equals
-> `assert_files_equals "expected" "actual"`
-
-Reports an error if `expected` and `actual` are not equals.
-
-[assert_files_not_equals](#assert-files-not-equals) is the inverse of this assertion and takes the same arguments.
-
-::: code-group
-```bash [Example]
-function test_success() {
-  local expected="/tmp/file1.txt"
-  local actual="/tmp/file2.txt"
-
-  echo "file content" > "$expected"
-  echo "file content" > "$actual"
-
-  assert_files_equals "$expected" "$actual"
-}
-
-function test_failure() {
-  local expected="/tmp/file1.txt"
-  local actual="/tmp/file2.txt"
-
-  echo "file content" > "$expected"
-  echo "different content" > "$actual"
-
-  assert_files_equals "$expected" "$actual"
-}
-```
-```[Output]
-✓ Passed: Success
-✗ Failed: Failure
-    Expected '/tmp/file1.txt'
-    Compared '/tmp/file2.txt'
-    Diff '@@ -1 +1 @@
--file content
-+different content'
-```
-:::
-
 ## assert_not_same
 > `assert_not_same "expected" "actual"`
 

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -56,12 +56,14 @@ function assert_files_equals() {
   local expected="$1"
   local actual="$2"
 
-  if ! cmp -s "$expected" "$actual"; then
+  if ! diff -u "$expected" "$actual"; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "compared" "${actual}" \
-        "Diff" "$(diff -u "$expected" "$actual" || true)"
+
+    actual_diff="$(echo -e "$(diff -u "$expected" "$actual" | sed '1,2d')")"
+    console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
+        "Diff" "$actual_diff"
     return
   fi
 

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -51,3 +51,37 @@ function assert_is_file_empty() {
 
   state::add_assertions_passed
 }
+
+function assert_files_equals() {
+  local expected="$1"
+  local actual="$2"
+
+  if [[ "$(diff -u "$expected" "$actual")" != '' ]] ; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+
+    console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
+        "Diff" "$(diff -u "$expected" "$actual" | sed '1,2d')"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
+function assert_files_not_equals() {
+  local expected="$1"
+  local actual="$2"
+
+  if [[ "$(diff -u "$expected" "$actual")" == '' ]] ; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+
+    console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
+        "Diff" "Files are equals"
+    return
+  fi
+
+  state::add_assertions_passed
+}

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -51,20 +51,3 @@ function assert_is_file_empty() {
 
   state::add_assertions_passed
 }
-
-function assert_files_equals() {
-  local expected="$1"
-  local actual="$2"
-
-  if [[ "$(diff -u "$expected" "$actual")" != '' ]] ; then
-    local label
-    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
-    state::add_assertions_failed
-
-    console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
-        "Diff" "$(diff -u "$expected" "$actual" | sed '1,2d')"
-    return
-  fi
-
-  state::add_assertions_passed
-}

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -56,14 +56,13 @@ function assert_files_equals() {
   local expected="$1"
   local actual="$2"
 
-  if ! diff -u "$expected" "$actual"; then
+  if [[ "$(diff -u "$expected" "$actual")" != '' ]] ; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
 
-    actual_diff="$(echo -e "$(diff -u "$expected" "$actual" | sed '1,2d')")"
     console_results::print_failed_test "${label}" "${expected}" "Compared" "${actual}" \
-        "Diff" "$actual_diff"
+        "Diff" "$(diff -u "$expected" "$actual" | sed '1,2d')"
     return
   fi
 

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -60,7 +60,7 @@ function assert_files_equals() {
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "but got " "${actual}" \
+    console_results::print_failed_test "${label}" "${expected}" "compared" "${actual}" \
         "Diff" "$(diff -u "$expected" "$actual" || true)"
     return
   fi

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -51,3 +51,19 @@ function assert_is_file_empty() {
 
   state::add_assertions_passed
 }
+
+function assert_files_equals() {
+  local expected="$1"
+  local actual="$2"
+
+  if ! cmp -s "$expected" "$actual"; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${expected}" "but got " "${actual}" \
+        "Diff" "$(diff -u "$expected" "$actual" || true)"
+    return
+  fi
+
+  state::add_assertions_passed
+}

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -4,11 +4,11 @@ function assert_match_snapshot() {
   local actual
   actual=$(echo -n "$1" | tr -d '\r')
   local directory
-    directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+  directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
   local test_file
-    test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
+  test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
   local snapshot_name
-    snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
+  snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
   local snapshot_file
   snapshot_file="${directory}/${test_file}.${snapshot_name}"
 
@@ -35,4 +35,3 @@ function assert_match_snapshot() {
 
   state::add_assertions_passed
 }
-

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -4,11 +4,11 @@ function assert_match_snapshot() {
   local actual
   actual=$(echo -n "$1" | tr -d '\r')
   local directory
-  directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+    directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
   local test_file
-  test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
+    test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
   local snapshot_name
-  snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
+    snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
   local snapshot_file
   snapshot_file="${directory}/${test_file}.${snapshot_name}"
 
@@ -35,3 +35,4 @@ function assert_match_snapshot() {
 
   state::add_assertions_passed
 }
+

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -188,6 +188,9 @@ function runner::run_test() {
   if [[ "$error_msg" == *"command not found"* ]]; then
     runtime_error=$(echo "${error_msg#*: }" | tr -d '\n')
   fi
+  if [[ "$error_msg" == *"unbound variable"* ]]; then
+    runtime_error=$(echo "${error_msg#*: }" | tr -d '\n')
+  fi
 
   local total_assertions
   total_assertions="$(state::calculate_total_assertions "$test_execution_result")"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -188,9 +188,6 @@ function runner::run_test() {
   if [[ "$error_msg" == *"command not found"* ]]; then
     runtime_error=$(echo "${error_msg#*: }" | tr -d '\n')
   fi
-  if [[ "$error_msg" == *"unbound variable"* ]]; then
-    runtime_error=$(echo "${error_msg#*: }" | tr -d '\n')
-  fi
 
   local total_assertions
   total_assertions="$(state::calculate_total_assertions "$test_execution_result")"

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -103,3 +103,18 @@ function test_successful_assert_files_equals() {
   rm "$file1"
   rm "$file2"
 }
+
+# shellcheck disable=SC2155
+function test_fails_assert_files_equals() {
+  datetime=$(date +%s)
+  local file1="/tmp/a_random_file_${datetime}_1"
+  local file2="/tmp/a_random_file_${datetime}_2"
+
+  echo "one content" > "$file1"
+  echo "another content" > "$file2"
+  actual="$(assert_files_equals "$file1" "$file2")"
+  assert_contains "Fails assert files equals" "$actual"
+
+  rm "$file1"
+  rm "$file2"
+}

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -107,14 +107,15 @@ function test_successful_assert_files_equals() {
 # shellcheck disable=SC2155
 function test_fails_assert_files_equals() {
   datetime=$(date +%s)
-  local file1="/tmp/a_random_file_${datetime}_1"
-  local file2="/tmp/a_random_file_${datetime}_2"
+  local expected="/tmp/a_random_file_${datetime}_1"
+  local actual="/tmp/a_random_file_${datetime}_2"
 
-  echo "one content" > "$file1"
-  echo "another content" > "$file2"
-  actual="$(assert_files_equals "$file1" "$file2")"
+  echo -e "same\noriginal content" > "$expected"
+  echo -e "same\ndifferent content" > "$actual"
+
+  actual="$(assert_files_equals "$expected" "$actual")"
   assert_contains "Fails assert files equals" "$actual"
 
-  rm "$file1"
-  rm "$file2"
+  rm "$expected"
+  rm "$actual"
 }

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -84,3 +84,22 @@ function test_unsuccessful_assert_is_file_empty() {
       "Unsuccessful assert is file empty" "$a_file" "to be empty" "but is not empty")"\
     "$(assert_is_file_empty "$a_file")"
 }
+
+# shellcheck disable=SC2155
+function test_successful_assert_files_equals() {
+  local file1="/tmp/a_random_file_$(date +%s)1"
+  local file2="/tmp/a_random_file_$(date +%s)2"
+
+  file_content="My multiline file
+  Special char: \$, \*, and \\
+
+  another extra line"
+
+  echo "$file_content" > "$file1"
+  echo "$file_content" > "$file2"
+
+  assert_empty "$(assert_files_equals "$file1" "$file2")"
+
+  rm "$file1"
+  rm "$file2"
+}

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -67,7 +67,7 @@ function test_unsuccessful_assert_is_file_when_a_folder_is_given() {
 }
 
 function test_successful_assert_is_file_empty() {
-  readonly path="/tmp/a_random_file_$(date +%s)"
+  local path="/tmp/a_random_file_$(date +%s)"
   touch "$path"
 
   assert_empty "$(assert_is_file_empty "$path")"
@@ -87,21 +87,22 @@ function test_unsuccessful_assert_is_file_empty() {
 
 # shellcheck disable=SC2155
 function test_successful_assert_files_equals() {
-  local file1="/tmp/a_random_file_$(date +%s)1"
-  local file2="/tmp/a_random_file_$(date +%s)2"
+  datetime=$(date +%s)
+  local expected="/tmp/a_random_file_${datetime}_1"
+  local actual="/tmp/a_random_file_${datetime}_2"
 
-  file_content="My multiline file
+  local file_content="My multiline file
   Special char: \$, \*, and \\
 
   another extra line"
 
-  echo "$file_content" > "$file1"
-  echo "$file_content" > "$file2"
+  echo "$file_content" > "$expected"
+  echo "$file_content" > "$actual"
 
-  assert_empty "$(assert_files_equals "$file1" "$file2")"
+  assert_empty "$(assert_files_equals "$expected" "$actual")"
 
-  rm "$file1"
-  rm "$file2"
+  rm "$expected"
+  rm "$actual"
 }
 
 # shellcheck disable=SC2155

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -67,7 +67,7 @@ function test_unsuccessful_assert_is_file_when_a_folder_is_given() {
 }
 
 function test_successful_assert_is_file_empty() {
-  local path="/tmp/a_random_file_$(date +%s)"
+  readonly path="/tmp/a_random_file_$(date +%s)"
   touch "$path"
 
   assert_empty "$(assert_is_file_empty "$path")"
@@ -83,40 +83,4 @@ function test_unsuccessful_assert_is_file_empty() {
     "$(console_results::print_failed_test\
       "Unsuccessful assert is file empty" "$a_file" "to be empty" "but is not empty")"\
     "$(assert_is_file_empty "$a_file")"
-}
-
-# shellcheck disable=SC2155
-function test_successful_assert_files_equals() {
-  datetime=$(date +%s)
-  local expected="/tmp/a_random_file_${datetime}_1"
-  local actual="/tmp/a_random_file_${datetime}_2"
-
-  local file_content="My multiline file
-  Special char: \$, \*, and \\
-
-  another extra line"
-
-  echo "$file_content" > "$expected"
-  echo "$file_content" > "$actual"
-
-  assert_empty "$(assert_files_equals "$expected" "$actual")"
-
-  rm "$expected"
-  rm "$actual"
-}
-
-# shellcheck disable=SC2155
-function test_fails_assert_files_equals() {
-  datetime=$(date +%s)
-  local expected="/tmp/a_random_file_${datetime}_1"
-  local actual="/tmp/a_random_file_${datetime}_2"
-
-  echo -e "same\noriginal content" > "$expected"
-  echo -e "same\ndifferent content" > "$actual"
-
-  actual="$(assert_files_equals "$expected" "$actual")"
-  assert_contains "Fails assert files equals" "$actual"
-
-  rm "$expected"
-  rm "$actual"
 }

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -67,7 +67,7 @@ function test_unsuccessful_assert_is_file_when_a_folder_is_given() {
 }
 
 function test_successful_assert_is_file_empty() {
-  readonly path="/tmp/a_random_file_$(date +%s)"
+  local path="/tmp/a_random_file_$(date +%s)"
   touch "$path"
 
   assert_empty "$(assert_is_file_empty "$path")"
@@ -83,4 +83,69 @@ function test_unsuccessful_assert_is_file_empty() {
     "$(console_results::print_failed_test\
       "Unsuccessful assert is file empty" "$a_file" "to be empty" "but is not empty")"\
     "$(assert_is_file_empty "$a_file")"
+}
+
+# shellcheck disable=SC2155
+function test_successful_assert_files_equals() {
+  datetime=$(date +%s)
+  local expected="/tmp/a_random_file_${datetime}_1"
+  local actual="/tmp/a_random_file_${datetime}_2"
+
+  local file_content="My multiline file
+  Special char: \$, \*, and \\
+
+  another extra line"
+
+  echo "$file_content" > "$expected"
+  echo "$file_content" > "$actual"
+
+  assert_empty "$(assert_files_equals "$expected" "$actual")"
+
+  rm "$expected"
+  rm "$actual"
+}
+
+# shellcheck disable=SC2155
+function test_fails_assert_files_equals() {
+  datetime=$(date +%s)
+  local expected="/tmp/a_random_file_${datetime}_1"
+  local actual="/tmp/a_random_file_${datetime}_2"
+
+  echo -e "same\noriginal content" > "$expected"
+  echo -e "same\ndifferent content" > "$actual"
+
+  actual="$(assert_files_equals "$expected" "$actual")"
+  assert_contains "Fails assert files equals" "$actual"
+
+  rm "$expected"
+  rm "$actual"
+}
+
+# shellcheck disable=SC2155
+function test_successful_assert_files_not_equals() {
+  local expected="/tmp/test_successful_assert_files_not_equals_1"
+  local actual="/tmp/test_successful_assert_files_not_equals_2"
+
+  echo -e "same\noriginal content" > "$expected"
+  echo -e "same\ndifferent content" > "$actual"
+
+  assert_empty "$(assert_files_not_equals "$expected" "$actual")"
+
+  rm "$expected"
+  rm "$actual"
+}
+
+# shellcheck disable=SC2155
+function test_fails_assert_files_not_equals() {
+  local expected="/tmp/test_fails_assert_files_not_equals"
+  local actual="/tmp/test_fails_assert_files_not_equals"
+
+  echo -e "same content" > "$expected"
+  echo -e "same content" > "$actual"
+
+  actual="$(assert_files_not_equals "$expected" "$actual")"
+  assert_contains "Files are equals" "$actual"
+
+  rm "$expected"
+  rm "$actual"
 }


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/322 by @staabm

## 🔖 Changes

- Add `assert_files_equals`
- Add `assert_files_not_equals`
- Fixed "unbound variable" on runtime error message

## 🎥  Demo

https://github.com/user-attachments/assets/31828c38-e676-48ed-9729-12ddc43038eb

## ✅ To-do list 

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes 
