### PR TITLE
Fix tr warning on ubuntu's CI

### DIFF
--- a/src/globals.sh
+++ b/src/globals.sh
@@ -29,16 +29,12 @@ function is_command_available() {
 
 function random_str() {
   local length=${1:-6}
-
-  if command -v openssl >/dev/null 2>&1; then
-    openssl rand -base64 "$length" | tr -dc A-Za-z0-9 | head -c "$length"
-  elif command -v uuidgen >/dev/null 2>&1; then
-    uuidgen | tr -dc A-Za-z0-9 | head -c "$length"
-  elif [[ -r /dev/urandom ]]; then
-    LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c "$length"
-  else
-    date +%s%N$$ | tr -dc A-Za-z0-9 | head -c "$length"
-  fi
+  local chars='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+  local str=''
+  for (( i=0; i<length; i++ )); do
+    str+="${chars:RANDOM%${#chars}:1}"
+  done
+  echo "$str"
 }
 
 function temp_file() {

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -29,7 +29,16 @@ function is_command_available() {
 
 function random_str() {
   local length=${1:-6}
-  LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c "$length"
+
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -base64 "$length" | tr -dc A-Za-z0-9 | head -c "$length"
+  elif command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr -dc A-Za-z0-9 | head -c "$length"
+  elif [[ -r /dev/urandom ]]; then
+    LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c "$length"
+  else
+    date +%s%N$$ | tr -dc A-Za-z0-9 | head -c "$length"
+  fi
 }
 
 function temp_file() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -156,7 +156,7 @@ function runner::run_test() {
     subshell_output=$line
   fi
 
-  local runtime_output="${test_execution_result%%##TEST_ID=*}"
+  local runtime_output="${test_execution_result%%##ASSERTIONS_=*}"
 
   local runtime_error=""
   for error in "command not found" "unbound variable" "permission denied" \
@@ -281,14 +281,7 @@ function runner::parse_result_parallel() {
     count=$((count + 1))
   done
 
-  if env::is_dev_mode_enabled; then
-    local test_id=$(\
-      echo "$execution_result" |\
-      tail -n 1 |\
-      sed -E -e 's/.*##TEST_ID=([a-zA-Z0-9]*)##.*/\1/g'\
-    )
-    log "debug" "[PARA] test_id:$test_id" "function_name:$function_name" "execution_result:$execution_result"
-  fi
+  log "debug" "[PARA]" "function_name:$function_name" "execution_result:$execution_result"
 
   runner::parse_result_sync "$function_name" "$execution_result"
 
@@ -329,14 +322,7 @@ function runner::parse_result_sync() {
     sed -E -e 's/.*##ASSERTIONS_SNAPSHOT=([0-9]*)##.*/\1/g'\
   )
 
-  if env::is_dev_mode_enabled; then
-    local test_id=$(\
-      echo "$execution_result" |\
-      tail -n 1 |\
-      sed -E -e 's/.*##TEST_ID=([a-zA-Z0-9]*)##.*/\1/g'\
-    )
-    log "debug" "[SYNC] test_id:$test_id" "function_name:$function_name" "execution_result:$execution_result"
-  fi
+  log "debug" "[SYNC]" "function_name:$function_name" "execution_result:$execution_result"
 
   ((_ASSERTIONS_PASSED += assertions_passed)) || true
   ((_ASSERTIONS_FAILED += assertions_failed)) || true

--- a/src/state.sh
+++ b/src/state.sh
@@ -149,11 +149,7 @@ function state::export_subshell_context() {
     encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64)
   fi
 
-  local test_id
-  test_id=$(LC_ALL=C tr -dc A-Za-z0-9 </dev/urandom | head -c 8)
-
   cat <<EOF
-##TEST_ID=$test_id\
 ##ASSERTIONS_FAILED=$_ASSERTIONS_FAILED\
 ##ASSERTIONS_PASSED=$_ASSERTIONS_PASSED\
 ##ASSERTIONS_SKIPPED=$_ASSERTIONS_SKIPPED\

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -249,8 +249,7 @@ function test_initialize_assertions_count() {
   )
 
   assert_same\
-    "##TEST_ID=abc123\
-##ASSERTIONS_FAILED=0\
+    "##ASSERTIONS_FAILED=0\
 ##ASSERTIONS_PASSED=0\
 ##ASSERTIONS_SKIPPED=0\
 ##ASSERTIONS_INCOMPLETE=0\
@@ -277,8 +276,7 @@ function test_export_assertions_count() {
   )
 
   assert_same\
-    "##TEST_ID=abc123\
-##ASSERTIONS_FAILED=5\
+    "##ASSERTIONS_FAILED=5\
 ##ASSERTIONS_PASSED=10\
 ##ASSERTIONS_SKIPPED=42\
 ##ASSERTIONS_INCOMPLETE=12\
@@ -288,8 +286,7 @@ function test_export_assertions_count() {
 }
 
 function test_calculate_total_assertions() {
-  local input="##TEST_ID=abc123\
-  ##ASSERTIONS_FAILED=1\
+  local input="##ASSERTIONS_FAILED=1\
   ##ASSERTIONS_PASSED=2\
   ##ASSERTIONS_SKIPPED=3\
   ##ASSERTIONS_INCOMPLETE=4\


### PR DESCRIPTION
## 🔖 Changes

- remove the test_id that I added on the assertions' internal output
- make global `random_str` non dependent on external tools