### PR TITLE
fix: avoid printf error on floating-point values by using awk

### DIFF
--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -106,7 +106,7 @@ function console_results::print_execution_time() {
     return
   fi
 
-  local time=$(printf "%.0f" "$(clock::total_runtime_in_milliseconds)")
+  local time=$(clock::total_runtime_in_milliseconds | awk '{printf "%.0f", $1}')
 
   if [[ "$time" -lt 1000 ]]; then
     printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" \
@@ -116,7 +116,7 @@ function console_results::print_execution_time() {
 
   local time_in_seconds=$(( time / 1000 ))
   local remainder_ms=$(( time % 1000 ))
-  local formatted_seconds=$(printf "%.2f" "$time_in_seconds.$remainder_ms")
+  local formatted_seconds=$(echo "$time_in_seconds.$remainder_ms" | awk '{printf "%.0f", $1}')
 
   printf "${_COLOR_BOLD}%s${_COLOR_DEFAULT}\n" \
     "Time taken: $formatted_seconds s"


### PR DESCRIPTION
## 📚 Description

Bash's built-in `printf` does not support floating-point formats like `%f`. This causes errors such as 'invalid number' when formatting values like `167.183`.

## 🔖 Changes

- This commit update the usage of `printf` with `awk`, which correctly handles float rounding and improves portability across platforms including GNU Bash.

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
