### PR TITLE
Improve render file header on verbose

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -188,7 +188,7 @@ function runner::run_test() {
     subshell_output=$line
   fi
 
-  local runtime_output="${test_execution_result%%##ASSERTIONS_=*}"
+  local runtime_output="${test_execution_result%%##ASSERTIONS_*}"
 
   local runtime_error=""
   for error in "command not found" "unbound variable" "permission denied" \

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -108,12 +108,18 @@ function runner::call_test_functions() {
 }
 
 function runner::render_running_file_header() {
-  if ! env::is_simple_output_enabled && ! parallel::is_enabled; then
-    printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" "Running: $script"
+  if parallel::is_enabled; then
+    return
   fi
 
-  if env::is_simple_output_enabled && env::is_verbose_enabled; then
-    printf "\n${_COLOR_BOLD}%s${_COLOR_DEFAULT}" "Running: $script"
+  if ! env::is_simple_output_enabled; then
+    if env::is_verbose_enabled; then
+      printf "\n${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" "Running $script"
+    else
+      printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" "Running $script"
+    fi
+  elif env::is_verbose_enabled; then
+    printf "\n\n${_COLOR_BOLD}%s${_COLOR_DEFAULT}" "Running $script"
   fi
 }
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -74,10 +74,7 @@ function runner::call_test_functions() {
     return
   fi
 
-  if ! env::is_simple_output_enabled && ! parallel::is_enabled; then
-    echo "Running $script"
-  fi
-
+  runner::render_running_file_header
   helper::check_duplicate_functions "$script" || true
 
   for function_name in "${functions_to_run[@]}"; do
@@ -108,6 +105,16 @@ function runner::call_test_functions() {
     done
     unset function_name
   done
+}
+
+function runner::render_running_file_header() {
+  if ! env::is_simple_output_enabled && ! parallel::is_enabled; then
+    printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" "Running: $script"
+  fi
+
+  if env::is_simple_output_enabled && env::is_verbose_enabled; then
+    printf "\n${_COLOR_BOLD}%s${_COLOR_DEFAULT}" "Running: $script"
+  fi
 }
 
 function runner::run_test() {

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -170,6 +170,8 @@ function runner::run_test() {
     printf "%s\n" "File:     $test_file"
     printf "%s\n" "Function: $function_name"
     printf "%s\n" "Duration: $duration ms"
+    local raw_text=${test_execution_result%%##ASSERTIONS_*}
+    [[ -n $raw_text ]] && printf "%s" "Raw text: ${test_execution_result%%##ASSERTIONS_*}"
     printf "%s\n" "##ASSERTIONS_${test_execution_result#*##ASSERTIONS_}"
     printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '-'
   fi

--- a/tests/acceptance/bashunit_execution_error_test.sh
+++ b/tests/acceptance/bashunit_execution_error_test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2155
 set -euo pipefail
 
 function set_up_before_script() {
@@ -7,25 +8,10 @@ function set_up_before_script() {
 
 function test_bashunit_when_a_execution_error() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
-  local fixture_start fixture_end
-  local color_default color_red color_dim color_bold
-
-  color_default="$(sgr 0)"
-  color_bold="$(sgr 1)"
-  color_dim="$(sgr 2)"
-  color_red="$(sgr 31)"
-
-  function format_fail_title() {
-    printf "\n%s%s%s%s" "${color_red}" "$1" "${color_default}" "$2"
-  }
-
-  function format_expect_title() {
-    printf "\n    %s%s%s" "${color_dim}" "$1" "${color_default}"
-  }
-
-  function format_expect_value() {
-    printf " %s%s%s" "${color_bold}" "$1" "${color_default}"
-  }
+  local color_default="$(sgr 0)"
+  local color_bold="$(sgr 1)"
+  local color_dim="$(sgr 2)"
+  local color_red="$(sgr 31)"
 
   function format_summary_title() {
     printf "\n%s%s%s" "${color_dim}" "$1" "${color_default}"
@@ -35,26 +21,23 @@ function test_bashunit_when_a_execution_error() {
     printf " %s%s%s%s" "${color_red}" "$1" "${color_default}" "$2"
   }
 
-  fixture_start=$(
-    printf "${color_bold}%s${color_default}\n" "Running ./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh"
-    format_fail_title "✗ Failed" ": Error"
-    format_expect_title "Expected"
-    format_expect_value "'127'"
-    format_expect_title "to be exactly"
-    format_expect_value "'1'"
+  local fixture_start=$(
+    printf "%sRunning ./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh%s\n" \
+      "${color_bold}" "${color_default}"
+    printf "%s✗ Error%s: Error\n" "${color_red}" "${color_default}"
+    printf "    %sline 4: invalid_function_name: command not found%s\n" "${color_dim}" "${color_default}"
   )
-  fixture_end=$(
+  local fixture_end=$(
     format_summary_title "Tests:     "
     format_summary_value "1 failed" ", 1 total"
     format_summary_title "Assertions:"
-    format_summary_value "1 failed" ", 1 total"
+    format_summary_value "0 failed" ", 0 total"
   )
 
   todo "Add snapshots with regex to assert this test (part of the error message is localized)"
   todo "Add snapshots with simple/verbose modes as in bashunit_pass_test and bashunit_fail_test"
 
-  # shellcheck disable=SC2155
-  local actual="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+  local actual="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
   assert_contains "$fixture_start" "$actual"
   assert_contains "$fixture_end" "$actual"
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"

--- a/tests/acceptance/bashunit_execution_error_test.sh
+++ b/tests/acceptance/bashunit_execution_error_test.sh
@@ -36,7 +36,7 @@ function test_bashunit_when_a_execution_error() {
   }
 
   fixture_start=$(
-    printf "Running ./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh"
+    printf "${color_bold}%s${color_default}\n" "Running ./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh"
     format_fail_title "✗ Failed" ": Error"
     format_expect_title "Expected"
     format_expect_value "'127'"
@@ -53,7 +53,9 @@ function test_bashunit_when_a_execution_error() {
   todo "Add snapshots with regex to assert this test (part of the error message is localized)"
   todo "Add snapshots with simple/verbose modes as in bashunit_pass_test and bashunit_fail_test"
 
-  assert_contains "$fixture_start" "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
-  assert_contains "$fixture_end" "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+  # shellcheck disable=SC2155
+  local actual="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+  assert_contains "$fixture_start" "$actual"
+  assert_contains "$fixture_end" "$actual"
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
 }

--- a/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 function test_error() {
-  invalid_function_name
-  assert_general_error
+  invalid_function_name arg1 arg2
+  assert_true 0
 }

--- a/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
@@ -2,5 +2,4 @@
 
 function test_error() {
   invalid_function_name arg1 arg2
-  assert_true 0
 }

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -1,7 +1,7 @@
-Running ./tests/acceptance/fixtures/tests_path/a_test.sh
+[1mRunning ./tests/acceptance/fixtures/tests_path/a_test.sh[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
-Running ./tests/acceptance/fixtures/tests_path/other_test.sh
+[1mRunning ./tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -1,7 +1,7 @@
-Running ./tests/acceptance/fixtures/tests_path/a_test.sh
+[1mRunning ./tests/acceptance/fixtures/tests_path/a_test.sh[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
-Running ./tests/acceptance/fixtures/tests_path/other_test.sh
+[1mRunning ./tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/tests_path/a_test.sh
+[1mRunning ./tests/acceptance/fixtures/tests_path/a_test.sh[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Failure
     [2mExpected[0m [1m'2'[0m

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Failure
     [2mExpected[0m [1m'2'[0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [32m✓ Passed[0m: Assert greater and less than

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [32m✓ Passed[0m: Assert greater and less than

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -1,7 +1,7 @@
-Running tests/acceptance/fixtures/tests_path/a_test.sh
+[1mRunning tests/acceptance/fixtures/tests_path/a_test.sh[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
-Running tests/acceptance/fixtures/tests_path/other_test.sh
+[1mRunning tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -1,7 +1,7 @@
-Running tests/acceptance/fixtures/tests_path/a_test.sh
+[1mRunning tests/acceptance/fixtures/tests_path/a_test.sh[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
-Running tests/acceptance/fixtures/tests_path/other_test.sh
+[1mRunning tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Fail
     [2mExpected[0m [1m'to be empty'[0m

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Fail
     [2mExpected[0m [1m'to be empty'[0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
 [32m✓ Passed[0m: A success
 [31m✗ Failed[0m: B error
     [2mExpected[0m [1m'1'[0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
@@ -1,4 +1,4 @@
-Running ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
 [32m✓ Passed[0m: A success
 [31m✗ Failed[0m: B error
     [2mExpected[0m [1m'1'[0m


### PR DESCRIPTION
## 🔖 Changes

- Add the `Running $script` text always when verbose is enabled
  - Make it bold 

## 🖼️ Screenshots

### No verbose

<img width="993" alt="Screenshot 2024-10-13 at 13 48 52" src="https://github.com/user-attachments/assets/a05119ea-ea7b-4ef4-bc42-c1d08b12e58c">

#### Verbose

#### Simple
<img width="1167" alt="Screenshot 2024-10-13 at 13 49 32" src="https://github.com/user-attachments/assets/860ed973-7f32-4285-b83f-7aee5d6b4300">

#### Detailed
<img width="1112" alt="Screenshot 2024-10-13 at 13 49 45" src="https://github.com/user-attachments/assets/da6dd41c-5f5c-4f1e-843f-d1d2f1794828">

