### PR TITLE
New subdomain and orgName for Sh:erpa

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -43,6 +43,6 @@ Loading bar for your shell scripts.
 
 It is a Docker (containers) based development environment for PHP.
 
-### [SherpaBasecamp/sherpa](https://sherpa-basecamp.netlify.app/tools/unit-tests/)
+### [SherpaCLI/sherpa](https://sherpa-cli.netlify.app/tools/unit-tests)
 
 Sh:erpa is a tool for simplifying script creation. It integrates **bashunit** to ensure reliable, tested Bash scripts for its users.


### PR DESCRIPTION
Hi,
There are some updates in the name and URL. The org on Github is now called SherpaCLI and the Netlify subdomain sherpa-cli. Shorter and more decriptive.

Moved from Astro to NuxtJS for the new website. 

_Out of curiosity... Any idea of the scheduled published date of the updated 'examples' page? The live one on [bashunit.typeddevs.com](https://bashunit.typeddevs.com/examples) seems to mention "Last updated: 09/11/2024" in the footer._

## 📚 Description

Updating a link after naming and subdomain changes.
