### PR TITLE
Use filter when calculating the total tests header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - command not found
     - unbound variable
 - Added `assert_files_equals`, `assert_files_not_equals`
+- Fixed total tests wrong number
 
 ## [0.15.0](https://github.com/TypedDevs/bashunit/compare/0.14.0...0.15.0) - 2024-09-01
 

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -1,20 +1,30 @@
 #!/bin/bash
 
 function console_header::print_version_with_env() {
-  local files=("${@:-}")
+  local filter=${1:-}
+  local files=("${@:2}")
   local should_print_ascii="true"
 
   if [[ "$BASHUNIT_SHOW_HEADER" != "$should_print_ascii" ]]; then
     return
   fi
 
-  console_header::print_version "${files[@]}"
+  console_header::print_version "$filter" "${files[@]}"
 }
 
 function console_header::print_version() {
-  local files=("${@:-}")
+  local filter=${1:-}
+  if [[ -n "$filter" ]]; then
+   shift
+  fi
+
+  local files=("$@")
   local total_tests
-  total_tests=$(helpers::find_total_tests "${files[@]}")
+  if [[ ${#files[@]} -eq 0 ]]; then
+    total_tests=0
+  else
+    total_tests=$(helpers::find_total_tests "$filter" "${files[@]}")
+  fi
 
   if [[ $BASHUNIT_HEADER_ASCII_ART == true ]]; then
     cat <<EOF

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -151,17 +151,23 @@ function helpers::get_latest_tag() {
 }
 
 function helpers::find_total_tests() {
-    local files=("$@")
+    local filter=${1:-}
+    local files=("${@:2}")
     local total_count=0
 
     for file in "${files[@]}"; do
         local count
-        count=$(grep -r -E '^\s*function\s+test' "$file" --include=\*.sh 2>/dev/null | wc -l)
+        if [[ -n "$filter" ]]; then
+            count=$(grep -r -E "^\s*function\s+test.*$filter" "$file" --include=\*.sh 2>/dev/null | wc -l)
+        else
+            count=$(grep -r -E '^\s*function\s+test' "$file" --include=\*.sh 2>/dev/null | wc -l)
+        fi
         total_count=$((total_count + count))
     done
 
     echo "$total_count"
 }
+
 
 function helper::load_test_files() {
   local filter=$1

--- a/src/main.sh
+++ b/src/main.sh
@@ -15,7 +15,7 @@ function main::exec_tests() {
     exit 1
   fi
 
-  console_header::print_version_with_env "${test_files[@]}"
+  console_header::print_version_with_env "$filter" "${test_files[@]}"
   runner::load_test_files "$filter" "${test_files[@]}"
   console_results::render_result
   exit_code=$?


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/320

## 🔖 Changes

- Use filter when calculating the total tests header

## 🖼️  Demo

<img width="878" alt="Screenshot 2024-09-14 at 12 43 05" src="https://github.com/user-attachments/assets/ed512f3c-8a43-4644-868a-4ed5c8b27893">

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
