### PR TITLE
Improve CI tests runtime (halved)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,8 +5,9 @@ on:
   push:
     branches:
       - main
+
 jobs:
-  tests:
+  ubuntu-macos:
     name: "Run tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -14,21 +15,27 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run Tests (Windows)
-        if: runner.os == 'Windows'
+      - name: Run Tests
+        run: make test
+
+  windows:
+    name: "Run tests on Windows"
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Tests
         shell: bash
         run: ./bashunit -e tests/bootstrap.sh tests/**/*_test.sh
-
-      - name: Run Tests (Linux/macOS)
-        if: runner.os != 'Windows'
-        run: make test
 
   simple-output:
     name: "Run tests with simple output"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
   windows:
     name: "Run tests on Windows"
     runs-on: windows-latest
+    strategy:
+      matrix:
+        test_chunk: [1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -35,8 +38,12 @@ jobs:
 
       - name: Run Tests
         shell: bash
-        run: ./bashunit -e tests/bootstrap.sh tests/**/*_test.sh
-
+        run: |
+          case ${{ matrix.test_chunk }} in
+            1) ./bashunit -e tests/bootstrap.sh tests/acceptance/*_test.sh ;;
+            2) ./bashunit -e tests/bootstrap.sh tests/functional/*_test.sh ;;
+            3) ./bashunit -e tests/bootstrap.sh tests/unit/*_test.sh ;;
+          esac
   simple-output:
     name: "Run tests with simple output"
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,13 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
+          set -e  # Exit on error
+          if [ -d tests/${{ matrix.test_chunk }} ]; then
+            ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
+          else
+            echo "Test directory tests/${{ matrix.test_chunk }} not found!"
+            exit 1
+          fi
 
   simple-output:
     name: "Tests simple output"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Tests
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,44 +7,15 @@ on:
       - main
 
 jobs:
-  tests:
+  ubuntu-macos:
+    name: "Tests on ${{ matrix.os }}"
     timeout-minutes: 10
-    name: "Run ${{ matrix.test_chunk }} tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        test_chunk: [acceptance, functional, unit]
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
-      fail-fast: false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Set up shell for Windows
-        if: matrix.os == 'windows-latest'
-        run: echo "Using bash as shell"
-        shell: bash
-
-      - name: Run tests
-        shell: bash
-        run: |
-          set -e  # Exit on error
-          if [ -d tests/${{ matrix.test_chunk }} ]; then
-            ./bashunit tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
-          else
-            echo "Test directory tests/${{ matrix.test_chunk }} not found!"
-            exit 1
-          fi
-
-  simple-output:
-    name: "Tests simple output"
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,8 +23,26 @@ jobs:
           fetch-depth: 1
 
       - name: Run Tests
+        run: make test
+
+  windows:
+    name: "Tests on windows (${{ matrix.test_chunk }})"
+    timeout-minutes: 10
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        test_chunk: [acceptance, functional, unit]
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run tests
+        shell: bash
         run: |
-          ./bashunit -e tests/bootstrap.sh --simple tests/
+          ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
 
   alpine:
     name: "Tests on alpine-latest"
@@ -72,3 +61,16 @@ jobs:
             adduser -D builder && \
             chown -R builder /project && \
             su - builder -c 'cd /project; make test';"
+
+  simple-output:
+    name: "Tests simple output"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Tests
+        run: |
+          ./bashunit -e tests/bootstrap.sh --simple tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,14 +7,16 @@ on:
       - main
 
 jobs:
-  ubuntu-macos:
-    name: "Run tests on ${{ matrix.os }}"
+  tests:
+    name: "Tests on ${{ matrix.os }} (${{ matrix.test_chunk }})"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        test_chunk: [acceptance, functional, unit]
         os:
           - ubuntu-latest
           - macos-latest
+          - windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,10 +24,12 @@ jobs:
           fetch-depth: 1
 
       - name: Run Tests
-        run: make test
+        shell: bash
+        run: |
+          ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
 
   simple-output:
-    name: "Run tests with simple output"
+    name: "Tests simple output"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,7 +42,7 @@ jobs:
           ./bashunit -e tests/bootstrap.sh --simple tests/
 
   alpine:
-    name: "Run tests on alpine-latest"
+    name: "Tests on alpine-latest"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -54,24 +58,3 @@ jobs:
             adduser -D builder && \
             chown -R builder /project && \
             su - builder -c 'cd /project; make test';"
-
-  windows:
-    name: "Run tests on Windows"
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        test_chunk: [1, 2, 3]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Tests
-        shell: bash
-        run: |
-          case ${{ matrix.test_chunk }} in
-            1) ./bashunit -e tests/bootstrap.sh tests/acceptance/*_test.sh ;;
-            2) ./bashunit -e tests/bootstrap.sh tests/functional/*_test.sh ;;
-            3) ./bashunit -e tests/bootstrap.sh tests/unit/*_test.sh ;;
-          esac

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Run Tests
         run: make test
+
+  simple-output:
+    name: "Run tests with simple output"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Tests
+        run: |
+          ./bashunit -e tests/bootstrap.sh --simple tests/
+
+  alpine:
+    name: "Run tests on alpine-latest"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Tests
+        run: |
+          docker run --rm -v "$(pwd)":/project alpine:latest /bin/sh -c " \
+            apk update && \
+            apk add --no-cache bash make git && \
+            adduser -D builder && \
+            chown -R builder /project && \
+            su - builder -c 'cd /project; make test';"
 
   windows:
     name: "Run tests on Windows"
@@ -44,33 +75,3 @@ jobs:
             2) ./bashunit -e tests/bootstrap.sh tests/functional/*_test.sh ;;
             3) ./bashunit -e tests/bootstrap.sh tests/unit/*_test.sh ;;
           esac
-  simple-output:
-    name: "Run tests with simple output"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Tests
-        run: |
-          ./bashunit -e tests/bootstrap.sh --simple tests/
-
-  alpine:
-    name: "Run tests on alpine-latest"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Tests
-        run: |
-          docker run --rm -v "$(pwd)":/project alpine:latest /bin/sh -c " \
-            apk update && \
-            apk add --no-cache bash make git && \
-            adduser -D builder && \
-            chown -R builder /project && \
-            su - builder -c 'cd /project; make test';"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   tests:
-    name: "Tests on ${{ matrix.os }} (${{ matrix.test_chunk }})"
+    name: "Run ${{ matrix.test_chunk }} tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -17,13 +17,21 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+      fail-fast: false
+      max-parallel: 3
+
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      - name: Run Tests
+      - name: Set up shell for Windows
+        if: matrix.os == 'windows-latest'
+        run: echo "Using bash as shell"
+        shell: bash
+
+      - name: Run tests
         shell: bash
         run: |
           ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-
 jobs:
   tests:
     name: "Run tests on ${{ matrix.os }}"
@@ -16,21 +15,20 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        include:
-          - os: windows-latest
-            script_name: 'bash -c "./bashunit -e tests/bootstrap.sh tests/**/*_test.sh"'
-          - os: macos-latest
-            script_name: 'make test'
-          - os: ubuntu-latest
-            script_name: 'make test'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run Tests
-        run: ${{ matrix.script_name }}
+      - name: Run Tests (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: ./bashunit -e tests/bootstrap.sh tests/**/*_test.sh
+
+      - name: Run Tests (Linux/macOS)
+        if: runner.os != 'Windows'
+        run: make test
 
   simple-output:
     name: "Run tests with simple output"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   tests:
+    timeout-minutes: 10
     name: "Run ${{ matrix.test_chunk }} tests on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
@@ -18,7 +19,6 @@ jobs:
           - macos-latest
           - windows-latest
       fail-fast: false
-      max-parallel: 3
 
     steps:
       - name: Checkout code
@@ -36,7 +36,7 @@ jobs:
         run: |
           set -e  # Exit on error
           if [ -d tests/${{ matrix.test_chunk }} ]; then
-            ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
+            ./bashunit tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
           else
             echo "Test directory tests/${{ matrix.test_chunk }} not found!"
             exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   ubuntu-macos:
-    name: "Tests on ${{ matrix.os }}"
+    name: "On ${{ matrix.os }}"
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
@@ -26,7 +26,7 @@ jobs:
         run: make test
 
   windows:
-    name: "Tests on windows (${{ matrix.test_chunk }})"
+    name: "On windows (${{ matrix.test_chunk }})"
     timeout-minutes: 10
     runs-on: windows-latest
     strategy:
@@ -45,7 +45,7 @@ jobs:
           ./bashunit -e tests/bootstrap.sh tests/${{ matrix.test_chunk }}/*_test.sh
 
   alpine:
-    name: "Tests on alpine-latest"
+    name: "On alpine-latest"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -63,7 +63,7 @@ jobs:
             su - builder -c 'cd /project; make test';"
 
   simple-output:
-    name: "Tests simple output"
+    name: "Simple output"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
     - cleanup_temp_files
     - log
 - Improved clean up temporal files and directories
+- Improved CI test speed by running them in parallel
 
 ## [0.17.0](https://github.com/TypedDevs/bashunit/compare/0.16.0...0.17.0) - 2024-10-01
 

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -103,11 +103,8 @@ function console_results::print_execution_time() {
     return
   fi
 
-  # shellcheck disable=SC2155
-  local execution_time=$(clock::total_runtime_in_milliseconds)
-
   printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" \
-    "Time taken: ${execution_time} ms"
+    "Time taken: $(clock::total_runtime_in_milliseconds) ms"
 }
 
 function console_results::print_successful_test() {

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -103,8 +103,11 @@ function console_results::print_execution_time() {
     return
   fi
 
+  # shellcheck disable=SC2155
+  local execution_time=$(clock::total_runtime_in_milliseconds)
+
   printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" \
-    "Time taken: $(clock::total_runtime_in_milliseconds) ms"
+    "Time taken: ${execution_time} ms"
 }
 
 function console_results::print_successful_test() {

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -103,8 +103,8 @@ function console_results::print_execution_time() {
     return
   fi
 
-  _EXECUTION_TIME=$(clock::total_runtime_in_milliseconds)
-  printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" "Time taken: ${_EXECUTION_TIME} ms"
+  printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" \
+    "Time taken: $(clock::total_runtime_in_milliseconds) ms"
 }
 
 function console_results::print_successful_test() {

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -16,7 +16,9 @@ function current_timestamp() {
 }
 
 function is_command_available() {
-  command -v "$1" >/dev/null 2>&1
+  if ! command -v "$1" >/dev/null 2>&1; then
+    return 1
+  fi
 }
 
 function random_str() {

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -16,9 +16,7 @@ function current_timestamp() {
 }
 
 function is_command_available() {
-  if ! command -v "$1" >/dev/null 2>&1; then
-    return 1
-  fi
+  command -v "$1" >/dev/null 2>&1
 }
 
 function random_str() {

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -273,7 +273,7 @@ function test_render_execution_time() {
 
     console_results::render_result
   )
-  assert_matches "Time taken: [[:digit:]]+ ms" "$render_result"
+  assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? ms" "$render_result"
 }
 
 function test_not_render_execution_time() {
@@ -304,7 +304,7 @@ function test_render_execution_time_on_osx_without_perl() {
     console_results::render_result
   )
 
-  assert_matches "Time taken: [[:digit:]]+ ms" "$render_result"
+  assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? ms" "$render_result"
 }
 
 function test_render_execution_time_on_osx_with_perl() {
@@ -326,7 +326,7 @@ function test_render_execution_time_on_osx_with_perl() {
     console_results::render_result
   )
 
-  assert_matches "Time taken: [[:digit:]]+ ms" "$render_result"
+  assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? ms" "$render_result"
 }
 
 function test_render_file_with_duplicated_functions_if_found_true() {

--- a/tests/unit/globals_test.sh
+++ b/tests/unit/globals_test.sh
@@ -25,11 +25,15 @@ function test_globals_current_timestamp() {
 }
 
 function test_globals_is_command_available() {
-  assert_successful_code "$(is_command_available ls)"
+  function existing_fn(){
+    # shellcheck disable=SC2317
+    return 0
+  }
+  assert_successful_code "$(is_command_available existing_fn)"
 }
 
 function test_globals_is_command_not_available() {
-  assert_general_error "$(is_command_available non-existing-command)"
+  assert_general_error "$(is_command_available non_existing_fn)"
 }
 
 function test_globals_random_str_default() {


### PR DESCRIPTION
## 📚 Description

Windows CI tests need to be faster. I want to explore ways to speed it up.

## 🔖 Changes

- Run different test dir (acceptance, functional, unit) in parallel

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

## 🖼️ Screenshots

### BEFORE (~8 min)
<img width="877" alt="Screenshot 2024-10-06 at 12 24 33" src="https://github.com/user-attachments/assets/ff403b5f-cc51-4397-9687-616533f6fcad">

### AFTER (~4 min)
<img width="1027" alt="Screenshot 2024-10-06 at 15 52 33" src="https://github.com/user-attachments/assets/0eb7401c-88c9-4590-9f5d-27e2a7e7e3f8">

