### PR TITLE
Add bashdep to installation

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,22 @@ We try to keep it stable, but there is no promise that we won't change functions
 Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
 :::
 
+## Brew
+
+You can install **bashunit** globally in your macOS (or Linux) using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
 ## GitHub Actions
 
 ```yaml
@@ -81,22 +97,6 @@ jobs:
 ::: tip
 Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::
-
-## Brew
-
-You can install **bashunit** globally in your macOS (or Linux) using brew.
-
-```bash
-brew install bashunit
-```
-
-## MacPorts
-
-On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
-
-```bash
-sudo port install bashunit
-```
 
 <script setup>
 import pkg from '../package.json'

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -48,6 +48,37 @@ We try to keep it stable, but there is no promise that we won't change functions
 Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
 :::
 
+## bashdep
+
+You can manage your dependencies using [bashdep](https://github.com/Chemaclass/bashdep),
+a simple dependency manager for bash.
+
+::: code-group
+```bash-vue [install-dependencies.sh]
+# Ensure bashdep is installed
+[ ! -f lib/bashdep ] && {
+  mkdir -p lib
+  curl -sLo lib/bashdep \
+    https://github.com/Chemaclass/bashdep/releases/download/0.1/bashdep
+  chmod +x lib/bashdep
+}
+
+# Add latest bashunit release to your dependencies
+DEPENDENCIES=(
+  "https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/bashunit"
+)
+
+# Load, configure and run bashdep
+source lib/bashdep
+bashdep::setup dir="lib" silent=false
+bashdep::install "${DEPENDENCIES[@]}"
+```
+```[Output]
+Downloading 'bashunit' to 'lib'...
+> bashunit installed successfully in 'lib'
+```
+:::
+
 ## Brew
 
 You can install **bashunit** globally in your macOS (or Linux) using brew.


### PR DESCRIPTION
## 📚 Description

I have created a new project: "A simple dependency manager for bash" named [bashdep](https://github.com/Chemaclass/bashdep)

## 🔖 Changes

- Add `bashdep` to the installation page: https://bashunit.typeddevs.com/installation

> Usage example: https://github.com/Chemaclass/bash-skeleton/blob/main/install-dependencies.sh 

<img width="1290" alt="Screenshot 2024-10-06 at 00 23 04" src="https://github.com/user-attachments/assets/d4b0fc7b-e5e0-4034-91a7-9ae30108bba4">
