### PR TITLE
Display failing tests again

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           docker run --rm -v "$(pwd)":/project alpine:latest /bin/sh -c " \
             apk update && \
-            apk add --no-cache bash make git curl perl && \
+            apk add --no-cache bash make git curl perl coreutils && \
             adduser -D builder && \
             chown -R builder /project && \
             su - builder -c 'cd /project; make test';"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Added support for Alpine (Linux Distro)
 - Added optional file-path as 2nd arg to `--debug` option
 - Added runtime per test
-- Simplified total tests display on header
+- Simplified total tests display on the header
 - Renamed `BASHUNIT_TESTS_ENV` to `BASHUNIT_LOAD_FILE`
+- Better handler runtime errors
+- Display failing tests after running the entire suite
 
 ## [0.16.0](https://github.com/TypedDevs/bashunit/compare/0.15.0...0.16.0) - 2024-09-15
 

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test/watch: $(TEST_SCRIPTS)
 
 test/alpine:
 	@docker run --rm -it -v "$(shell pwd)":/project -w /project alpine:latest \
-		sh -c  "apk add bash make shellcheck git curl perl && make test"
+		sh -c  "apk add bash make shellcheck git curl perl coreutils && make test"
 
 env/example:
 	@echo "Copying variables without the values from .env into .env.example"

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -255,7 +255,16 @@ function console_results::print_error_test() {
 
 function console_results::print_failing_tests_and_reset() {
   if [[ -s "$NON_SUCCESSFUL_RESULT_OUTPUT" ]]; then
-    echo -e "${_COLOR_BOLD}There were $(state::get_tests_failed) failures:${_COLOR_DEFAULT}\n"
+    local total_failed
+    total_failed=$(state::get_tests_failed)
+
+    echo ""
+    if [[ "$total_failed" -eq 1 ]]; then
+      echo -e "${_COLOR_BOLD}There was 1 failure:${_COLOR_DEFAULT}\n"
+    else
+      echo -e "${_COLOR_BOLD}There were $total_failed failures:${_COLOR_DEFAULT}\n"
+    fi
+
     sed '${/^$/d;}' "$NON_SUCCESSFUL_RESULT_OUTPUT" | sed 's/^/|/'
     rm "$NON_SUCCESSFUL_RESULT_OUTPUT"
   fi

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -254,7 +254,7 @@ function console_results::print_error_test() {
 }
 
 function console_results::print_failing_tests_and_reset() {
-  if [[ -s "$NON_SUCCESSFUL_RESULT_OUTPUT" ]]; then
+  if [[ -s "$FAILURES_OUTPUT_PATH" ]]; then
     local total_failed
     total_failed=$(state::get_tests_failed)
 
@@ -265,7 +265,7 @@ function console_results::print_failing_tests_and_reset() {
       echo -e "${_COLOR_BOLD}There were $total_failed failures:${_COLOR_DEFAULT}\n"
     fi
 
-    sed '${/^$/d;}' "$NON_SUCCESSFUL_RESULT_OUTPUT" | sed 's/^/|/'
-    rm "$NON_SUCCESSFUL_RESULT_OUTPUT"
+    sed '${/^$/d;}' "$FAILURES_OUTPUT_PATH" | sed 's/^/|/'
+    rm "$FAILURES_OUTPUT_PATH"
   fi
 }

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -148,7 +148,7 @@ ${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
     ${_COLOR_FAINT}Message:${_COLOR_DEFAULT} ${_COLOR_BOLD}'%s'${_COLOR_DEFAULT}\n"\
     "${test_name}" "${failure_message}")"
 
-    state::print_line "failure" "$line"
+  state::print_line "failure" "$line"
 }
 
 function console_results::print_failed_test() {
@@ -247,7 +247,7 @@ function console_results::print_error_test() {
   test_name=$(helper::normalize_test_function_name "$function_name")
 
   local line
-  line="$(printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
+  line="$(printf "${_COLOR_FAILED}✗ Error${_COLOR_DEFAULT}: %s
     ${_COLOR_FAINT}%s${_COLOR_DEFAULT}\n" "${test_name}" "${error}")"
 
   state::print_line "error" "$line"

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -31,5 +31,4 @@ function find_terminal_width() {
 }
 
 TERMINAL_WIDTH="$(find_terminal_width)"
-
-NON_SUCCESSFUL_RESULT_OUTPUT=$(mktemp)
+FAILURES_OUTPUT_PATH=$(mktemp)

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -16,25 +16,18 @@ _DEFAULT_TERMINAL_WIDTH=150
 CAT="$(which cat)"
 
 function find_terminal_width() {
-  if [[ -n "$TERM" && $(command -v tput) ]]; then
-      _cols=$(tput cols 2>/dev/null) || _cols=""
+  local _cols=""
 
-      # If tput fails, fallback to stty if available
-      if [[ -z "$_cols" ]] && command -v stty > /dev/null; then
-          _cols=$(stty size | cut -d' ' -f2)
-      fi
-  else
-      # Fallback to stty if TERM is not set and stty is available
-      if command -v stty > /dev/null; then
-          _cols=$(stty size | cut -d' ' -f2)
-      fi
+  if [[ -n "$TERM" ]] && command -v tput > /dev/null; then
+    _cols=$(tput cols 2>/dev/null)
   fi
 
-  if [[ -z "$_cols" ]]; then
-      _cols=$_DEFAULT_TERMINAL_WIDTH
+  if [[ -z "$_cols" ]] && command -v stty > /dev/null; then
+    _cols=$(stty size 2>/dev/null | cut -d' ' -f2)
   fi
 
-  echo "$_cols"
+  # Directly echo the value with fallback
+  echo "${_cols:-$_DEFAULT_TERMINAL_WIDTH}"
 }
 
 TERMINAL_WIDTH="$(find_terminal_width)"

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -38,3 +38,5 @@ function find_terminal_width() {
 }
 
 TERMINAL_WIDTH="$(find_terminal_width)"
+
+NON_SUCCESSFUL_RESULT_OUTPUT=$(mktemp)

--- a/src/main.sh
+++ b/src/main.sh
@@ -17,6 +17,10 @@ function main::exec_tests() {
 
   console_header::print_version_with_env "$filter" "${test_files[@]}"
   runner::load_test_files "$filter" "${test_files[@]}"
+
+  echo ""
+  console_results::print_failing_tests_and_reset
+
   console_results::render_result
   exit_code=$?
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -17,10 +17,7 @@ function main::exec_tests() {
 
   console_header::print_version_with_env "$filter" "${test_files[@]}"
   runner::load_test_files "$filter" "${test_files[@]}"
-
-  echo ""
   console_results::print_failing_tests_and_reset
-
   console_results::render_result
   exit_code=$?
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -150,12 +150,18 @@ function runner::run_test() {
   local current_assertions_skipped
   current_assertions_skipped="$(state::get_assertions_skipped)"
 
+  # (FD = File Descriptor)
+  # Duplicate the current std-output (FD 1) and assigns it to FD 3.
+  # This means that FD 3 now points to wherever the std-output was pointing.
+  exec 3>&1
+
   local test_execution_result
   test_execution_result=$(
     state::initialize_assertions_count
     runner::run_set_up
 
     # 2>&1: Redirects the std-error (FD 2) to the std-output (FD 1).
+    # points to the original std-output.
     "$function_name" "$@" 2>&1
 
     runner::run_tear_down
@@ -163,13 +169,26 @@ function runner::run_test() {
     state::export_assertions_count
   )
 
+  # Closes FD 3, which was used temporarily to hold the original stdout.
+  exec 3>&-
+
   runner::parse_execution_result "$test_execution_result"
+
+  local subshell_output
+  subshell_output=$(\
+    echo "$test_execution_result" |\
+    tail -n 1 |\
+    sed -E -e 's/.*##TEST_OUTPUT=(.*)##.*/\1/g' |\
+    base64 --decode
+  )
+  if [[ -n "$subshell_output" ]]; then
+    printf "%s\n" "$subshell_output"
+  fi
 
   local runtime_output
   runtime_output="${test_execution_result%%##ASSERTIONS*}"
-  printf "%s" "$runtime_output"
 
-  local runtime_error
+  local runtime_error=""
   if [[ "$runtime_output" == *"command not found"* ]]; then
     runtime_error=$(echo "${runtime_output#*: }" | tr -d '\n')
   fi
@@ -188,22 +207,17 @@ function runner::run_test() {
     state::add_tests_failed
     console_results::print_error_test "$function_name" "$runtime_error"
     logger::test_failed "$test_file" "$function_name" "$duration" "$total_assertions"
-
-    echo -e "$(state::get_tests_failed)) $test_file\n$runtime_error\n" >> "$NON_SUCCESSFUL_RESULT_OUTPUT"
-
+    runner::write_failure_result_output "$test_file" "$runtime_error"
     return
   fi
 
   if [[ "$current_assertions_failed" != "$(state::get_assertions_failed)" ]]; then
     state::add_tests_failed
     logger::test_failed "$test_file" "$function_name" "$duration" "$total_assertions"
-
-    echo -e "$(state::get_tests_failed)) $test_file\n$runtime_output" >> "$NON_SUCCESSFUL_RESULT_OUTPUT"
-
+    runner::write_failure_result_output "$test_file" "$subshell_output"
     if [ "$BASHUNIT_STOP_ON_FAILURE" = true ]; then
       exit 1
     fi
-
     return
   fi
 
@@ -232,6 +246,13 @@ function runner::run_test() {
   console_results::print_successful_test "${label}" "$duration" "$@"
   state::add_tests_passed
   logger::test_passed "$test_file" "$function_name" "$duration" "$total_assertions"
+}
+
+function runner::write_failure_result_output() {
+  local test_file=$1
+  local error_msg=$2
+
+  echo -e "$(state::get_tests_failed)) $test_file\n$error_msg" >> "$NON_SUCCESSFUL_RESULT_OUTPUT"
 }
 
 function runner::run_set_up() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -166,12 +166,12 @@ function runner::run_test() {
 
     runner::run_tear_down
     runner::clear_mocks
-    state::export_assertions_count
+    state::export_subshell_context
   )
 
   # Closes FD 3, which was used temporarily to hold the original stdout.
   exec 3>&-
-#dump $test_execution_result
+
   runner::parse_execution_result "$test_execution_result"
 
   local subshell_output

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -200,7 +200,7 @@ function runner::run_test() {
 
   if [[ -n $runtime_error ]]; then
     state::add_tests_failed
-    console_results::print_error_test "$function_name" "$runtime_error" "$duration"
+    console_results::print_error_test "$function_name" "$runtime_error"
     logger::test_failed "$test_file" "$function_name" "$duration" "$total_assertions"
     return
   fi

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -190,11 +190,11 @@ function runner::run_test() {
 
   local runtime_error=""
   for error in "command not found" "unbound variable" "permission denied" \
-               "no such file or directory" "syntax error" "bad substitution" \
-               "division by 0" "cannot allocate memory" "bad file descriptor" \
-               "segmentation fault" "illegal option" "argument list too long" \
-               "readonly variable" "missing keyword" "killed" \
-               "cannot execute binary file"; do
+      "no such file or directory" "syntax error" "bad substitution" \
+      "division by 0" "cannot allocate memory" "bad file descriptor" \
+      "segmentation fault" "illegal option" "argument list too long" \
+      "readonly variable" "missing keyword" "killed" \
+      "cannot execute binary file"; do
     if [[ "$runtime_output" == *"$error"* ]]; then
       runtime_error=$(echo "${runtime_output#*: }" | tr -d '\n')
       break

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -257,7 +257,7 @@ function runner::write_failure_result_output() {
   local test_file=$1
   local error_msg=$2
 
-  echo -e "$(state::get_tests_failed)) $test_file\n$error_msg" >> "$NON_SUCCESSFUL_RESULT_OUTPUT"
+  echo -e "$(state::get_tests_failed)) $test_file\n$error_msg" >> "$FAILURES_OUTPUT_PATH"
 }
 
 function runner::run_set_up() {

--- a/src/state.sh
+++ b/src/state.sh
@@ -140,7 +140,13 @@ function state::initialize_assertions_count() {
 
 function state::export_assertions_count() {
   local encoded_test_output
-  encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64)
+  if base64 --help 2>&1 | grep -q -- "-w"; then
+    # Alpine needs -w 0 to avoid line wrapping
+    encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64 -w 0)
+  else
+    # macOS and others don't need -w 0
+    encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64)
+  fi
 
   echo "##ASSERTIONS_FAILED=$_ASSERTIONS_FAILED\
 ##ASSERTIONS_PASSED=$_ASSERTIONS_PASSED\

--- a/src/state.sh
+++ b/src/state.sh
@@ -138,7 +138,7 @@ function state::initialize_assertions_count() {
     _TEST_OUTPUT=""
 }
 
-function state::export_assertions_count() {
+function state::export_subshell_context() {
   local encoded_test_output
   if base64 --help 2>&1 | grep -q -- "-w"; then
     # Alpine needs -w 0 to avoid line wrapping

--- a/src/state.sh
+++ b/src/state.sh
@@ -13,6 +13,7 @@ _ASSERTIONS_SNAPSHOT=0
 _DUPLICATED_FUNCTION_NAMES=""
 _FILE_WITH_DUPLICATED_FUNCTION_NAMES=""
 _DUPLICATED_TEST_FUNCTIONS_FOUND=false
+_TEST_OUTPUT=""
 
 function state::get_tests_passed() {
   echo "$_TESTS_PASSED"
@@ -118,6 +119,10 @@ function state::set_file_with_duplicated_function_names() {
   _FILE_WITH_DUPLICATED_FUNCTION_NAMES="$1"
 }
 
+function state::add_test_output() {
+  _TEST_OUTPUT+="$(printf "%s\n" "$1")"
+}
+
 function state::set_duplicated_functions_merged() {
   state::set_duplicated_test_functions_found
   state::set_file_with_duplicated_function_names "$1"
@@ -130,14 +135,19 @@ function state::initialize_assertions_count() {
     _ASSERTIONS_SKIPPED=0
     _ASSERTIONS_INCOMPLETE=0
     _ASSERTIONS_SNAPSHOT=0
+    _TEST_OUTPUT=""
 }
 
 function state::export_assertions_count() {
+  local encoded_test_output
+  encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64)
+
   echo "##ASSERTIONS_FAILED=$_ASSERTIONS_FAILED\
 ##ASSERTIONS_PASSED=$_ASSERTIONS_PASSED\
 ##ASSERTIONS_SKIPPED=$_ASSERTIONS_SKIPPED\
 ##ASSERTIONS_INCOMPLETE=$_ASSERTIONS_INCOMPLETE\
 ##ASSERTIONS_SNAPSHOT=$_ASSERTIONS_SNAPSHOT\
+##TEST_OUTPUT=$encoded_test_output\
 ##"
 }
 
@@ -160,4 +170,5 @@ function state::print_line() {
   local type=$1
   local line=$2
   printf "%s\n" "$line"
+  state::add_test_output "$(printf "%s\n" "$line")"
 }

--- a/src/state.sh
+++ b/src/state.sh
@@ -122,7 +122,6 @@ function state::set_duplicated_functions_merged() {
   state::set_duplicated_test_functions_found
   state::set_file_with_duplicated_function_names "$1"
   state::set_duplicated_function_names "$2"
-
 }
 
 function state::initialize_assertions_count() {
@@ -154,4 +153,11 @@ function state::calculate_total_assertions() {
   done
 
   echo $total
+}
+
+function state::print_line() {
+  # shellcheck disable=SC2034
+  local type=$1
+  local line=$2
+  printf "%s\n" "$line"
 }

--- a/tests/acceptance/bashunit_report_html_test.sh
+++ b/tests/acceptance/bashunit_report_html_test.sh
@@ -11,7 +11,10 @@ function test_bashunit_when_report_html_option() {
 
   assert_match_snapshot "$(./bashunit --env "$TEST_ENV_FILE" --report-html custom.html "$test_file")"
   assert_file_exists custom.html
-  rm custom.html
+
+  if [[ -f custom.html ]]; then
+    rm custom.html
+  fi
 }
 
 function test_bashunit_when_report_html_env() {
@@ -19,5 +22,8 @@ function test_bashunit_when_report_html_env() {
 
   assert_match_snapshot "$(./bashunit --env "$TEST_ENV_FILE_REPORT_HTML" "$test_file")"
   assert_file_exists report.html
-  rm report.html
+
+  if [[ -f custom.html ]]; then
+    rm custom.html
+  fi
 }

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -7,6 +7,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+|[31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'1'[0m
+|    [2mbut got [0m [1m'0'[0m
+
 [2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
 [2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -7,6 +7,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+|[31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'1'[0m
+|    [2mbut got [0m [1m'0'[0m
+
 [2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
 [2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -4,6 +4,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
     [2mExpected[0m [1m'2'[0m
     [2mbut got [0m [1m'3'[0m
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+|[31m✗ Failed[0m: Failure
+|    [2mExpected[0m [1m'2'[0m
+|    [2mbut got [0m [1m'3'[0m
+
 [2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 [2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -4,6 +4,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
     [2mExpected[0m [1m'2'[0m
     [2mbut got [0m [1m'3'[0m
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+|[31m✗ Failed[0m: Failure
+|    [2mExpected[0m [1m'2'[0m
+|    [2mbut got [0m [1m'3'[0m
+
 [2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 [2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -6,6 +6,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+|[31m✗ Failed[0m: Fail
+|    [2mExpected[0m [1m'to be empty'[0m
+|    [2mbut got [0m [1m'non empty'[0m
+
 [2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 [2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -6,6 +6,13 @@ Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+|[31m✗ Failed[0m: Fail
+|    [2mExpected[0m [1m'to be empty'[0m
+|    [2mbut got [0m [1m'non empty'[0m
+
 [2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 [2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -83,9 +83,8 @@ function test_unsuccessful_assert_is_file_empty() {
 
 # shellcheck disable=SC2155
 function test_successful_assert_files_equals() {
-  datetime=$(date +%s)
-  local expected="/tmp/a_random_file_${datetime}_1"
-  local actual="/tmp/a_random_file_${datetime}_2"
+  local expected="/tmp/test_successful_assert_files_equals_1"
+  local actual="/tmp/test_successful_assert_files_equals_2"
 
   local file_content="My multiline file
   Special char: \$, \*, and \\
@@ -109,8 +108,8 @@ function test_fails_assert_files_equals() {
   echo -e "same\noriginal content" > "$expected"
   echo -e "same\ndifferent content" > "$actual"
 
-  actual="$(assert_files_equals "$expected" "$actual")"
-  assert_contains "Fails assert files equals" "$actual"
+  assert_contains "Fails assert files equals" \
+    "$(assert_files_equals "$expected" "$actual")"
 
   rm "$expected"
   rm "$actual"
@@ -132,14 +131,14 @@ function test_successful_assert_files_not_equals() {
 
 # shellcheck disable=SC2155
 function test_fails_assert_files_not_equals() {
-  local expected="/tmp/test_fails_assert_files_not_equals"
-  local actual="/tmp/test_fails_assert_files_not_equals"
+  local expected="/tmp/test_fails_assert_files_not_equals_1"
+  local actual="/tmp/test_fails_assert_files_not_equals_2"
 
-  echo -e "same content" > "$expected"
-  echo -e "same content" > "$actual"
+  echo "same content" > "$expected"
+  echo "same content" > "$actual"
 
-  actual="$(assert_files_not_equals "$expected" "$actual")"
-  assert_contains "Files are equals" "$actual"
+  assert_contains "Files are equals" \
+    "$(assert_files_not_equals "$expected" "$actual")"
 
   rm "$expected"
   rm "$actual"

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -252,6 +252,7 @@ function test_initialize_assertions_count() {
 ##ASSERTIONS_SKIPPED=0\
 ##ASSERTIONS_INCOMPLETE=0\
 ##ASSERTIONS_SNAPSHOT=0\
+##TEST_OUTPUT=\
 ##"\
     "$export_assertions_count"
 }
@@ -264,16 +265,19 @@ function test_export_assertions_count() {
     _ASSERTIONS_SKIPPED=42
     _ASSERTIONS_INCOMPLETE=12
     _ASSERTIONS_SNAPSHOT=33
+    _ASSERTIONS_SNAPSHOT=33
+    _TEST_OUTPUT="something"
 
     state::export_assertions_count
   )
 
   assert_same\
-    "##ASSERTIONS_FAILED=5##\
-ASSERTIONS_PASSED=10##\
-ASSERTIONS_SKIPPED=42##\
-ASSERTIONS_INCOMPLETE=12##\
-ASSERTIONS_SNAPSHOT=33##"\
+    "##ASSERTIONS_FAILED=5\
+##ASSERTIONS_PASSED=10\
+##ASSERTIONS_SKIPPED=42\
+##ASSERTIONS_INCOMPLETE=12\
+##ASSERTIONS_SNAPSHOT=33\
+##TEST_OUTPUT=$(echo -n "something" | base64)##"\
     "$export_assertions_count"
 }
 
@@ -282,7 +286,8 @@ function test_calculate_total_assertions() {
   ##ASSERTIONS_PASSED=2\
   ##ASSERTIONS_SKIPPED=3\
   ##ASSERTIONS_INCOMPLETE=4\
-  ##ASSERTIONS_SNAPSHOT=5##"
+  ##ASSERTIONS_SNAPSHOT=5\
+  ##TEST_OUTPUT=##"
 
   assert_same 15 "$(state::calculate_total_assertions "$input")"
 }

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -243,7 +243,7 @@ function test_initialize_assertions_count() {
     _ASSERTIONS_SNAPSHOT=33
 
     state::initialize_assertions_count
-    state::export_assertions_count
+    state::export_subshell_context
   )
 
   assert_same\
@@ -268,7 +268,7 @@ function test_export_assertions_count() {
     _ASSERTIONS_SNAPSHOT=33
     _TEST_OUTPUT="something"
 
-    state::export_assertions_count
+    state::export_subshell_context
   )
 
   assert_same\


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/294

## 🔖 Changes

- Better handler runtime errors
- Have control over the single-test-outcomes
  - Do not use FD 3 when executing the test function. Instead, add the test output to the `subshell context`
-  Save the failing tests into a temporal file so that we can render them at the end of the runner


## 🖼️  Demo

<img width="869" alt="Screenshot 2024-09-23 at 00 49 29" src="https://github.com/user-attachments/assets/c63b2e56-3254-432d-aa9a-538fdb70003f">

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes