### PR TITLE
fix: improve duplicate function detection to handle functions without function keyword

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -32,7 +32,15 @@ function helper::check_duplicate_functions() {
   filtered_lines=$(grep -E '^[[:space:]]*(function[[:space:]]+)?test[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)\s*\{' "$script")
 
   local function_names
-  function_names=$(echo "$filtered_lines" | awk '{gsub(/\(|\)/, ""); print $2}')
+  function_names=$(echo "$filtered_lines" | awk '{
+    for (i=1; i<=NF; i++) {
+      if ($i ~ /^test[a-zA-Z_][a-zA-Z0-9_]*\(\)$/) {
+        gsub(/\(\)/, "", $i)
+        print $i
+        break
+      }
+    }
+  }')
 
   local duplicates
   duplicates=$(echo "$function_names" | sort | uniq -d)
@@ -40,6 +48,7 @@ function helper::check_duplicate_functions() {
     state::set_duplicated_functions_merged "$script" "$duplicates"
     return 1
   fi
+  return 0
 }
 
 #

--- a/tests/unit/fixtures/no_function_keyword_duplicates.sh
+++ b/tests/unit/fixtures/no_function_keyword_duplicates.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# shellcheck disable=SC2317
+test_func1() {
+  echo "Function 1"
+}
+
+test_func2() {
+  echo "Function 2"
+}
+
+test_func3() {
+  echo "Function 3"
+}
+
+test_func2() {
+  echo "Function 2 Duplicate"
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -97,6 +97,13 @@ function test_check_duplicate_functions_without_duplicates() {
   assert_successful_code "$(helper::check_duplicate_functions "$file")"
 }
 
+function test_check_duplicate_functions_without_function_keyword() {
+  local file
+  file="$(current_dir)/fixtures/no_function_keyword_duplicates.sh"
+
+  assert_general_error "$(helper::check_duplicate_functions "$file")"
+}
+
 function test_normalize_variable_name() {
   assert_same "valid_name123" "$(helper::normalize_variable_name "valid_name123")"
   assert_same "non_valid_symbols__________" "$(helper::normalize_variable_name "non_valid_symbols!@#$%^&*()")"


### PR DESCRIPTION
The previous implementation assumed that function names would always be in the second field when using awk to extract them. This caused issues when the function keyword was omitted, as the function name could be in any field.

This fix:

1. Scans all fields in each line for a pattern matching a test function name
2. Uses a proper regex pattern to identify function names
3. Only processes and prints actual function names
4. Adds an explicit return 0 for clarity

Added test case to verify the fix works with function declarations that omit the function keyword.