### PR TITLE
Fix display multiline errors within the same test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+- Fixed name rendered when having `test_test_*`
+- Fixed display test with multiple outputs in multiline
 - Improved output: adding a space between each test file
 - Removed `BASHUNIT_DEV_MODE` in favor of `BASHUNIT_DEV_LOG`
-- Fixed name rendered when having `test_test_*`
+- Added source file and line on global dev function `log`
 
 ## [0.18.0](https://github.com/TypedDevs/bashunit/compare/0.17.0...0.18.0) - 2024-10-16
 

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -71,5 +71,7 @@ function log() {
     *) set -- "$level $@"; level="INFO" ;;
   esac
 
-  echo "$(current_timestamp) [$level]: $@" >> "$BASHUNIT_DEV_LOG"
+  local GRAY='\033[1;30m'
+  local RESET='\033[0m'
+  echo -e "$(current_timestamp) [$level]: $@ ${GRAY}#${BASH_SOURCE[1]}:${BASH_LINENO[0]}${RESET}" >> "$BASHUNIT_DEV_LOG"
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -188,7 +188,7 @@ function runner::run_test() {
     type="${type#[}"                    # Remove the leading "["
     local line="${subshell_output#*]}"  # Remove everything before and including "]"
 
-    # Replace [failed] with a newline to split failure messages
+    # Replace [type] with a newline to split the messages
     line=$(echo "$line" | sed -e 's/\[failed\]/\n/g' \
                               -e 's/\[skipped\]/\n/g' \
                               -e 's/\[incomplete\]/\n/g')

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -187,6 +187,10 @@ function runner::run_test() {
     local type="${subshell_output%%]*}" # Remove everything after "]"
     type="${type#[}"                    # Remove the leading "["
     local line="${subshell_output#*]}"  # Remove everything before and including "]"
+
+    # Replace [failed] with a newline to split failure messages
+    line=$(echo "$line" | sed 's/\[failed\]/\n/g')
+
     state::print_line "$type" "$line"
 
     subshell_output=$line

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -189,7 +189,9 @@ function runner::run_test() {
     local line="${subshell_output#*]}"  # Remove everything before and including "]"
 
     # Replace [failed] with a newline to split failure messages
-    line=$(echo "$line" | sed 's/\[failed\]/\n/g')
+    line=$(echo "$line" | sed -e 's/\[failed\]/\n/g' \
+                              -e 's/\[skipped\]/\n/g' \
+                              -e 's/\[incomplete\]/\n/g')
 
     state::print_line "$type" "$line"
 

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -48,7 +48,7 @@ function test_bashunit_with_multiple_failing_tests() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
 
   # shellcheck disable=SC2317
-  assert_match_snapshot "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
+  assert_match_snapshot "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
   # shellcheck disable=SC2317
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
 }

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -44,6 +44,15 @@ function test_bashunit_when_a_test_fail_simple_output_option() {
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
 }
 
+function test_bashunit_with_multiple_failing_tests() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+
+  # shellcheck disable=SC2317
+  assert_match_snapshot "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
+  # shellcheck disable=SC2317
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
+}
+
 function test_different_simple_snapshots_matches() {
   todo "The different snapshots for these tests should also be identical to each other, option to choose snapshot name?"
 }

--- a/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+++ b/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
@@ -5,7 +5,6 @@ function test_assert_same() {
 }
 
 function test_assert_failing() {
-  assert_same 1 0
-  assert_same 2 3
-  assert_same 4 5
+  assert_same 1 2
+  assert_same 3 4
 }

--- a/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+++ b/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function test_assert_same() {
+  assert_same 1 1
+}
+
+function test_assert_failing() {
+  assert_same 1 0
+  assert_same 2 3
+  assert_same 4 5
+}

--- a/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+++ b/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
@@ -8,3 +8,13 @@ function test_assert_failing() {
   assert_same 1 2
   assert_same 3 4
 }
+
+function test_assert_todo_and_skip() {
+  todo "foo"
+  skip "bar"
+}
+
+function test_assert_skip_and_todo() {
+  skip "baz"
+  todo "yei"
+}

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
@@ -5,17 +5,14 @@
 |1) ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
 |[31m✗ Failed[0m: Assert failing
 |    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'0'[0m
-|[failed][31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'2'[0m
-|    [2mbut got [0m [1m'3'[0m
-|[failed][31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'4'[0m
-|    [2mbut got [0m [1m'5'[0m
+|    [2mbut got [0m [1m'2'[0m
+|[31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'3'[0m
+|    [2mbut got [0m [1m'4'[0m
 
 
 
 [2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m3 failed[0m, 4 total
+[2mAssertions:[0m [32m1 passed[0m, [31m2 failed[0m, 3 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
@@ -1,0 +1,21 @@
+.[31mF[0m
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+|[31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'1'[0m
+|    [2mbut got [0m [1m'0'[0m
+|[failed][31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'2'[0m
+|    [2mbut got [0m [1m'3'[0m
+|[failed][31m✗ Failed[0m: Assert failing
+|    [2mExpected[0m [1m'4'[0m
+|    [2mbut got [0m [1m'5'[0m
+
+
+
+[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[2mAssertions:[0m [32m1 passed[0m, [31m3 failed[0m, 4 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
@@ -1,4 +1,15 @@
-.[31mF[0m
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh[0m
+[32m✓ Passed[0m: Assert same
+[31m✗ Failed[0m: Assert failing
+    [2mExpected[0m [1m'1'[0m
+    [2mbut got [0m [1m'2'[0m
+[31m✗ Failed[0m: Assert failing
+    [2mExpected[0m [1m'3'[0m
+    [2mbut got [0m [1m'4'[0m
+[36m✒ Incomplete[0m: Assert todo and skip[2m    foo[0m
+[33m↷ Skipped[0m: Assert todo and skip[2m    bar[0m
+[33m↷ Skipped[0m: Assert skip and todo[2m    baz[0m
+[36m✒ Incomplete[0m: Assert skip and todo[2m    yei[0m
 
 [1mThere was 1 failure:[0m
 
@@ -10,9 +21,7 @@
 |    [2mExpected[0m [1m'3'[0m
 |    [2mbut got [0m [1m'4'[0m
 
-
-
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m2 failed[0m, 3 total
+[2mTests:     [0m [32m1 passed[0m, [33m0 skipped[0m, [36m2 incomplete[0m, [31m1 failed[0m, 4 total
+[2mAssertions:[0m [32m1 passed[0m, [33m2 skipped[0m, [36m2 incomplete[0m, [31m2 failed[0m, 7 total
 
 [41m[30m[1m Some tests failed [0m


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/381

## 🔖 Changes

- Add caller source and line to `log` (global function)
- Fix displaying errors on multiline


## 🖼️  Demo
### BEFORE

<img width="1511" alt="Screenshot 2024-12-05 at 23 38 39" src="https://github.com/user-attachments/assets/e5b8bafb-3cce-4f29-a560-06c32a45e70c">

### AFTER

<img width="1505" alt="Screenshot 2024-12-05 at 23 39 23" src="https://github.com/user-attachments/assets/1caf68c5-33df-40cf-a657-d78351250031">


## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix