### PR TITLE
Improve assert true/false accepting callable as arg

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -5,9 +5,9 @@ We provide assertions for these checks.
 Below is their documentation.
 
 ## assert_true
-> `assert_true bool`
+> `assert_true bool|function|command`
 
-Reports an error if the `bool` is truthy `true` or `0`.
+Reports an error if the argument result in a truthy value: `true` or `0`.
 
 - [assert_false](#assert-false) is similar but different.
 
@@ -16,19 +16,30 @@ Reports an error if the `bool` is truthy `true` or `0`.
 function test_success() {
   assert_true true
   assert_true 0
+  assert_true "eval return 0"
+  assert_true mock_true
 }
 
 function test_failure() {
   assert_true false
   assert_true 1
+  assert_true "eval return 1"
+  assert_true mock_false
 }
 ```
+```bash [globals.sh]
+function mock_true() {
+  return 0
+}
+function mock_false() {
+  return 1
+}
 :::
 
 ## assert_false
-> `assert_false bool`
+> `assert_false bool|function|command`
 
-Reports an error if the `bool` is falsy `false` or `1`.
+Reports an error if the argument result in a falsy value: `false` or `1`.
 
 - [assert_true](#assert-true) is similar but different.
 
@@ -37,11 +48,23 @@ Reports an error if the `bool` is falsy `false` or `1`.
 function test_success() {
   assert_false false
   assert_false 1
+  assert_false "eval return 1"
+  assert_false mock_false
 }
 
 function test_failure() {
   assert_false true
   assert_false 0
+  assert_false "eval return 0"
+  assert_false mock_true
+}
+```
+```bash [globals.sh]
+function mock_true() {
+  return 0
+}
+function mock_false() {
+  return 1
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -23,7 +23,7 @@ function assert_true() {
   local exit_code=$?
 
   if [[ $exit_code -ne 0 ]]; then
-    handle_bool_assertion_failure "valid command, function, or true/0" "exit code: $exit_code"
+    handle_bool_assertion_failure "command or function with zero exit code" "exit code: $exit_code"
   else
     state::add_assertions_passed
   fi

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -33,7 +33,7 @@ function assert_true() {
 
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "valid command, function, or true/0"\
-      "but got" "unknown input"
+      "but got" "unknown input:$actual"
     return
   fi
 
@@ -82,7 +82,7 @@ function assert_false() {
 
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "valid command, function, or false/1"\
-      "but got" "unknown input"
+      "but got" "unknown input:$actual"
     return
   fi
 
@@ -104,7 +104,7 @@ function assert_false() {
 
   state::add_assertions_failed
   console_results::print_failed_test "${label}" "command or function with non-zero exit code"\
-    "but got" "unknown input"
+    "but got" "exit_code:$exit_code"
 }
 
 function assert_same() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -58,6 +58,18 @@ function test_unsuccessful_assert_false() {
     "$(assert_false true)"
 }
 
+function test_successful_assert_false_on_function() {
+  assert_empty "$(assert_false mock_false)"
+}
+
+function test_unsuccessful_assert_false_on_function() {
+  assert_same\
+    "$(console_results::print_failed_test "Unsuccessful assert false on function"\
+      "command or function with non-zero exit code"\
+      "but got" "unknown input")" \
+    "$(assert_false mock_true)"
+}
+
 function test_successful_assert_same() {
   assert_empty "$(assert_same "1" "1")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -36,7 +36,7 @@ function test_unsuccessful_assert_true_on_function() {
   assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert true on function"\
       "valid command, function, or true/0"\
-      "but got" "unknown input")" \
+      "but got" "unknown input:")" \
     "$(assert_true "$(return 1)")"
 }
 
@@ -66,8 +66,8 @@ function test_unsuccessful_assert_false_on_function() {
   assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert false on function"\
       "command or function with non-zero exit code"\
-      "but got" "unknown input")" \
-    "$(assert_false mock_true)"
+      "but got" "exit_code:0")" \
+    "$(assert_false ls)"
 }
 
 function test_successful_assert_same() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -41,7 +41,7 @@ function test_unsuccessful_assert_true_on_function() {
     "$(console_results::print_failed_test\
       "Unsuccessful assert true on function"\
       "valid command, function, or true/0"\
-      "but got " "unknown input: ")" \
+      "but got " "exit code: 127")" \
     "$(assert_true "$(return 1)")"
 }
 

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -28,6 +28,18 @@ function test_unsuccessful_assert_true() {
     "$(assert_true false)"
 }
 
+function test_successful_assert_true_on_function() {
+  assert_empty "$(assert_true ls)"
+}
+
+function test_unsuccessful_assert_true_on_function() {
+  assert_same\
+    "$(console_results::print_failed_test "Unsuccessful assert true on function"\
+      "valid command, function, or true/0"\
+      "but got" "unknown input")" \
+    "$(assert_true "$(return 1)")"
+}
+
 # data_provider provider_successful_assert_false
 function test_successful_assert_false() {
   # shellcheck disable=SC2086

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -40,9 +40,9 @@ function test_unsuccessful_assert_true_on_function() {
   assert_same\
     "$(console_results::print_failed_test\
       "Unsuccessful assert true on function"\
-      "valid command, function, or true/0"\
-      "but got " "exit code: 127")" \
-    "$(assert_true "$(return 1)")"
+      "command or function with zero exit code"\
+      "but got " "exit code: 2")" \
+    "$(assert_true "eval return 2")"
 }
 
 # data_provider provider_successful_assert_false

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -6,7 +6,8 @@ function test_successful_fail() {
 
 function test_unsuccessful_fail() {
   assert_same\
-    "$(console_results::print_failure_message "Unsuccessful fail" "Failure message")"\
+    "$(console_results::print_failure_message \
+      "Unsuccessful fail" "Failure message")"\
     "$(fail "Failure message")"
 }
 
@@ -24,7 +25,10 @@ function provider_successful_assert_true() {
 
 function test_unsuccessful_assert_true() {
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful assert true" "true or 0" "but got " "false")"\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert true" \
+      "true or 0" \
+      "but got " "false")"\
     "$(assert_true false)"
 }
 
@@ -34,9 +38,10 @@ function test_successful_assert_true_on_function() {
 
 function test_unsuccessful_assert_true_on_function() {
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful assert true on function"\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert true on function"\
       "valid command, function, or true/0"\
-      "but got" "unknown input:")" \
+      "but got " "unknown input: ")" \
     "$(assert_true "$(return 1)")"
 }
 
@@ -54,20 +59,24 @@ function provider_successful_assert_false() {
 
 function test_unsuccessful_assert_false() {
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful assert false" "false or 1" "but got " "true")"\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert false" \
+      "false or 1" \
+      "but got " "true")"\
     "$(assert_false true)"
 }
 
 function test_successful_assert_false_on_function() {
-  assert_empty "$(assert_false mock_false)"
+  assert_empty "$(assert_false "eval return 1")"
 }
 
 function test_unsuccessful_assert_false_on_function() {
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful assert false on function"\
+    "$(console_results::print_failed_test\
+      "Unsuccessful assert false on function"\
       "command or function with non-zero exit code"\
-      "but got" "exit_code:0")" \
-    "$(assert_false ls)"
+      "but got " "exit code: 0")" \
+    "$(assert_false "eval return 0")"
 }
 
 function test_successful_assert_same() {


### PR DESCRIPTION
## 📚 Description

Follow up after: https://github.com/TypedDevs/bashunit/pull/350

Idea by @skinner-m-c -> https://github.com/TypedDevs/bashunit/pull/350#discussion_r1788722180

## 🔖 Changes

- Improve `assert_true` and `assert_false`
  - Consider passing a function/command/alias that will resolve into true or false

## 🖼️ Screenshots

<img width="737" alt="Screenshot 2024-10-06 at 11 18 58" src="https://github.com/user-attachments/assets/3a064d64-cd23-4508-87b4-4d6bb19d043f">

<img width="765" alt="Screenshot 2024-10-06 at 11 19 07" src="https://github.com/user-attachments/assets/5b4882e5-3728-4700-9b65-2bdeeb4c3186">

