### PR TITLE
Fix false negative with `set -e`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fixed false negative with `set -e`
 - Fixed name rendered when having `test_test_*`
 - Fixed display test with multiple outputs in multiline
 - Improved output: adding a space between each test file

--- a/src/state.sh
+++ b/src/state.sh
@@ -14,6 +14,7 @@ _DUPLICATED_FUNCTION_NAMES=""
 _FILE_WITH_DUPLICATED_FUNCTION_NAMES=""
 _DUPLICATED_TEST_FUNCTIONS_FOUND=false
 _TEST_OUTPUT=""
+_TEST_EXIT_CODE=0
 
 function state::get_tests_passed() {
   echo "$_TESTS_PASSED"
@@ -123,6 +124,14 @@ function state::add_test_output() {
   _TEST_OUTPUT+="$1"
 }
 
+function state::get_test_exit_code() {
+  echo "$_TEST_EXIT_CODE"
+}
+
+function state::set_test_exit_code() {
+  _TEST_EXIT_CODE="$1"
+}
+
 function state::set_duplicated_functions_merged() {
   state::set_duplicated_test_functions_found
   state::set_file_with_duplicated_function_names "$1"
@@ -155,6 +164,7 @@ function state::export_subshell_context() {
 ##ASSERTIONS_SKIPPED=$_ASSERTIONS_SKIPPED\
 ##ASSERTIONS_INCOMPLETE=$_ASSERTIONS_INCOMPLETE\
 ##ASSERTIONS_SNAPSHOT=$_ASSERTIONS_SNAPSHOT\
+##TEST_EXIT_CODE=$_TEST_EXIT_CODE\
 ##TEST_OUTPUT=$encoded_test_output\
 ##
 EOF

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -45,6 +45,13 @@ function test_bashunit_with_multiple_failing_tests() {
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
 }
 
+function test_bashunit_with_a_test_fail_and_exit_immediately() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
+
+  assert_match_snapshot "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
+}
+
 function test_different_simple_snapshots_matches() {
   todo "The different snapshots for these tests should also be identical to each other, option to choose snapshot name?"
 }

--- a/tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+function test_error() {
+  set -e
+  invalid_function_name arg1 arg2 &>/dev/null
+}

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
@@ -1,0 +1,12 @@
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh[0m
+[31m✗ Error[0m: Error
+    [2m[0m
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
+
+[2mTests:     [0m [31m1 failed[0m, 1 total
+[2mAssertions:[0m [31m0 failed[0m, 0 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -254,6 +254,7 @@ function test_initialize_assertions_count() {
 ##ASSERTIONS_SKIPPED=0\
 ##ASSERTIONS_INCOMPLETE=0\
 ##ASSERTIONS_SNAPSHOT=0\
+##TEST_EXIT_CODE=0\
 ##TEST_OUTPUT=\
 ##"\
     "$export_assertions_count"
@@ -270,6 +271,7 @@ function test_export_assertions_count() {
     _ASSERTIONS_INCOMPLETE=12
     _ASSERTIONS_SNAPSHOT=33
     _ASSERTIONS_SNAPSHOT=33
+    _TEST_EXIT_CODE=1
     _TEST_OUTPUT="something"
 
     state::export_subshell_context
@@ -281,6 +283,7 @@ function test_export_assertions_count() {
 ##ASSERTIONS_SKIPPED=42\
 ##ASSERTIONS_INCOMPLETE=12\
 ##ASSERTIONS_SNAPSHOT=33\
+##TEST_EXIT_CODE=1\
 ##TEST_OUTPUT=$(echo -n "something" | base64)##"\
     "$export_assertions_count"
 }
@@ -291,6 +294,7 @@ function test_calculate_total_assertions() {
   ##ASSERTIONS_SKIPPED=3\
   ##ASSERTIONS_INCOMPLETE=4\
   ##ASSERTIONS_SNAPSHOT=5\
+  ##TEST_EXIT_CODE=0\
   ##TEST_OUTPUT=3zhbEncodedBase64##"
 
   assert_same 15 "$(state::calculate_total_assertions "$input")"


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/390

## 🔖 Changes

- Traps the exit code when running a test

🖼️ Demo

**Before**

![image](https://github.com/user-attachments/assets/804ca765-d544-4be4-a8b1-da9d1a124961)

**After**

![image](https://github.com/user-attachments/assets/072c7019-a0a9-4709-8ec8-c7a4078edf7b)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
