### PR TITLE
refactor: update shebang with `#!/usr/bin/env bash`

### DIFF
--- a/bashunit
+++ b/bashunit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # shellcheck disable=SC2034

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Running pre-commit checks"
 
 make pre_commit/run

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source src/check_os.sh
 
@@ -37,7 +37,7 @@ function build::generate_bin() {
   local temp
   temp="$(dirname "$out")/temp.sh"
 
-  echo '#!/bin/bash' > "$temp"
+  echo '#!/usr/bin/env bash' > "$temp"
   echo "Generating bashunit in the '$(dirname "$out")' folder..."
 
   for file in $(build::dependencies); do

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ Once **bashunit** is installed, you're ready to get started.
 2.  Next, create your first test file named `example_test.sh` within this folder:
     ::: code-group
     ```bash [tests/example_test.sh]
-    #!/bin/bash
+    #!/usr/bin/env bash
 
     function test_bashunit_is_working() {
       assert_same "bashunit is working" "bashunit is working"

--- a/example/custom_functions.sh
+++ b/example/custom_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function say_hi(){
   echo "Hi, $1!"

--- a/example/custom_functions_test.sh
+++ b/example/custom_functions_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function set_up() {
   ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."

--- a/example/script_logic.sh
+++ b/example/script_logic.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "expected $1"

--- a/example/script_logic_test.sh
+++ b/example/script_logic_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function set_up() {
   ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")/.."

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 # shellcheck disable=SC2164
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function fail() {
   local message="${1:-${FUNCNAME[1]}}"

--- a/src/assert_arrays.sh
+++ b/src/assert_arrays.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_array_contains() {
   local expected="$1"

--- a/src/assert_files.sh
+++ b/src/assert_files.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_file_exists() {
   local expected="$1"

--- a/src/assert_folders.sh
+++ b/src/assert_folders.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_directory_exists() {
   local expected="$1"

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_match_snapshot() {
   local actual

--- a/src/assertions.sh
+++ b/src/assertions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source "$BASHUNIT_ROOT_DIR/src/assert.sh"
 source "$BASHUNIT_ROOT_DIR/src/assert_arrays.sh"

--- a/src/bashunit.sh
+++ b/src/bashunit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This file provides a facade to developers who wants
 # to interact with the internals of bashunit.

--- a/src/check_os.sh
+++ b/src/check_os.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 _OS="Unknown"

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function clock::now() {
   if dependencies::has_perl && perl -MTime::HiRes -e "" > /dev/null 2>&1; then

--- a/src/colors.sh
+++ b/src/colors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Pass in any number of ANSI SGR codes.
 #

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function console_header::print_version_with_env() {
   local filter=${1:-}

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 
 _TOTAL_TESTS_COUNT=0

--- a/src/dependencies.sh
+++ b/src/dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function dependencies::has_perl() {

--- a/src/dev/debug.sh
+++ b/src/dev/debug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # An alternative to echo when debugging.
 # This is debug function; do not use in prod!

--- a/src/env.sh
+++ b/src/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 # This file provides a set of global functions to developers.

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 declare -r BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 

--- a/src/io.sh
+++ b/src/io.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function io::download_to() {
   local url="$1"

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function main::exec_tests() {
   local filter=$1

--- a/src/math.sh
+++ b/src/math.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if dependencies::has_bc; then
   # bc is better than awk because bc has no integer limits.

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function parallel::aggregate_test_results() {
   local temp_dir_parallel_test_suite=$1

--- a/src/reports.sh
+++ b/src/reports.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 
 _REPORTS_TEST_FILES=()

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 
 function runner::load_test_files() {

--- a/src/skip_todo.sh
+++ b/src/skip_todo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function skip() {
   local reason=${1-}

--- a/src/state.sh
+++ b/src/state.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 _TESTS_PASSED=0
 _TESTS_FAILED=0

--- a/src/str.sh
+++ b/src/str.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function str::rpad() {
   local left_text="$1"

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 declare -a MOCKED_FUNCTIONS=()
 

--- a/src/upgrade.sh
+++ b/src/upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function upgrade::upgrade() {
   local script_path

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_execution_error_test.sh
+++ b/tests/acceptance/bashunit_execution_error_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 set -euo pipefail
 

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_find_tests_command_line_test.sh
+++ b/tests/acceptance/bashunit_find_tests_command_line_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function set_up_before_script() {
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"

--- a/tests/acceptance/bashunit_pass_test.sh
+++ b/tests/acceptance/bashunit_pass_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_path_test.sh
+++ b/tests/acceptance/bashunit_path_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_report_html_test.sh
+++ b/tests/acceptance/bashunit_report_html_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_test.sh
+++ b/tests/acceptance/bashunit_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up_before_script() {

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -uo pipefail
 set +e
 

--- a/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_error() {
   invalid_function_name arg1 arg2

--- a/tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_assert_same() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_assert_same() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_error() {
   set -e

--- a/tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_success() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/test_bashunit_when_report_html.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_report_html.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_success() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_a_success() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
+++ b/tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_assert_same() {
   assert_same 1 1

--- a/tests/acceptance/fixtures/tests_path/a_test.sh
+++ b/tests/acceptance/fixtures/tests_path/a_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_assert_greater_and_less_than() {
   assert_greater_than 1 999

--- a/tests/acceptance/fixtures/tests_path/other_test.sh
+++ b/tests/acceptance/fixtures/tests_path/other_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_assert_same() {
   assert_same 1 1

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2317
 set -uo pipefail
 set +e

--- a/tests/acceptance/mock_test.sh
+++ b/tests/acceptance/mock_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 #

--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function mock_non_existing_fn() {

--- a/tests/functional/custom_asserts.sh
+++ b/tests/functional/custom_asserts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function assert_foo() {
   local actual="$1"

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up() {

--- a/tests/functional/fixtures/doubles_function.sh
+++ b/tests/functional/fixtures/doubles_function.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function top_mem() {
   ps -eo cmd,%mem --sort=-%mem | awk '$2 >= 1.0 {print $0}' | head -n 3

--- a/tests/functional/fixtures/doubles_script.sh
+++ b/tests/functional/fixtures/doubles_script.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ps -eo cmd,%mem --sort=-%mem | awk '$2 >= 1.0 {print $0}' | head -n 3

--- a/tests/functional/logic.sh
+++ b/tests/functional/logic.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "expected $1"

--- a/tests/functional/logic_test.sh
+++ b/tests/functional/logic_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(current_dir)"

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function set_up() {

--- a/tests/unit/assert_snapshot_test.sh
+++ b/tests/unit/assert_snapshot_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function set_up() {
   export BASHUNIT_SIMPLE_OUTPUT=false

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_successful_fail() {
   true || fail "This cannot fail"

--- a/tests/unit/check_os_test.sh
+++ b/tests/unit/check_os_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_default_os() {
   mock uname echo "bogus OS"

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 __ORIGINAL_OS=""
 

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function mock_all_state_getters() {
   mock state::is_duplicated_test_functions_found echo false

--- a/tests/unit/dependencies_test.sh
+++ b/tests/unit/dependencies_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_has_perl_search_path_for_perl() {
   spy command

--- a/tests/unit/directory_test.sh
+++ b/tests/unit/directory_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2155
 
 function test_successful_assert_directory_exists() {

--- a/tests/unit/file_test.sh
+++ b/tests/unit/file_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2155
 

--- a/tests/unit/fixtures/duplicate_functions.sh
+++ b/tests/unit/fixtures/duplicate_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2317
 function func1() {

--- a/tests/unit/fixtures/fake_function_to_spy.sh
+++ b/tests/unit/fixtures/fake_function_to_spy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function function_to_be_spied_on(){
   echo "this function should be spy and not execute"

--- a/tests/unit/fixtures/no_duplicate_functions.sh
+++ b/tests/unit/fixtures/no_duplicate_functions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2317
 function func1() {

--- a/tests/unit/fixtures/no_function_keyword_duplicates.sh
+++ b/tests/unit/fixtures/no_function_keyword_duplicates.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2317
 test_func1() {

--- a/tests/unit/fixtures/tests/example1_test.sh
+++ b/tests/unit/fixtures/tests/example1_test.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # internationally blank

--- a/tests/unit/fixtures/tests/example2_test.sh
+++ b/tests/unit/fixtures/tests/example2_test.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # internationally blank

--- a/tests/unit/globals_test.sh
+++ b/tests/unit/globals_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 function tear_down_after_script() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function tear_down() {
   helper::unset_if_exists fake_function

--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 _ERROR_LOG=temp_error.log

--- a/tests/unit/setup_teardown_test.sh
+++ b/tests/unit/setup_teardown_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TEST_COUNTER=1
 

--- a/tests/unit/skip_todo_test.sh
+++ b/tests/unit/skip_todo_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function test_skip_output() {
   assert_same\

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034
 

--- a/tests/unit/str_test.sh
+++ b/tests/unit/str_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2155
 

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function tear_down() {
   unset code
@@ -104,4 +104,3 @@ function test_successful_spy_called_times_with_source() {
 
   assert_have_been_called_times 2 function_to_be_spied_on
 }
-


### PR DESCRIPTION
## 📚 Description

Using `#!/usr/bin/env bash` improves portability across systems where bash may not be located in `/bin`. This change ensures scripts can run reliably in more environments.

## 🔖 Changes

- replace `#!/bin/bash` with `#!/usr/bin/env bash`

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
