### PR TITLE
Improve test duration output 

### DIFF
--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -131,7 +131,7 @@ function console_results::print_successful_test() {
 
     local full_line=$line
     if [[ $BASHUNIT_SHOW_EXECUTION_TIME == true ]]; then
-      full_line="$(printf "%s\n" "$(str::rpad "$line" "($duration ms)")")"
+      full_line="$(printf "%s\n" "$(str::rpad "$line" "$duration ms")")"
     fi
 
     state::print_line "successful" "$full_line"

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -11,17 +11,16 @@ _DEFAULT_DEFAULT_PATH=
 _DEFAULT_LOG_JUNIT=
 _DEFAULT_REPORT_HTML=
 _DEFAULT_BASHUNIT_LOAD_FILE=
-_DEFAULT_TERMINAL_WIDTH=250
+_DEFAULT_TERMINAL_WIDTH=100
 
 function find_terminal_width() {
   local cols=""
 
-  if [[ -n "$TERM" ]] && command -v tput > /dev/null; then
-    cols=$(stty size 2>/dev/null | cut -d' ' -f2)
-  fi
-
   if [[ -z "$cols" ]] && command -v stty > /dev/null; then
     cols=$(tput cols 2>/dev/null)
+  fi
+  if [[ -n "$TERM" ]] && command -v tput > /dev/null; then
+    cols=$(stty size 2>/dev/null | cut -d' ' -f2)
   fi
 
   # Directly echo the value with fallback

--- a/src/default_env_config.sh
+++ b/src/default_env_config.sh
@@ -11,24 +11,23 @@ _DEFAULT_DEFAULT_PATH=
 _DEFAULT_LOG_JUNIT=
 _DEFAULT_REPORT_HTML=
 _DEFAULT_BASHUNIT_LOAD_FILE=
-_DEFAULT_TERMINAL_WIDTH=150
-
-CAT="$(which cat)"
+_DEFAULT_TERMINAL_WIDTH=250
 
 function find_terminal_width() {
-  local _cols=""
+  local cols=""
 
   if [[ -n "$TERM" ]] && command -v tput > /dev/null; then
-    _cols=$(tput cols 2>/dev/null)
+    cols=$(stty size 2>/dev/null | cut -d' ' -f2)
   fi
 
-  if [[ -z "$_cols" ]] && command -v stty > /dev/null; then
-    _cols=$(stty size 2>/dev/null | cut -d' ' -f2)
+  if [[ -z "$cols" ]] && command -v stty > /dev/null; then
+    cols=$(tput cols 2>/dev/null)
   fi
 
   # Directly echo the value with fallback
-  echo "${_cols:-$_DEFAULT_TERMINAL_WIDTH}"
+  echo "${cols:-$_DEFAULT_TERMINAL_WIDTH}"
 }
 
 TERMINAL_WIDTH="$(find_terminal_width)"
 FAILURES_OUTPUT_PATH=$(mktemp)
+CAT="$(which cat)"

--- a/src/str.sh
+++ b/src/str.sh
@@ -4,7 +4,8 @@ function str::rpad() {
   local left_text="$1"
   local right_word="$2"
   local width_padding="${3:-$TERMINAL_WIDTH}"
-  local padding=$((width_padding - ${#right_word} - 1))  # Subtract 1 more to account for the extra space
+  # Subtract 1 more to account for the extra space
+  local padding=$((width_padding - ${#right_word} - 1))
 
   # Remove ANSI escape sequences (non-visible characters) for length calculation
   # shellcheck disable=SC2155
@@ -44,12 +45,23 @@ function str::rpad() {
     fi
   done
 
-  if $truncated; then
+  local remaining_space
+  if [[ "$truncated" == true ]]; then
     result_left_text+="..."
+    # 1: due to a blank space
+    # 3: due to the appended ...
+    remaining_space=$((width_padding - ${#clean_left_text} - ${#right_word} - 1 - 3))
   else
     # Copy any remaining characters after the truncation point
     result_left_text+="${left_text:$j}"
+    remaining_space=$((width_padding - ${#clean_left_text} - ${#right_word} - 1))
   fi
 
-  printf "%-${padding}s %s" "$result_left_text" "$right_word"
+  # Ensure the right word is placed exactly at the far right of the screen
+  # filling the remaining space with padding
+  if [[ $remaining_space -lt 0 ]]; then
+    remaining_space=0
+  fi
+
+  printf "%s%${remaining_space}s %s\n" "$result_left_text" "" "$right_word"
 }

--- a/src/str.sh
+++ b/src/str.sh
@@ -3,8 +3,13 @@
 function str::rpad() {
   local left_text="$1"
   local right_word="$2"
-  local width_padding="${3:-(($TERMINAL_WIDTH))}"
-  local padding=$((width_padding - ${#left_text}))
+  local width_padding="${3:-$TERMINAL_WIDTH}"
+  local padding=$((width_padding - ${#right_word}))
 
-  printf "%s%*s" "$left_text" "$padding" "$right_word"
+  # If the left text exceeds the padding, truncate it and add "..."
+  if [[ ${#left_text} -gt $padding ]]; then
+    left_text="${left_text:0:$((padding - 3))}..."
+  fi
+
+  printf "%-${padding}s%s" "$left_text" "$right_word"
 }

--- a/src/str.sh
+++ b/src/str.sh
@@ -4,12 +4,52 @@ function str::rpad() {
   local left_text="$1"
   local right_word="$2"
   local width_padding="${3:-$TERMINAL_WIDTH}"
-  local padding=$((width_padding - ${#right_word}))
+  local padding=$((width_padding - ${#right_word} - 1))  # Subtract 1 more to account for the extra space
 
-  # If the left text exceeds the padding, truncate it and add "..."
-  if [[ ${#left_text} -gt $padding ]]; then
-    left_text="${left_text:0:$((padding - 3))}..."
+  # Remove ANSI escape sequences (non-visible characters) for length calculation
+  # shellcheck disable=SC2155
+  local clean_left_text=$(echo -e "$left_text" | sed 's/\x1b\[[0-9;]*m//g')
+
+  local truncated=false
+  # If the visible left text exceeds the padding, truncate it and add "..."
+  if [[ ${#clean_left_text} -gt $padding ]]; then
+    local truncation_length=$((padding - 3))  # Subtract 3 for "..."
+    clean_left_text="${clean_left_text:0:$truncation_length}"
+    truncated=true
   fi
 
-  printf "%-${padding}s%s" "$left_text" "$right_word"
+  # Rebuild the text with ANSI codes intact, preserving the truncation
+  local result_left_text=""
+  local i=0
+  local j=0
+  while [[ $i -lt ${#clean_left_text} && $j -lt ${#left_text} ]]; do
+    local char="${clean_left_text:$i:1}"
+    local original_char="${left_text:$j:1}"
+
+    # If the current character is part of an ANSI sequence, skip it and copy it
+    if [[ "$original_char" == $'\x1b' ]]; then
+      while [[ "${left_text:$j:1}" != "m" && $j -lt ${#left_text} ]]; do
+        result_left_text+="${left_text:$j:1}"
+        ((j++))
+      done
+      result_left_text+="${left_text:$j:1}"  # Append the final 'm'
+      ((j++))
+    elif [[ "$char" == "$original_char" ]]; then
+      # Match the actual character
+      result_left_text+="$char"
+      ((i++))
+      ((j++))
+    else
+      ((j++))
+    fi
+  done
+
+  if $truncated; then
+    result_left_text+="..."
+  else
+    # Copy any remaining characters after the truncation point
+    result_left_text+="${left_text:$j}"
+  fi
+
+  printf "%-${padding}s %s" "$result_left_text" "$right_word"
 }

--- a/tests/unit/str_test.sh
+++ b/tests/unit/str_test.sh
@@ -29,8 +29,15 @@ function test_rpad_custom_width_padding_2_digit() {
 
   assert_same "input             10" "$actual"
 }
+
 function test_rpad_custom_width_padding_3_digit() {
   local actual=$(str::rpad "input" "100" 20)
 
   assert_same "input            100" "$actual"
+}
+
+function test_rpad_custom_width_padding_text_too_long() {
+  local actual=$(str::rpad "very long text too large" "100" 20)
+
+  assert_same "very long text...100" "$actual"
 }

--- a/tests/unit/str_test.sh
+++ b/tests/unit/str_test.sh
@@ -39,5 +39,14 @@ function test_rpad_custom_width_padding_3_digit() {
 function test_rpad_custom_width_padding_text_too_long() {
   local actual=$(str::rpad "very long text too large" "100" 20)
 
-  assert_same "very long text...100" "$actual"
+  assert_same "very long tex... 100" "$actual"
+}
+
+function test_rpad_custom_width_padding_text_too_long_and_special_chars() {
+  local txt=$(printf "%s%s%s%s" "$_COLOR_PASSED" "ok: " "$_COLOR_DEFAULT" "very long text as well")
+  local actual=$(str::rpad "$txt" "100" 20)
+
+  assert_same \
+    "$(printf "%sok: %svery long... 100" "$_COLOR_PASSED" "$_COLOR_DEFAULT")" \
+    "$actual"
 }


### PR DESCRIPTION
## 📚  Changes

- Render the execution test-time on the same line - at the very end of the terminal.
  - If the line is too long, then cut it and use `...` to create awareness the test name is larger than what you see
- Simplify the test duration: from `(123 ms)` to `123 ms`

## 🖼️  Demo

### BEFORE

![Screenshot 2024-09-28 at 13 13 16](https://github.com/user-attachments/assets/d14c48cf-1ad4-4e1e-a6ef-0be79eca6c12)

### AFTER

![Screenshot 2024-09-28 at 13 12 57](https://github.com/user-attachments/assets/a723e87d-40b7-4536-a8ae-9ead5b78342e)

