### PR TITLE
Fix display name when test_test_*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Improved output: adding a space between each test file
-- Remove `BASHUNIT_DEV_MODE` in favor of `BASHUNIT_DEV_LOG`
+- Removed `BASHUNIT_DEV_MODE` in favor of `BASHUNIT_DEV_LOG`
+- Fixed name rendered when having `test_test_*`
 
 ## [0.18.0](https://github.com/TypedDevs/bashunit/compare/0.17.0...0.18.0) - 2024-10-16
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -11,12 +11,14 @@ function helper::normalize_test_function_name() {
   local original_function_name="${1-}"
   local result
 
-  # Remove "test_" prefix
+  # Remove the first "test_" prefix, if present
   result="${original_function_name#test_}"
+  # If no "test_" was removed (e.g., "testFoo"), remove the "test" prefix
+  if [[ "$result" == "$original_function_name" ]]; then
+    result="${original_function_name#test}"
+  fi
   # Replace underscores with spaces
   result="${result//_/ }"
-  # Remove "test" prefix
-  result="${result#test}"
   # Capitalize the first letter
   result="$(tr '[:lower:]' '[:upper:]' <<< "${result:0:1}")${result:1}"
 

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -24,6 +24,10 @@ function test_normalize_test_function_name_snake_case() {
   assert_same "Some logic" "$(helper::normalize_test_function_name "test_some_logic")"
 }
 
+function test_normalize_double_test_function_name_snake_case() {
+  assert_same "Test some logic" "$(helper::normalize_test_function_name "test_test_some_logic")"
+}
+
 function test_normalize_test_function_name_camel_case() {
   assert_same "SomeLogic" "$(helper::normalize_test_function_name "testSomeLogic")"
 }


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/387

## 🔖 Changes

-Adapt `helper::normalize_test_function_name` for test functions that want `test` to be render

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix