### PR TITLE
Better cleanup temporal files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - temp_dir
     - cleanup_temp_files
     - log
+- Improved clean up temporal files and directories
 
 ## [0.17.0](https://github.com/TypedDevs/bashunit/compare/0.16.0...0.17.0) - 2024-10-01
 

--- a/bashunit
+++ b/bashunit
@@ -102,8 +102,6 @@ done
 
 set +eu
 
-trap 'cleanup_temp_files' EXIT
-
 if [[ -n "$_ASSERT_FN" ]]; then
   main::exec_assert "$_ASSERT_FN" "${_ARGS[@]}"
 else

--- a/bashunit
+++ b/bashunit
@@ -102,6 +102,8 @@ done
 
 set +eu
 
+trap 'cleanup_temp_files' EXIT
+
 if [[ -n "$_ASSERT_FN" ]]; then
   main::exec_assert "$_ASSERT_FN" "${_ARGS[@]}"
 else

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -25,17 +25,17 @@ function random_str() {
 }
 
 function temp_file() {
-  mkdir -p /tmp/bashunit
-  mktemp --tmpdir="/tmp/bashunit" "XXXXXXX"
+  mkdir -p /tmp/bashunit-tmp && chmod -R 777 /tmp/bashunit-tmp
+  mktemp --tmpdir="/tmp/bashunit-tmp" "XXXXXXX"
 }
 
 function temp_dir() {
-  mkdir -p /tmp/bashunit
-  mktemp -d --tmpdir="/tmp/bashunit" "XXXXXXX"
+  mkdir -p /tmp/bashunit-tmp && chmod -R 777 /tmp/bashunit-tmp
+  mktemp -d --tmpdir="/tmp/bashunit-tmp" "XXXXXXX"
 }
 
 function cleanup_temp_files() {
-  rm -rf /tmp/bashunit/*
+  rm -rf /tmp/bashunit-tmp/*
 }
 
 # shellcheck disable=SC2145

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -25,21 +25,17 @@ function random_str() {
 }
 
 function temp_file() {
-  # shellcheck disable=SC2155
-  local path="/tmp/bashunit_temp.$(random_str)"
-  touch "$path"
-  echo "$path"
+  mkdir -p /tmp/bashunit
+  mktemp --tmpdir="/tmp/bashunit" "XXXXXXX"
 }
 
 function temp_dir() {
-  # shellcheck disable=SC2155
-  local dir="/tmp/bashunit_tempdir.$(random_str 5)}"
-  mkdir -p "$dir"
-  echo "$dir"
+  mkdir -p /tmp/bashunit
+  mktemp -d --tmpdir="/tmp/bashunit" "XXXXXXX"
 }
 
 function cleanup_temp_files() {
-  rm -rf /tmp/bashunit_temp*
+  rm -rf /tmp/bashunit/*
 }
 
 # shellcheck disable=SC2145

--- a/src/main.sh
+++ b/src/main.sh
@@ -29,6 +29,8 @@ function main::exec_tests() {
     logger::generate_report_html "$BASHUNIT_REPORT_HTML"
   fi
 
+  cleanup_temp_files
+
   exit $exit_code
 }
 

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -89,19 +89,17 @@ function test_bashunit_direct_fn_call_non_existing_fn() {
 
 # shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_successful_with_inner_func() {
-  local temp=$(mktemp)
+  local temp=$(temp_file)
   # shellcheck disable=SC2116
   local output="$(./bashunit -a exit_code "0" "$(echo "unknown command")" 2> "$temp")"
 
   assert_empty "$output"
   assert_same "Command not found: unknown command" "$(cat "$temp")"
-
-  rm "$temp"
 }
 
 # shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_error_with_inner_func() {
-  local temp=$(mktemp)
+  local temp=$(temp_file)
   # shellcheck disable=SC2116
   local output="$(./bashunit -a exit_code "1" "$(echo "unknown command")" 2> "$temp")"
 
@@ -110,8 +108,6 @@ function test_bashunit_assert_exit_code_error_with_inner_func() {
   assert_contains\
     "$(console_results::print_failed_test "Main::exec assert" "0" "to be" "1")"\
     "$(cat "$temp")"
-
-  rm "$temp"
 }
 
 function test_bashunit_assert_exit_code_str_successful_code() {
@@ -126,7 +122,7 @@ function test_bashunit_assert_exit_code_str_general_error() {
 
 # shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_str_successful_but_exit_code_error() {
-  local temp=$(mktemp)
+  local temp=$(temp_file)
   local output="$(./bashunit -a exit_code "1" "echo something to stdout" 2> "$temp")"
 
   assert_same "something to stdout" "$output"
@@ -134,17 +130,13 @@ function test_bashunit_assert_exit_code_str_successful_but_exit_code_error() {
   assert_contains\
     "$(console_results::print_failed_test "Main::exec assert" "1" "but got " "0")"\
     "$(cat "$temp")"
-
-  rm "$temp"
 }
 
 # shellcheck disable=SC2155
 function test_bashunit_assert_exit_code_str_successful_and_exit_code_ok() {
-  local temp=$(mktemp)
+  local temp=$(temp_file)
   local output="$(./bashunit -a exit_code "0" "echo something to stdout" 2> "$temp")"
 
   assert_same "something to stdout" "$output"
   assert_empty "$(cat "$temp")"
-
-  rm "$temp"
 }

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -94,7 +94,7 @@ function test_bashunit_assert_exit_code_successful_with_inner_func() {
   local output="$(./bashunit -a exit_code "0" "$(echo "unknown command")" 2> "$temp")"
 
   assert_empty "$output"
-  assert_same "Command not found: unknown command" "$(cat "$temp")"
+  assert_file_contains "$temp" "Command not found: unknown command"
 }
 
 # shellcheck disable=SC2155
@@ -105,9 +105,8 @@ function test_bashunit_assert_exit_code_error_with_inner_func() {
 
   assert_empty "$output"
 
-  assert_contains\
-    "$(console_results::print_failed_test "Main::exec assert" "0" "to be" "1")"\
-    "$(cat "$temp")"
+  assert_file_contains "$temp" \
+    "$(console_results::print_failed_test "Main::exec assert" "0" "to be" "1")"
 }
 
 function test_bashunit_assert_exit_code_str_successful_code() {
@@ -127,9 +126,8 @@ function test_bashunit_assert_exit_code_str_successful_but_exit_code_error() {
 
   assert_same "something to stdout" "$output"
 
-  assert_contains\
-    "$(console_results::print_failed_test "Main::exec assert" "1" "but got " "0")"\
-    "$(cat "$temp")"
+  assert_file_contains "$temp" \
+    "$(console_results::print_failed_test "Main::exec assert" "1" "but got " "0")"
 }
 
 # shellcheck disable=SC2155

--- a/tests/unit/directory_test.sh
+++ b/tests/unit/directory_test.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 
 function test_successful_assert_directory_exists() {
-  local a_directory
-  a_directory="$(current_dir)"
+  local a_directory="$(current_dir)"
 
   assert_empty "$(assert_directory_exists "$a_directory")"
 }
@@ -17,8 +17,7 @@ function test_unsuccessful_assert_directory_exists() {
 }
 
 function test_assert_directory_exists_should_not_work_with_files() {
-  local a_file
-  a_file="$(current_dir)/$(current_filename)"
+  local a_file="$(current_dir)/$(current_filename)"
 
   assert_same\
     "$(console_results::print_failed_test \
@@ -33,8 +32,7 @@ function test_successful_assert_directory_not_exists() {
 }
 
 function test_unsuccessful_assert_directory_not_exists() {
-  local a_directory
-  a_directory="$(current_dir)"
+  local a_directory="$(current_dir)"
 
   assert_same\
     "$(console_results::print_failed_test \
@@ -43,8 +41,7 @@ function test_unsuccessful_assert_directory_not_exists() {
 }
 
 function test_successful_assert_is_directory() {
-  local a_directory
-  a_directory="$(current_dir)"
+  local a_directory="$(current_dir)"
 
   assert_empty "$(assert_is_directory "$a_directory")"
 }
@@ -59,8 +56,7 @@ function test_unsuccessful_assert_is_directory() {
 }
 
 function test_unsuccessful_assert_is_directory_when_a_file_is_given() {
-  local a_file
-  a_file="$(current_dir)/$(current_filename)"
+  local a_file="$(current_dir)/$(current_filename)"
 
   assert_same\
     "$(console_results::print_failed_test\
@@ -69,17 +65,13 @@ function test_unsuccessful_assert_is_directory_when_a_file_is_given() {
 }
 
 function test_successful_assert_is_directory_empty() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_empty "$(assert_is_directory_empty "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_empty() {
-  local a_directory
-  a_directory="$(current_dir)"
+  local a_directory="$(current_dir)"
 
   assert_same\
     "$(console_results::print_failed_test \
@@ -88,36 +80,28 @@ function test_unsuccessful_assert_is_directory_empty() {
 }
 
 function test_successful_assert_is_directory_not_empty() {
-  local a_directory
-  a_directory="$(current_dir)"
+  local a_directory="$(current_dir)"
 
   assert_empty "$(assert_is_directory_not_empty "$a_directory")"
 }
 
 function test_unsuccessful_assert_is_directory_not_empty() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory not empty" "$a_directory" "to not be empty" "but is empty")"\
     "$(assert_is_directory_not_empty "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_successful_assert_is_directory_readable() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_empty "$(assert_is_directory_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_readable_when_a_file_is_given() {
-  local a_file
-  a_file="$(current_dir)/$(current_filename)"
+  local a_file="$(current_dir)/$(current_filename)"
 
   assert_same\
     "$(console_results::print_failed_test\
@@ -131,8 +115,7 @@ function test_unsuccessful_assert_is_directory_readable_without_execution_permis
     return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-x "$a_directory"
 
   assert_same\
@@ -140,8 +123,6 @@ function test_unsuccessful_assert_is_directory_readable_without_execution_permis
       "Unsuccessful assert is directory readable without execution permission" \
       "$a_directory" "to be readable" "but is not readable")"\
     "$(assert_is_directory_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_readable_without_read_permission() {
@@ -149,8 +130,7 @@ function test_unsuccessful_assert_is_directory_readable_without_read_permission(
       return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-r "$a_directory"
 
   assert_same\
@@ -158,8 +138,6 @@ function test_unsuccessful_assert_is_directory_readable_without_read_permission(
       "Unsuccessful assert is directory readable without read permission" \
       "$a_directory" "to be readable" "but is not readable")"\
     "$(assert_is_directory_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_successful_assert_is_directory_not_readable_without_read_permission() {
@@ -167,13 +145,10 @@ function test_successful_assert_is_directory_not_readable_without_read_permissio
       return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-r "$a_directory"
 
   assert_empty "$(assert_is_directory_not_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_successful_assert_is_directory_not_readable_without_execution_permission() {
@@ -181,34 +156,25 @@ function test_successful_assert_is_directory_not_readable_without_execution_perm
       return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-x "$a_directory"
 
   assert_empty "$(assert_is_directory_not_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_not_readable() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory not readable" "$a_directory" "to be not readable" "but is readable")"\
     "$(assert_is_directory_not_readable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_successful_assert_is_directory_writable() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_empty "$(assert_is_directory_writable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_writable() {
@@ -216,21 +182,17 @@ function test_unsuccessful_assert_is_directory_writable() {
       return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-w "$a_directory"
 
   assert_same\
     "$(console_results::print_failed_test \
       "Unsuccessful assert is directory writable" "$a_directory" "to be writable" "but is not writable")"\
     "$(assert_is_directory_writable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_writable_when_a_file_is_given() {
-  local a_file
-  a_file="$(current_dir)/$(current_filename)"
+  local a_file="$(current_dir)/$(current_filename)"
 
   assert_same\
     "$(console_results::print_failed_test\
@@ -244,24 +206,18 @@ function test_successful_assert_is_directory_not_writable() {
       return
   fi
 
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
   chmod a-w "$a_directory"
 
   assert_empty "$(assert_is_directory_not_writable "$a_directory")"
-
-  rmdir "$a_directory"
 }
 
 function test_unsuccessful_assert_is_directory_not_writable() {
-  local a_directory
-  a_directory=$(mktemp -d)
+  local a_directory=$(temp_dir)
 
   assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert is directory not writable" \
       "$a_directory" "to be not writable" "but is writable")"\
     "$(assert_is_directory_not_writable "$a_directory")"
-
-  rmdir "$a_directory"
 }


### PR DESCRIPTION
## 🔖 Changes

- Improved `temp_file` and `temp_dir`
- Call `cleanup_temp_files` at the end of bashunit > `main::exec()`
- Use `temp_file` instead of `mktemp` for better cleanup 

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix