### PR TITLE
fix: add check that git is installed to `install.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     - `DEFAULT_PATH="tests"`
     - `LOG_PATH="out.log"`
     - `LOAD_FILE="tests/bootstrap.sh"`
+- Add check that git is installed to `install.sh` 
 
 ## [0.17.0](https://github.com/TypedDevs/bashunit/compare/0.16.0...0.17.0) - 2024-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
     - `DEFAULT_PATH="tests"`
     - `LOG_PATH="out.log"`
     - `LOAD_FILE="tests/bootstrap.sh"`
-- Add check that git is installed to `install.sh` 
+- Add check that git is installed to `install.sh`
 
 ## [0.17.0](https://github.com/TypedDevs/bashunit/compare/0.16.0...0.17.0) - 2024-10-01
 

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,15 @@
 # shellcheck disable=SC2103
 declare -r BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 
+function check_git_is_installed() {
+  if ! command -v git >/dev/null 2>&1; then
+    echo "Error: git is not installed." >&2
+    exit 1
+  fi
+}
+
+check_git_is_installed
+
 function get_latest_tag() {
   git ls-remote --tags "$BASHUNIT_GIT_REPO" |
     awk '{print $2}' |

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-
+# shellcheck disable=SC2155
 # shellcheck disable=SC2164
 # shellcheck disable=SC2103
-declare -r BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 
 function check_git_is_installed() {
   if ! command -v git >/dev/null 2>&1; then
@@ -11,8 +10,6 @@ function check_git_is_installed() {
   fi
 }
 
-check_git_is_installed
-
 function get_latest_tag() {
   git ls-remote --tags "$BASHUNIT_GIT_REPO" |
     awk '{print $2}' |
@@ -20,14 +17,6 @@ function get_latest_tag() {
     sort -Vr |
     head -n 1
 }
-
-# shellcheck disable=SC2155
-declare -r LATEST_BASHUNIT_VERSION="$(get_latest_tag)"
-
-DIR=${1-lib}
-VERSION=${2-latest}
-TAG="$LATEST_BASHUNIT_VERSION"
-
 
 function build_and_install_beta() {
   echo "> Downloading non-stable version: 'beta'"
@@ -63,6 +52,19 @@ function install() {
   fi
   chmod u+x "bashunit"
 }
+
+#########################
+######### MAIN ##########
+#########################
+
+check_git_is_installed
+
+DIR=${1-lib}
+VERSION=${2-latest}
+
+BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
+LATEST_BASHUNIT_VERSION="$(get_latest_tag)"
+TAG="$LATEST_BASHUNIT_VERSION"
 
 cd "$(dirname "$0")"
 rm -f "$DIR"/bashunit


### PR DESCRIPTION
## 📚 Description

Fixes #359 

## 🔖 Changes

- Add check that git is installed to `install.sh`

The first place to use the `git` command in `install.sh` was the `get_latest_tag` function.
Before calling `get_latest_tag`, a check had to be made.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
