### PR TITLE
Make asserting failed exit codes and output nicer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Renamed `BASHUNIT_TESTS_ENV` to `BASHUNIT_LOAD_FILE`
 - Better handler runtime errors
 - Display failing tests after running the entire suite
+- Added defer expressions with `eval` when using standalone assertions
 
 ## [0.16.0](https://github.com/TypedDevs/bashunit/compare/0.15.0...0.16.0) - 2024-09-15
 

--- a/bashunit
+++ b/bashunit
@@ -28,6 +28,7 @@ source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
 _ASSERT_FN=""
 _FILTER=""
+_FORWARD_STDOUT=false
 _ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -40,6 +41,9 @@ while [[ $# -gt 0 ]]; do
     -f|--filter)
       _FILTER="$2"
       shift
+      ;;
+    --forward-stdout)
+      _FORWARD_STDOUT=true
       ;;
     -s|--simple)
       export BASHUNIT_SIMPLE_OUTPUT=true
@@ -97,7 +101,7 @@ done
 set +eu
 
 if [[ -n "$_ASSERT_FN" ]]; then
-  main::exec_assert "$_ASSERT_FN" "${_ARGS[@]}"
+  main::exec_assert "$_ASSERT_FN" "$_FORWARD_STDOUT" "${_ARGS[@]}"
 else
   main::exec_tests "$_FILTER" "${_ARGS[@]}"
 fi

--- a/bashunit
+++ b/bashunit
@@ -28,7 +28,6 @@ source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
 _ASSERT_FN=""
 _FILTER=""
-_FORWARD_STDOUT=false
 _ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -41,9 +40,6 @@ while [[ $# -gt 0 ]]; do
     -f|--filter)
       _FILTER="$2"
       shift
-      ;;
-    --forward-stdout)
-      _FORWARD_STDOUT=true
       ;;
     -s|--simple)
       export BASHUNIT_SIMPLE_OUTPUT=true
@@ -101,7 +97,7 @@ done
 set +eu
 
 if [[ -n "$_ASSERT_FN" ]]; then
-  main::exec_assert "$_ASSERT_FN" "$_FORWARD_STDOUT" "${_ARGS[@]}"
+  main::exec_assert "$_ASSERT_FN" "${_ARGS[@]}"
 else
   main::exec_tests "$_FILTER" "${_ARGS[@]}"
 fi

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -45,12 +45,12 @@ The prefix `assert_` is optional.
 
 ## Lazy evaluations
 
-You can evaluate the `exit_code` for your scripts using `eval...` instead of executing them with `$(...)` to avoid
-interrupting the CI when encountering a potential error (anything but `0`).
+You can evaluate the `exit_code` for your scripts using the command to call as raw-string instead of
+executing them with `$(...)` to avoid interrupting the CI when encountering a potential error (anything but `0`).
 
 ::: code-group
 ```bash [Example]
-./bashunit -a exit_code "1" "eval $PHPSTAN_PATH analyze \
+./bashunit -a exit_code "1" "$PHPSTAN_PATH analyze \
   --no-progress --level 8 \
   --error-format raw ./"
 ```
@@ -59,11 +59,11 @@ Testing.php:3:Method Testing::bar() has no return type specified.
 ```
 :::
 
-This is useful to get control over the output of your `eval...`:
+This is useful to get control over the output of your "callable":
 
 ::: code-group
 ```bash [Example]
