### PR TITLE
Add `assert_not_same` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Removed git dependency for stable installations
 - Rename option `--verbose` to `--detailed`
     - which is the default display behaviour, the opposite as `--simple`
+- Added `assert_not_same`
 
 ## [0.17.0](https://github.com/TypedDevs/bashunit/compare/0.16.0...0.17.0) - 2024-10-01
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -140,7 +140,7 @@ function assert_not_empty() {
   state::add_assertions_passed
 }
 
-function assert_not_equals() {
+function assert_not_same() {
   local expected="$1"
   local actual="$2"
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -112,6 +112,31 @@ function assert_equals() {
   state::add_assertions_passed
 }
 
+function assert_not_equals() {
+  local expected="$1"
+  local actual="$2"
+
+  # Remove ANSI escape sequences (color codes)
+  local actual_cleaned
+  actual_cleaned=$(echo -e "$actual" | sed -r "s/\x1B\[[0-9;]*[mK]//g")
+  local expected_cleaned
+  expected_cleaned=$(echo -e "$expected" | sed -r "s/\x1B\[[0-9;]*[mK]//g")
+
+  # Remove all control characters and whitespace (optional, depending on your needs)
+  actual_cleaned=$(echo "$actual_cleaned" | tr -d '[:cntrl:]')
+  expected_cleaned=$(echo "$expected_cleaned" | tr -d '[:cntrl:]')
+
+  if [[ "$expected_cleaned" == "$actual_cleaned" ]]; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${expected_cleaned}" "but got " "${actual_cleaned}"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
 function assert_empty() {
   local expected="$1"
 

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -109,14 +109,14 @@ function test_unsuccessful_assert_not_empty() {
     "$(assert_not_empty "")"
 }
 
-function test_successful_assert_not_equals() {
-  assert_empty "$(assert_not_equals "1" "2")"
+function test_successful_assert_not_same() {
+  assert_empty "$(assert_not_same "1" "2")"
 }
 
-function test_unsuccessful_assert_not_equals() {
+function test_unsuccessful_assert_not_same() {
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful assert not equals" "1" "but got " "1")"\
-    "$(assert_not_equals "1" "1")"
+    "$(console_results::print_failed_test "Unsuccessful assert not same" "1" "but got " "1")"\
+    "$(assert_not_same "1" "1")"
 }
 
 function test_successful_assert_contains_ignore_case() {

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -124,7 +124,7 @@ function test_successful_assert_not_equals() {
 }
 
 function test_unsuccessful_assert_not_equals() {
-  assert_equals\
+  assert_same\
     "$(console_results::print_failed_test "Unsuccessful assert not equals" "1" "but got " "1")"\
     "$(assert_not_equals "1" "1")"
 }

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -134,7 +134,9 @@ function test_unsuccessful_assert_not_equals_with_special_chars() {
   local str2="✗ Failed foo"
 
   assert_equals\
-    "$(console_results::print_failed_test "Unsuccessful assert not equals with special chars" "$str1" "but got " "$str2")"\
+    "$(console_results::print_failed_test \
+      "Unsuccessful assert not equals with special chars" \
+      "$str1" "but got " "$str2")"\
     "$(assert_not_equals "$str1" "$str2")"
 }
 

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -119,6 +119,25 @@ function test_unsuccessful_assert_not_same() {
     "$(assert_not_same "1" "1")"
 }
 
+function test_successful_assert_not_equals() {
+  assert_empty "$(assert_not_equals "1" "2")"
+}
+
+function test_unsuccessful_assert_not_equals() {
+  assert_equals\
+    "$(console_results::print_failed_test "Unsuccessful assert not equals" "1" "but got " "1")"\
+    "$(assert_not_equals "1" "1")"
+}
+
+function test_unsuccessful_assert_not_equals_with_special_chars() {
+  local str1="${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT} foo"
+  local str2="✗ Failed foo"
+
+  assert_equals\
+    "$(console_results::print_failed_test "Unsuccessful assert not equals with special chars" "$str1" "but got " "$str2")"\
+    "$(assert_not_equals "$str1" "$str2")"
+}
+
 function test_successful_assert_contains_ignore_case() {
   assert_empty "$(assert_contains_ignore_case "Linux" "GNU/LINUX")"
 }


### PR DESCRIPTION
## 📚 Description

Add `assert_not_same` function

Fixes #372 

## 🔖 Changes

- rename assert_not_equals to assert_not_same (and all its usages)
- add a new assert_not_equals (look at assert_equals and use opposite condition)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
