### PR TITLE
Improve build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@ function build::verify() {
     --report-html "bin/report.html" \
     --stop-on-failure
 
+  # shellcheck disable=SC2181
   if [[ $? -eq 0 ]]; then
     echo "✅ Build verified ✅"
   fi

--- a/build.sh
+++ b/build.sh
@@ -2,53 +2,45 @@
 
 source src/check_os.sh
 
+BASHUNIT_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export BASHUNIT_ROOT_DIR
+
 function build() {
   local out=$1
 
-  generate_bin "$out"
-  generate_checksum "$out"
+  build::generate_bin "$out"
+  build::generate_checksum "$out"
 
-  echo "⚡️Build completed⚡️"
+  echo "⚡️ Build completed ⚡️"
 }
 
-function verify_build() {
+function build::verify() {
   local out=$1
 
   echo "Verifying build ⏱️"
 
   "$out" tests \
     --simple \
+    --parallel \
     --log-junit "bin/log-junit.xml" \
     --report-html "bin/report.html" \
-    --stop-on-failure &
+    --stop-on-failure
 
-  pid=$!
-
-  function cleanup() {
-    kill "$pid" 2>/dev/null
-    tput cnorm # Show the cursor
-    exit 1
-  }
-
-  trap cleanup SIGINT
-  spinner $pid
-  wait $pid
-  echo "✅ Build verified ✅ "
+  if [[ $? -eq 0 ]]; then
+    echo "✅ Build verified ✅"
+  fi
 }
 
-function generate_bin() {
+function build::generate_bin() {
   local out=$1
   local temp
   temp="$(dirname "$out")/temp.sh"
 
   echo '#!/bin/bash' > "$temp"
   echo "Generating bashunit in the '$(dirname "$out")' folder..."
-  for file in src/*.sh; do
-    {
-      echo "# $file"
-      tail -n +2 "$file" >> "$temp"
-      echo ""
-    } >> "$temp"
+
+  for file in $(build::dependencies); do
+    build::process_file "$file" "$temp"
   done
 
   cat bashunit >> "$temp"
@@ -57,37 +49,81 @@ function generate_bin() {
   chmod u+x "$out"
 }
 
-function generate_checksum() {
+# Recursive function to process each file and any files it sources
+function build::process_file() {
+  local file=$1
+  local temp=$2
+
+  {
+    echo "# $(basename "$file")"
+    tail -n +2 "$file" >> "$temp"
+    echo ""
+  } >> "$temp"
+
+  # Search for any 'source' lines in the current file
+  grep '^source ' "$file" | while read -r line; do
+    # Extract the path from the 'source' command
+    local sourced_file
+    sourced_file=$(echo "$line" | awk '{print $2}' | sed 's/^"//;s/"$//') # Remove any quotes
+
+    # Handle cases where the path uses $BASHUNIT_ROOT_DIR or other variables
+    sourced_file=$(eval echo "$sourced_file")
+
+    # Handle relative paths if necessary
+    if [[ ! "$sourced_file" =~ ^/ ]]; then
+      sourced_file="$(dirname "$file")/$sourced_file"
+    fi
+
+    # Recursively process the sourced file if it exists
+    if [[ -f "$sourced_file" ]]; then
+      build::process_file "$sourced_file" "$temp"
+    fi
+  done
+}
+
+function build::dependencies() {
+  deps=(
+    "src/check_os.sh"
+    "src/str.sh"
+    "src/globals.sh"
+    "src/dependencies.sh"
+    "src/io.sh"
+    "src/math.sh"
+    "src/parallel.sh"
+    "src/env.sh"
+    "src/clock.sh"
+    "src/state.sh"
+    "src/colors.sh"
+    "src/console_header.sh"
+    "src/console_results.sh"
+    "src/helpers.sh"
+    "src/upgrade.sh"
+    "src/assertions.sh"
+    "src/reports.sh"
+    "src/runner.sh"
+    "src/bashunit.sh"
+    "src/main.sh"
+  )
+
+  echo "${deps[@]}"
+}
+
+function build::generate_checksum() {
   local out=$1
 
   if [[ "$_OS" == "Windows" ]]; then
     return
   fi
 
-  if [[ "$_OS" == "OSX" ]]; then
+  # Use a single command for both macOS and Linux
+  if command -v shasum &>/dev/null; then
     checksum=$(shasum -a 256 "$out")
-  elif [[ "$_OS" == "Linux" ]]; then
+  else
     checksum=$(sha256sum "$out")
   fi
 
   echo "$checksum" > "$(dirname "$out")/checksum"
   echo "$checksum"
-}
-
-function spinner() {
-    local pid=$1
-    local delay=0.1
-    local spinstr="|/-\\"
-    tput civis  # Hide the cursor
-    printf "\r[%c] " " "
-    while kill -0 "$pid" 2>/dev/null; do
-        local temp=${spinstr#?}
-        printf "\r [%c]  " "$spinstr"
-        local spinstr=$temp${spinstr%"$temp"}
-        sleep $delay
-    done
-    printf "\r    \r"  # Clear spinner
-    tput cnorm  # Show the cursor
 }
 
 ########################
@@ -114,5 +150,5 @@ OUT="$DIR/bashunit"
 build "$OUT"
 
 if [[ $SHOULD_VERIFY_BUILD == true ]]; then
-  verify_build "$OUT"
+  build::verify "$OUT"
 fi

--- a/tests/unit/debug_test.sh
+++ b/tests/unit/debug_test.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-function test_dump() {
-  assert_equals \
-    "[DUMP] tests/unit/debug_test.sh:6: hi, debugging"\
-    "$(dump "hi, debugging")"
-}


### PR DESCRIPTION
## 📚 Description

The build right now append all files from `src/*.sh` in alphabetical order. 
However, the sourcing order is important (same as it is defined in the entry-point `./bashunit`.

## 🔖 Changes

- Define an order how to "source" the src files when building the project with `./build.sh`