-OUTPUT=$(./bashunit -a exit_code "1" "eval $PHPSTAN_PATH analyze \
+OUTPUT=$(./bashunit -a exit_code "1" "$PHPSTAN_PATH analyze \
   --no-progress --level 8 \
   --error-format raw ./")
 ./bashunit -a line_count 1 "$OUTPUT"
@@ -75,12 +75,12 @@ OUTPUT=$(./bashunit -a exit_code "1" "eval $PHPSTAN_PATH analyze \
 
 ### Full control over the stdout and stderr
 
-The stdout will be used for the eval result, while bashunit output will be on stderr.
+The stdout will be used for the callable result, while bashunit output will be on stderr.
 This way you can control the FD and redirect the output as you need.
 
 ::: code-group
 ```bash [Example]
-./bashunit -a exit_code "0" "eval $PHPSTAN_PATH analyze \
+./bashunit -a exit_code "0" "$PHPSTAN_PATH analyze \
   --no-progress --level 8 \
   --error-format raw ./" 2> /tmp/error.log
 ```

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -43,3 +43,24 @@ The prefix `assert_` is optional.
 ```
 :::
 
+
+## Lazy evaluations
+
+You can evaluate the `exit_code` for your scripts using `eval...` instead of executing them with `$(...)` to avoid
+interrupting the CI when encountering a potential error (anything different from `0`). For example:
+
+::: code-group
+```bash [Example]
+../bashunit -a exit_code "0" "eval $PHPSTAN_PATH analyze \
+  --no-progress --level 8 \
+  --error-format raw ./" 1>&1 2> /tmp/error.log
+```
+```[Output]
+Testing.php:3:Method Testing::bar() has no return type specified.
+```
+```[/tmp/error.log]
+✗ Failed: Main::exec assert
+    Expected '0'
+    but got  '1'
+```
+:::

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -43,17 +43,46 @@ The prefix `assert_` is optional.
 ```
 :::
 
-
 ## Lazy evaluations
 
 You can evaluate the `exit_code` for your scripts using `eval...` instead of executing them with `$(...)` to avoid
-interrupting the CI when encountering a potential error (anything different from `0`). For example:
+interrupting the CI when encountering a potential error (anything but `0`).
 
 ::: code-group
 ```bash [Example]
-../bashunit -a exit_code "0" "eval $PHPSTAN_PATH analyze \
+./bashunit -a exit_code "1" "eval $PHPSTAN_PATH analyze \
   --no-progress --level 8 \
-  --error-format raw ./" 1>&1 2> /tmp/error.log
+  --error-format raw ./"
+```
+```[Output]
+Testing.php:3:Method Testing::bar() has no return type specified.
+```
+:::
+
+This is useful to get control over the output of your `eval...`:
+
+::: code-group
+```bash [Example]
+OUTPUT=$(./bashunit -a exit_code "1" "eval $PHPSTAN_PATH analyze \
+  --no-progress --level 8 \
+  --error-format raw ./")
+./bashunit -a line_count 1 "$OUTPUT"
+```
+```[Output]
+# No output
+```
+:::
+
+### Full control over the stdout and stderr
+
+The stdout will be used for the eval result, while bashunit output will be on stderr.
+This way you can control the FD and redirect the output as you need.
+
+::: code-group
+```bash [Example]
+./bashunit -a exit_code "0" "eval $PHPSTAN_PATH analyze \
+  --no-progress --level 8 \
+  --error-format raw ./" 2> /tmp/error.log
 ```
 ```[Output]
 Testing.php:3:Method Testing::bar() has no return type specified.

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -213,7 +213,7 @@ function assert_general_error() {
   local actual_exit_code=${3-"$?"}
   local expected_exit_code=1
 
-  if [[ $actual_exit_code -ne "$expected_exit_code" ]]; then
+  if [[ "$actual_exit_code" -ne "$expected_exit_code" ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed

--- a/src/main.sh
+++ b/src/main.sh
@@ -34,8 +34,7 @@ function main::exec_tests() {
 
 function main::exec_assert() {
   local original_assert_fn=$1
-  local forward_stdout=$2
-  local args=("${@:3}")
+  local args=("${@:2}")
 
   local assert_fn=$original_assert_fn
 
@@ -56,7 +55,7 @@ function main::exec_assert() {
   local bashunit_exit_code=0
   local output
 
-  if [[ "$last_arg" == eval* ]]; then
+  if [[ "$assert_fn" == "assert_exit_code" && "$last_arg" == eval* ]]; then
     local callable_command="${last_arg#eval }"
     output=$(eval "$callable_command" 2>&1 || echo "inner_exit_code:$?")
 
@@ -74,8 +73,8 @@ function main::exec_assert() {
   fi
 
   if [[ -n "$output" ]]; then
-    [[ "$forward_stdout" == "true" ]] && echo "$output" 1>&1
-    [[ "$assert_fn" == "assert_exit_code" ]] && assert_fn="assert_same"
+    echo "$output" 1>&1
+    assert_fn="assert_same"
   fi
 
   # Run the assertion function and write into stderr

--- a/src/main.sh
+++ b/src/main.sh
@@ -43,45 +43,48 @@ function main::exec_assert() {
   if ! type "$assert_fn" > /dev/null 2>&1; then
     assert_fn="assert_$assert_fn"
     if ! type "$assert_fn" > /dev/null 2>&1; then
+      # Write into stderr
+      echo "Function $original_assert_fn does not exist." 1>&2
       exit 127
     fi
   fi
 
-  if [[ "$assert_fn" == "assert_exit_code" ]]; then
-    # Get the last argument safely by calculating the array length
-    local last_index=$((${#args[@]} - 1))
-    local last_arg="${args[$last_index]}"
+  # Get the last argument safely by calculating the array length
+  local last_index=$((${#args[@]} - 1))
+  local last_arg="${args[$last_index]}"
+  local inner_exit_code=0
+  local bashunit_exit_code=0
+  local output
 
-    if [[ "$last_arg" == callable:* ]]; then
-      local callable_command="${last_arg#callable:(}"
-      callable_command="${callable_command%)}"  # Remove both 'callable:(' and ')'
+  if [[ "$last_arg" == eval* ]]; then
+    local callable_command="${last_arg#eval }"
+    output=$(eval "$callable_command" 2>&1 || echo "inner_exit_code:$?")
 
-      # Capture the output directly into a variable
-      local output
-      output=$(eval "$callable_command" 2>&1 || echo "exit_code:$?")
-
-      local last_line
-      last_line=$(echo "$output" | tail -n 1)
-      local exit_code
-      exit_code=$(echo "$last_line" | grep -o 'exit_code:[0-9]*' | cut -d':' -f2)
-      output=$(echo "$output" | sed '$d')
-
-      # Remove the last argument and append the output
-      args=("${args[@]:0:last_index}")
-      args+=("$exit_code")
+    local last_line
+    last_line=$(echo "$output" | tail -n 1)
+    inner_exit_code=$(echo "$last_line" | grep -o 'inner_exit_code:[0-9]*' | cut -d':' -f2)
+    if ! [[ $inner_exit_code =~ ^[0-9]+$ ]]; then
+      inner_exit_code=1
     fi
+    output=$(echo "$output" | sed '$d')
 
-    if [[ "$forward_stdout" == "true" ]]; then
-      echo "$output"
-    fi
-
-    assert_fn=assert_same
+    # Remove the last argument and append the output
+    args=("${args[@]:0:last_index}")
+    args+=("$inner_exit_code")
   fi
 
-  # Run the assertion function
-  "$assert_fn" "${args[@]}"
+  if [[ -n "$output" ]]; then
+    [[ "$forward_stdout" == "true" ]] && echo "$output" 1>&1
+    [[ "$assert_fn" == "assert_exit_code" ]] && assert_fn="assert_same"
+  fi
+
+  # Run the assertion function and write into stderr
+  "$assert_fn" "${args[@]}" 1>&2
+  bashunit_exit_code=$?
 
   if [[ "$(state::get_tests_failed)" -gt 0 ]] || [[ "$(state::get_assertions_failed)" -gt 0 ]]; then
     exit 1
   fi
+
+  return "$bashunit_exit_code"
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -56,7 +56,9 @@ function main::exec_assert() {
   local output
 
   if [[ "$assert_fn" == "assert_exit_code" && "$last_arg" == eval* ]]; then
+    # remove the "eval" word from the last argument
     local callable_command="${last_arg#eval }"
+    # use real bash "eval" to evaluate your command
     output=$(eval "$callable_command" 2>&1 || echo "inner_exit_code:$?")
 
     local last_line

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -83,12 +83,43 @@ function test_bashunit_direct_fn_call_non_existing_fn() {
   assert_command_not_found "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
 }
 
-function test_bashunit_assert_exit_code_successful_code() {
+function test_bashunit_assert_exit_code_successful_with_inner_func() {
+  local temp
+  temp=$(mktemp)
+
+  local output
+  # shellcheck disable=SC2116
+  output="$(./bashunit -a exit_code "0" "$(echo "this wont go to stdout")" 2> "$temp")"
+
+  assert_empty "$output"
+  assert_empty "$(cat "$temp")"
+
+  rm "$temp"
+}
+
+function test_bashunit_assert_exit_code_error_with_inner_func() {
+  local temp
+  temp=$(mktemp)
+
+  local output
+  # shellcheck disable=SC2116
+  output="$(./bashunit -a exit_code "1" "$(echo "this wont go to stdout")" 2> "$temp")"
+
+  assert_empty "$output"
+
+  assert_contains\
+    "$(console_results::print_failed_test "Main::exec assert" "0" "to be" "1")"\
+    "$(cat "$temp")"
+
+  rm "$temp"
+}
+
+function test_bashunit_assert_exit_code_eval_successful_code() {
   ./bashunit -a exit_code "0" "eval ./bashunit -a same 1 1"
   assert_successful_code
 }
 
-function test_bashunit_assert_exit_code_general_error() {
+function test_bashunit_assert_exit_code_eval_general_error() {
   ./bashunit -a exit_code "1" "eval ./bashunit -a same 0 1"
   assert_successful_code
 }

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -144,8 +144,3 @@ function test_bashunit_assert_exit_code_str_successful_and_exit_code_ok() {
 
   rm "$temp"
 }
-
-#function test_bashunit_assert_() {
-#  ./bashunit -a exit_code "1" -a contains "some error" -e "the_command"
-#  assert_successful_code
-#}

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -74,11 +74,11 @@ function test_bashunit_direct_fn_call_failure() {
   local expected="foo"
   local actual="bar"
 
-  assert_match_snapshot "$(./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual)"
+  assert_match_snapshot "$(./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual 2>&1)"
   assert_general_error "$(./bashunit -a assert_same --env "$TEST_ENV_FILE" "$expected" $actual)"
 }
 
 function test_bashunit_direct_fn_call_non_existing_fn() {
-  assert_match_snapshot "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
+  assert_match_snapshot "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE" 2>&1)"
   assert_command_not_found "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
 }

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -87,10 +87,10 @@ function test_bashunit_direct_fn_call_non_existing_fn() {
 function test_bashunit_assert_exit_code_successful_with_inner_func() {
   local temp=$(mktemp)
   # shellcheck disable=SC2116
-  local output="$(./bashunit -a exit_code "0" "$(echo "this wont go to stdout")" 2> "$temp")"
+  local output="$(./bashunit -a exit_code "0" "$(echo "unknown command")" 2> "$temp")"
 
   assert_empty "$output"
-  assert_empty "$(cat "$temp")"
+  assert_same "Command not found: unknown command" "$(cat "$temp")"
 
   rm "$temp"
 }
@@ -99,7 +99,7 @@ function test_bashunit_assert_exit_code_successful_with_inner_func() {
 function test_bashunit_assert_exit_code_error_with_inner_func() {
   local temp=$(mktemp)
   # shellcheck disable=SC2116
-  local output="$(./bashunit -a exit_code "1" "$(echo "this wont go to stdout")" 2> "$temp")"
+  local output="$(./bashunit -a exit_code "1" "$(echo "unknown command")" 2> "$temp")"
 
   assert_empty "$output"
 
@@ -144,3 +144,8 @@ function test_bashunit_assert_exit_code_str_successful_and_exit_code_ok() {
 
   rm "$temp"
 }
+
+#function test_bashunit_assert_() {
+#  ./bashunit -a exit_code "1" -a contains "some error" -e "the_command"
+#  assert_successful_code
+#}

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -82,3 +82,42 @@ function test_bashunit_direct_fn_call_non_existing_fn() {
   assert_match_snapshot "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE" 2>&1)"
   assert_command_not_found "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
 }
+
+function test_bashunit_assert_exit_code_successful_code() {
+  ./bashunit -a exit_code "0" "eval ./bashunit -a same 1 1"
+  assert_successful_code
+}
+
+function test_bashunit_assert_exit_code_general_error() {
+  ./bashunit -a exit_code "1" "eval ./bashunit -a same 0 1"
+  assert_successful_code
+}
+
+function test_bashunit_assert_exit_code_eval_successful_but_exit_code_error() {
+  local temp
+  temp=$(mktemp)
+
+  local output
+  output="$(./bashunit -a exit_code "1" "eval echo something to stdout" 2> "$temp")"
+
+  assert_same "something to stdout" "$output"
+
+  assert_contains\
+    "$(console_results::print_failed_test "Main::exec assert" "1" "but got " "0")"\
+    "$(cat "$temp")"
+
+  rm "$temp"
+}
+
+function test_bashunit_assert_exit_code_eval_successful_and_exit_code_ok() {
+  local temp
+  temp=$(mktemp)
+
+  local output
+  output="$(./bashunit -a exit_code "0" "eval echo something to stdout" 2> "$temp")"
+
+  assert_same "something to stdout" "$output"
+  assert_empty "$(cat "$temp")"
+
+  rm "$temp"
+}

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -83,13 +83,11 @@ function test_bashunit_direct_fn_call_non_existing_fn() {
   assert_command_not_found "$(./bashunit -a non_existing_fn --env "$TEST_ENV_FILE")"
 }
 
+# shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_successful_with_inner_func() {
-  local temp
-  temp=$(mktemp)
-
-  local output
+  local temp=$(mktemp)
   # shellcheck disable=SC2116
-  output="$(./bashunit -a exit_code "0" "$(echo "this wont go to stdout")" 2> "$temp")"
+  local output="$(./bashunit -a exit_code "0" "$(echo "this wont go to stdout")" 2> "$temp")"
 
   assert_empty "$output"
   assert_empty "$(cat "$temp")"
@@ -97,13 +95,11 @@ function test_bashunit_assert_exit_code_successful_with_inner_func() {
   rm "$temp"
 }
 
+# shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_error_with_inner_func() {
-  local temp
-  temp=$(mktemp)
-
-  local output
+  local temp=$(mktemp)
   # shellcheck disable=SC2116
-  output="$(./bashunit -a exit_code "1" "$(echo "this wont go to stdout")" 2> "$temp")"
+  local output="$(./bashunit -a exit_code "1" "$(echo "this wont go to stdout")" 2> "$temp")"
 
   assert_empty "$output"
 
@@ -114,22 +110,20 @@ function test_bashunit_assert_exit_code_error_with_inner_func() {
   rm "$temp"
 }
 
-function test_bashunit_assert_exit_code_eval_successful_code() {
-  ./bashunit -a exit_code "0" "eval ./bashunit -a same 1 1"
+function test_bashunit_assert_exit_code_str_successful_code() {
+  ./bashunit -a exit_code "0" "./bashunit -a same 1 1"
   assert_successful_code
 }
 
-function test_bashunit_assert_exit_code_eval_general_error() {
-  ./bashunit -a exit_code "1" "eval ./bashunit -a same 0 1"
+function test_bashunit_assert_exit_code_str_general_error() {
+  ./bashunit -a exit_code "1" "./bashunit -a same 1 2"
   assert_successful_code
 }
 
-function test_bashunit_assert_exit_code_eval_successful_but_exit_code_error() {
-  local temp
-  temp=$(mktemp)
-
-  local output
-  output="$(./bashunit -a exit_code "1" "eval echo something to stdout" 2> "$temp")"
+# shellcheck disable=SC2155
+function test_bashunit_assert_exit_code_str_successful_but_exit_code_error() {
+  local temp=$(mktemp)
+  local output="$(./bashunit -a exit_code "1" "echo something to stdout" 2> "$temp")"
 
   assert_same "something to stdout" "$output"
 
@@ -140,12 +134,10 @@ function test_bashunit_assert_exit_code_eval_successful_but_exit_code_error() {
   rm "$temp"
 }
 
-function test_bashunit_assert_exit_code_eval_successful_and_exit_code_ok() {
-  local temp
-  temp=$(mktemp)
-
-  local output
-  output="$(./bashunit -a exit_code "0" "eval echo something to stdout" 2> "$temp")"
+# shellcheck disable=SC2155
+function test_bashunit_assert_exit_code_str_successful_and_exit_code_ok() {
+  local temp=$(mktemp)
+  local output="$(./bashunit -a exit_code "0" "echo something to stdout" 2> "$temp")"
 
   assert_same "something to stdout" "$output"
   assert_empty "$(cat "$temp")"


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/334

## 🔖 Changes

- Allow defer calling a function when asserting `exit_code` by passing the callable command to evaluate as raw string instead of `$(...)`
- bashunit output will be render on the stderr

## 🖼️  Demo

Render the stdout in the terminal and the errors in a file

<img width="1504" alt="Screenshot 2024-09-28 at 10 21 54" src="https://github.com/user-attachments/assets/6bdd0e57-d877-452f-8991-4fc8f7665d9c">

```bash
export PHPSTAN_PATH=[...]/vendor/bin/phpstan

../bashunit -a exit_code "1" "$PHPSTAN_PATH analyze --no-progress --level 8 --error-format raw ./"
echo $?

../bashunit -a exit_code "0" "$PHPSTAN_PATH analyze --no-progress --level 8 --error-format raw ./"
echo $?

../bashunit -a exit_code "0" "$PHPSTAN_PATH analyze --no-progress --level 8 --error-format raw ./" 2> /tmp/error.log
cat /tmp/error.log
```

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes

![Screenshot 2024-09-28 at 10 25 43](https://github.com/user-attachments/assets/d941944b-26cf-4070-a4e8-b9f0748f87c7)

