### PR TITLE
fix: use mktemp compatible bash 3.2

### DIFF
--- a/src/globals.sh
+++ b/src/globals.sh
@@ -26,12 +26,12 @@ function random_str() {
 
 function temp_file() {
   mkdir -p /tmp/bashunit-tmp && chmod -R 777 /tmp/bashunit-tmp
-  mktemp --tmpdir="/tmp/bashunit-tmp" "XXXXXXX"
+  mktemp /tmp/bashunit-tmp/bashunit.XXXXXXX
 }
 
 function temp_dir() {
   mkdir -p /tmp/bashunit-tmp && chmod -R 777 /tmp/bashunit-tmp
-  mktemp -d --tmpdir="/tmp/bashunit-tmp" "XXXXXXX"
+  mktemp -d /tmp/bashunit-tmp/bashunit.XXXXXXX
 }
 
 function cleanup_temp_files() {


### PR DESCRIPTION
## 📚 Description

When running on my macos 2017 with my default bash, my `tests/unit/directory_test.sh` are failing

```
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin22)
Copyright (C) 2007 Free Software Foundation, Inc.
```

## 🔖 Changes

- Fix `directory_test`

![Screenshot 2024-10-08 at 22 09 39](https://github.com/user-attachments/assets/fa6bd88b-be66-4513-9f7a-7c9796657d1b)

