### PR TITLE
Fix assert_have_been_called spy functions in subshell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## Unreleased
+
+- Fix asserts on test doubles in subshell
+
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 
-- replace `#!/bin/bash` with `#!/usr/bin/env bash`
-- usage printf with awk, which correctly handles float rounding and improves portability
+- Replace `#!/bin/bash` with `#!/usr/bin/env bash`
+- Usage printf with awk, which correctly handles float rounding and improves portability
 
 ## [0.19.0](https://github.com/TypedDevs/bashunit/compare/0.18.0...0.19.0) - 2025-02-19
 

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -130,7 +130,9 @@ function assert_have_been_called_times() {
 
   if [[ -z "${!actual-}" && $expected -ne 0 || $times -ne $expected ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${command}" "to has been called" "${expected} times"
+    console_results::print_failed_test "${label}" "${command}" \
+      "to has been called" "${expected} times" \
+      "actual" "${times} times"
     return
   fi
 

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -9,6 +9,16 @@ function unmock() {
     if [[ "${MOCKED_FUNCTIONS[$i]}" == "$command" ]]; then
       unset "MOCKED_FUNCTIONS[$i]"
       unset -f "$command"
+      local variable
+      variable="$(helper::normalize_variable_name "$command")"
+      local times_file_var="${variable}_times_file"
+      local params_file_var="${variable}_params_file"
+      [[ -f "${!times_file_var-}" ]] && rm -f "${!times_file_var}"
+      [[ -f "${!params_file_var-}" ]] && rm -f "${!params_file_var}"
+      unset "${variable}_times"
+      unset "${variable}_params"
+      unset "$times_file_var"
+      unset "$params_file_var"
       break
     fi
   done
@@ -37,7 +47,22 @@ function spy() {
   export "${variable}_times"=0
   export "${variable}_params"
 
-  eval "function $command() { ${variable}_params=(\"\$*\"); ((${variable}_times++)) || true; }"
+  local times_file params_file
+  times_file=$(temp_file "${variable}_times")
+  params_file=$(temp_file "${variable}_params")
+  echo 0 > "$times_file"
+  : > "$params_file"
+  export "${variable}_times_file"="$times_file"
+  export "${variable}_params_file"="$params_file"
+
+  eval "function $command() {
+    ${variable}_params=(\"\$*\")
+    echo \"\$*\" > '$params_file'
+    ((${variable}_times++)) || true
+    local _c=\$(cat '$times_file')
+    _c=\$((_c+1))
+    echo \"\$_c\" > '$times_file'
+  }"
 
   export -f "${command?}"
 
@@ -50,9 +75,14 @@ function assert_have_been_called() {
   variable="$(helper::normalize_variable_name "$command")"
   local actual
   actual="${variable}_times"
+  local file_var="${variable}_times_file"
+  local times="${!actual-0}"
+  if [[ -f "${!file_var-}" ]]; then
+    times=$(cat "${!file_var}")
+  fi
   local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  if [[ ${!actual} -eq 0 ]]; then
+  if [[ $times -eq 0 ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${command}" "to has been called" "once"
     return
@@ -68,11 +98,16 @@ function assert_have_been_called_with() {
   variable="$(helper::normalize_variable_name "$command")"
   local actual
   actual="${variable}_params"
+  local file_var="${variable}_params_file"
+  local params="${!actual-}"
+  if [[ -f "${!file_var-}" ]]; then
+    params=$(cat "${!file_var}")
+  fi
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  if [[ "$expected" != "${!actual}" ]]; then
+  if [[ "$expected" != "$params" ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${expected}" "but got " "${!actual}"
+    console_results::print_failed_test "${label}" "${expected}" "but got " "$params"
     return
   fi
 
@@ -86,9 +121,14 @@ function assert_have_been_called_times() {
   variable="$(helper::normalize_variable_name "$command")"
   local actual
   actual="${variable}_times"
+  local file_var="${variable}_times_file"
+  local times="${!actual-0}"
+  if [[ -f "${!file_var-}" ]]; then
+    times=$(cat "${!file_var}")
+  fi
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
-  if [[ -z "${!actual-}" && $expected -ne 0 || ${!actual-0} -ne $expected ]]; then
+  if [[ -z "${!actual-}" && $expected -ne 0 || $times -ne $expected ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${command}" "to has been called" "${expected} times"
     return

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -62,7 +62,9 @@ function test_unsuccessful_spy_called_times() {
   ps
 
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful spy called times" "ps" "to has been called" "1 times")"\
+    "$(console_results::print_failed_test "Unsuccessful spy called times" "ps" \
+    "to has been called" "1 times" \
+    "actual" "2 times")"\
     "$(assert_have_been_called_times 1 ps)"
 }
 
@@ -88,8 +90,8 @@ function test_unsuccessful_spy_with_source_function_have_been_called() {
     "$(console_results::print_failed_test \
     "Unsuccessful spy with source function have been called"\
     "function_to_be_spied_on" \
-    "to has been called" \
-    "1 times")"\
+    "to has been called" "1 times" \
+    "actual" "2 times")"\
     "$(assert_have_been_called_times 1 function_to_be_spied_on)"
 }
 
@@ -106,18 +108,19 @@ function test_successful_spy_called_times_with_source() {
 }
 
 function test_spy_called_in_subshell() {
-  spy create_remote_time_entries
+  spy spy_called_in_subshell
 
   function run() {
-    create_remote_time_entries "$1"
+    spy_called_in_subshell "$1"
+    spy_called_in_subshell "$1"
     echo "done"
   }
 
   local result
-  result="$(run "2023-10-01")"
+  result="$(run "2025-05-23")"
 
   assert_same "done" "$result"
-  assert_have_been_called create_remote_time_entries
-  assert_have_been_called_with "2023-10-01" create_remote_time_entries
-  assert_have_been_called_times 1 create_remote_time_entries
+  assert_have_been_called spy_called_in_subshell
+  assert_have_been_called_times 2 spy_called_in_subshell
+  assert_have_been_called_with "2025-05-23" spy_called_in_subshell
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -104,3 +104,20 @@ function test_successful_spy_called_times_with_source() {
 
   assert_have_been_called_times 2 function_to_be_spied_on
 }
+
+function test_spy_called_in_subshell() {
+  spy create_remote_time_entries
+
+  function run() {
+    create_remote_time_entries "$1"
+    echo "done"
+  }
+
+  local result
+  result="$(run "2023-10-01")"
+
+  assert_same "done" "$result"
+  assert_have_been_called create_remote_time_entries
+  assert_have_been_called_with "2023-10-01" create_remote_time_entries
+  assert_have_been_called_times 1 create_remote_time_entries
+}


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/395

## 🔖 Changes

- Fix spy functions in subshell
  - `assert_have_been_called`
  - `assert_have_been_called_times`
  -  `assert_have_been_called_with`

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
