### PR TITLE
fix: only run macos related tests on macos

### DIFF
--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -54,7 +54,7 @@ function test_now_on_windows_without_without_powershell() {
 }
 
 function test_now_on_osx_without_perl() {
-  if check_os::is_windows; then
+  if ! check_os::is_macos; then
     skip
     return
   fi

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -288,7 +288,7 @@ function test_not_render_execution_time() {
 }
 
 function test_render_execution_time_on_osx_without_perl() {
-  if check_os::is_windows; then
+  if ! check_os::is_macos; then
     skip
     return
   fi
@@ -307,7 +307,7 @@ function test_render_execution_time_on_osx_without_perl() {
 }
 
 function test_render_execution_time_on_osx_with_perl() {
-  if check_os::is_windows; then
+  if ! check_os::is_macos; then
     skip
     return
   fi


### PR DESCRIPTION
## 📚 Description

Fixes #396.

## 🔖 Changes

Only run the macos related tests on macos and skip on linux so that all tests pass.

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
