### PR TITLE
Allow interpolating arguments data providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix asserts on test doubles in subshell
+- Allow interpolating arguments in data providers output
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 

--- a/docs/data-providers.md
+++ b/docs/data-providers.md
@@ -24,6 +24,31 @@ function test_my_test_case() {
 
 The provider function can echo a single value like `"one"` or multiple values `"one" "two" "three"`.
 
+## Interpolating arguments in test names
+
+You can reference the values provided by a data provider directly in the test
+function name using placeholders like `::1::`, `::2::`, ... matching the
+argument position.
+
+::: code-group
+```bash [example_test.sh]
+# data_provider fizz_numbers
+function test_returns_fizz_when_multiple_of_::1::_like_::2::_given() {
+  # ...
+}
+
+function fizz_numbers() {
+  echo 3 4
+  echo 3 6
+}
+```
+```[Output]
+Running example_test.sh
+✓ Passed: Returns fizz when multiple of '3' like '4' given
+✓ Passed: Returns fizz when multiple of '3' like '6' given
+```
+:::
+
 ## Multiple args in one call
 
 ::: code-group

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -8,21 +8,20 @@ declare -r BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 # @return string Eg: "Some logic camelCase"
 #
 function helper::normalize_test_function_name() {
-  local original_function_name="${1-}"
+  local original_fn_name="${1-}"
+  local interpolated_fn_name="${2-}"
 
-  if [[ -n "${BASHUNIT_CURRENT_FUNCTION_NAME-}" &&
-        "$original_function_name" == "$BASHUNIT_CURRENT_FUNCTION_NAME" &&
-        -n "${BASHUNIT_INTERPOLATED_FUNCTION_NAME-}" ]]; then
-    original_function_name="$BASHUNIT_INTERPOLATED_FUNCTION_NAME"
+  if [[ -n "${interpolated_fn_name-}" ]]; then
+    original_fn_name="$interpolated_fn_name"
   fi
 
   local result
 
   # Remove the first "test_" prefix, if present
-  result="${original_function_name#test_}"
+  result="${original_fn_name#test_}"
   # If no "test_" was removed (e.g., "testFoo"), remove the "test" prefix
-  if [[ "$result" == "$original_function_name" ]]; then
-    result="${original_function_name#test}"
+  if [[ "$result" == "$original_fn_name" ]]; then
+    result="${original_fn_name#test}"
   fi
   # Replace underscores with spaces
   result="${result//_/ }"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -135,6 +135,8 @@ function runner::run_test() {
   shift
   local function_name="$1"
   shift
+  export BASHUNIT_CURRENT_FUNCTION_NAME="$function_name"
+  export BASHUNIT_INTERPOLATED_FUNCTION_NAME="$(helper::interpolate_function_name "$function_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"
   local current_assertions_incomplete="$(state::get_assertions_incomplete)"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -135,8 +135,8 @@ function runner::run_test() {
   shift
   local fn_name="$1"
   shift
-  export BASHUNIT_CURRENT_fn_name="$fn_name"
-  local interpolated_fn_name="$(helper::interpolate_fn_name "$fn_name" "$@")"
+
+  local interpolated_fn_name="$(helper::interpolate_function_name "$fn_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"
   local current_assertions_incomplete="$(state::get_assertions_incomplete)"
@@ -265,9 +265,13 @@ function runner::run_test() {
     return
   fi
 
-  local label="$(helper::normalize_test_fn_name "$fn_name" "$interpolated_fn_name")"
+  local label="$(helper::normalize_test_function_name "$fn_name" "$interpolated_fn_name")"
 
-  console_results::print_successful_test "${label}" "$duration" "$@"
+  if [[ "$fn_name" == "$interpolated_fn_name" ]]; then
+    console_results::print_successful_test "${label}" "$duration" "$@"
+  else
+    console_results::print_successful_test "${label}" "$duration"
+  fi
   state::add_tests_passed
   reports::add_test_passed "$test_file" "$fn_name" "$duration" "$total_assertions"
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -136,7 +136,7 @@ function runner::run_test() {
   local function_name="$1"
   shift
   export BASHUNIT_CURRENT_FUNCTION_NAME="$function_name"
-  export BASHUNIT_INTERPOLATED_FUNCTION_NAME="$(helper::interpolate_function_name "$function_name" "$@")"
+  local interpolated_function_name="$(helper::interpolate_function_name "$function_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"
   local current_assertions_incomplete="$(state::get_assertions_incomplete)"
@@ -265,7 +265,7 @@ function runner::run_test() {
     return
   fi
 
-  local label="$(helper::normalize_test_function_name "$function_name")"
+  local label="$(helper::normalize_test_function_name "$function_name" "$interpolated_function_name")"
 
   console_results::print_successful_test "${label}" "$duration" "$@"
   state::add_tests_passed

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -50,11 +50,11 @@ function runner::spinner() {
 
 function runner::functions_for_script() {
   local script="$1"
-  local all_function_names="$2"
+  local all_fn_names="$2"
 
   # Filter the names down to the ones defined in the script, sort them by line number
   shopt -s extdebug
-  for f in $all_function_names; do
+  for f in $all_fn_names; do
     declare -F "$f" | grep "$script"
   done | sort -k2 -n | awk '{print $1}'
   shopt -u extdebug
@@ -65,8 +65,8 @@ function runner::call_test_functions() {
   local filter="$2"
   local prefix="test"
   # Use declare -F to list all function names
-  local all_function_names=$(declare -F | awk '{print $3}')
-  local filtered_functions=$(helper::get_functions_to_run "$prefix" "$filter" "$all_function_names")
+  local all_fn_names=$(declare -F | awk '{print $3}')
+  local filtered_functions=$(helper::get_functions_to_run "$prefix" "$filter" "$all_fn_names")
   # shellcheck disable=SC2207
   local functions_to_run=($(runner::functions_for_script "$script" "$filtered_functions"))
 
@@ -77,7 +77,7 @@ function runner::call_test_functions() {
   runner::render_running_file_header
   helper::check_duplicate_functions "$script" || true
 
-  for function_name in "${functions_to_run[@]}"; do
+  for fn_name in "${functions_to_run[@]}"; do
     if parallel::is_enabled && parallel::must_stop_on_failure; then
       break
     fi
@@ -85,12 +85,12 @@ function runner::call_test_functions() {
     local provider_data=()
     while IFS=" " read -r line; do
       provider_data+=("$line")
-    done <<< "$(helper::get_provider_data "$function_name" "$script")"
+    done <<< "$(helper::get_provider_data "$fn_name" "$script")"
 
     # No data provider found
     if [[ "${#provider_data[@]}" -eq 0 ]]; then
-      runner::run_test "$script" "$function_name"
-      unset function_name
+      runner::run_test "$script" "$fn_name"
+      unset fn_name
       continue
     fi
 
@@ -98,12 +98,12 @@ function runner::call_test_functions() {
     for data in "${provider_data[@]}"; do
       IFS=" " read -r -a args <<< "$data"
       if [ "${#args[@]}" -gt 1 ]; then
-        runner::run_test "$script" "$function_name" "${args[@]}"
+        runner::run_test "$script" "$fn_name" "${args[@]}"
       else
-        runner::run_test "$script" "$function_name" "$data"
+        runner::run_test "$script" "$fn_name" "$data"
       fi
     done
-    unset function_name
+    unset fn_name
   done
 
   if ! env::is_simple_output_enabled; then
@@ -133,10 +133,10 @@ function runner::run_test() {
 
   local test_file="$1"
   shift
-  local function_name="$1"
+  local fn_name="$1"
   shift
-  export BASHUNIT_CURRENT_FUNCTION_NAME="$function_name"
-  local interpolated_function_name="$(helper::interpolate_function_name "$function_name" "$@")"
+  export BASHUNIT_CURRENT_fn_name="$fn_name"
+  local interpolated_fn_name="$(helper::interpolate_fn_name "$fn_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"
   local current_assertions_incomplete="$(state::get_assertions_incomplete)"
@@ -159,7 +159,7 @@ function runner::run_test() {
 
     # 2>&1: Redirects the std-error (FD 2) to the std-output (FD 1).
     # points to the original std-output.
-    "$function_name" "$@" 2>&1
+    "$fn_name" "$@" 2>&1
 
   )
 
@@ -177,7 +177,7 @@ function runner::run_test() {
 
     printf '%*s\n' "$TERMINAL_WIDTH" '' | tr ' ' '='
     printf "%s\n" "File:     $test_file"
-    printf "%s\n" "Function: $function_name"
+    printf "%s\n" "Function: $fn_name"
     printf "%s\n" "Duration: $duration ms"
     local raw_text=${test_execution_result%%##ASSERTIONS_*}
     [[ -n $raw_text ]] && printf "%s" "Raw text: ${test_execution_result%%##ASSERTIONS_*}"
@@ -218,22 +218,22 @@ function runner::run_test() {
     fi
   done
 
-  runner::parse_result "$function_name" "$test_execution_result" "$@"
+  runner::parse_result "$fn_name" "$test_execution_result" "$@"
 
   local total_assertions="$(state::calculate_total_assertions "$test_execution_result")"
   local test_exit_code="$(state::get_test_exit_code)"
 
   if [[ -n $runtime_error || $test_exit_code -ne 0 ]]; then
     state::add_tests_failed
-    console_results::print_error_test "$function_name" "$runtime_error"
-    reports::add_test_failed "$test_file" "$function_name" "$duration" "$total_assertions"
+    console_results::print_error_test "$fn_name" "$runtime_error"
+    reports::add_test_failed "$test_file" "$fn_name" "$duration" "$total_assertions"
     runner::write_failure_result_output "$test_file" "$runtime_error"
     return
   fi
 
   if [[ "$current_assertions_failed" != "$(state::get_assertions_failed)" ]]; then
     state::add_tests_failed
-    reports::add_test_failed "$test_file" "$function_name" "$duration" "$total_assertions"
+    reports::add_test_failed "$test_file" "$fn_name" "$duration" "$total_assertions"
     runner::write_failure_result_output "$test_file" "$subshell_output"
 
     if env::is_stop_on_failure_enabled; then
@@ -248,28 +248,28 @@ function runner::run_test() {
 
   if [[ "$current_assertions_snapshot" != "$(state::get_assertions_snapshot)" ]]; then
     state::add_tests_snapshot
-    console_results::print_snapshot_test "$function_name"
-    reports::add_test_snapshot "$test_file" "$function_name" "$duration" "$total_assertions"
+    console_results::print_snapshot_test "$fn_name"
+    reports::add_test_snapshot "$test_file" "$fn_name" "$duration" "$total_assertions"
     return
   fi
 
   if [[ "$current_assertions_incomplete" != "$(state::get_assertions_incomplete)" ]]; then
     state::add_tests_incomplete
-    reports::add_test_incomplete "$test_file" "$function_name" "$duration" "$total_assertions"
+    reports::add_test_incomplete "$test_file" "$fn_name" "$duration" "$total_assertions"
     return
   fi
 
   if [[ "$current_assertions_skipped" != "$(state::get_assertions_skipped)" ]]; then
     state::add_tests_skipped
-    reports::add_test_skipped "$test_file" "$function_name" "$duration" "$total_assertions"
+    reports::add_test_skipped "$test_file" "$fn_name" "$duration" "$total_assertions"
     return
   fi
 
-  local label="$(helper::normalize_test_function_name "$function_name" "$interpolated_function_name")"
+  local label="$(helper::normalize_test_fn_name "$fn_name" "$interpolated_fn_name")"
 
   console_results::print_successful_test "${label}" "$duration" "$@"
   state::add_tests_passed
-  reports::add_test_passed "$test_file" "$function_name" "$duration" "$total_assertions"
+  reports::add_test_passed "$test_file" "$fn_name" "$duration" "$total_assertions"
 }
 
 function runner::decode_subshell_output() {
@@ -287,21 +287,21 @@ function runner::decode_subshell_output() {
 }
 
 function runner::parse_result() {
-  local function_name=$1
+  local fn_name=$1
   shift
   local execution_result=$1
   shift
   local args=("$@")
 
   if parallel::is_enabled; then
-    runner::parse_result_parallel "$function_name" "$execution_result" "${args[@]}"
+    runner::parse_result_parallel "$fn_name" "$execution_result" "${args[@]}"
   else
-    runner::parse_result_sync "$function_name" "$execution_result"
+    runner::parse_result_sync "$fn_name" "$execution_result"
   fi
 }
 
 function runner::parse_result_parallel() {
-  local function_name=$1
+  local fn_name=$1
   shift
   local execution_result=$1
   shift
@@ -312,9 +312,9 @@ function runner::parse_result_parallel() {
 
   local test_result_file=$(echo "${args[@]}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
   if [[ -z "$test_result_file" ]]; then
-    test_result_file="${function_name}.$$.result"
+    test_result_file="${fn_name}.$$.result"
   else
-    test_result_file="${function_name}-${test_result_file}.$$.result"
+    test_result_file="${fn_name}-${test_result_file}.$$.result"
   fi
 
   local unique_test_result_file="${test_suite_dir}/${test_result_file}"
@@ -325,15 +325,15 @@ function runner::parse_result_parallel() {
     count=$((count + 1))
   done
 
-  log "debug" "[PARA]" "function_name:$function_name" "execution_result:$execution_result"
+  log "debug" "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
 
-  runner::parse_result_sync "$function_name" "$execution_result"
+  runner::parse_result_sync "$fn_name" "$execution_result"
 
   echo "$execution_result" > "$unique_test_result_file"
 }
 
 function runner::parse_result_sync() {
-  local function_name=$1
+  local fn_name=$1
   local execution_result=$2
 
   local assertions_failed=$(\
@@ -372,7 +372,7 @@ function runner::parse_result_sync() {
     sed -E -e 's/.*##TEST_EXIT_CODE=([0-9]*)##.*/\1/g'\
   )
 
-  log "debug" "[SYNC]" "function_name:$function_name" "execution_result:$execution_result"
+  log "debug" "[SYNC]" "fn_name:$fn_name" "execution_result:$execution_result"
 
   ((_ASSERTIONS_PASSED += assertions_passed)) || true
   ((_ASSERTIONS_FAILED += assertions_failed)) || true

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -228,13 +228,14 @@ function test_to_run_with_filter_matching_string_in_function_name() {
 function test_interpolate_function_name() {
   local result
   result="$(helper::interpolate_function_name "test_name_::1::_foo" "bar")"
+
   assert_same "test_name_'bar'_foo" "$result"
 }
 
 function test_normalize_test_function_name_with_interpolation() {
-  local fn="test_returns_value_::1::_given"
-  export BASHUNIT_CURRENT_FUNCTION_NAME="$fn"
+  local fn="test_returns_value_::1::_and_::2::_given"
   # shellcheck disable=SC2155
-  export BASHUNIT_INTERPOLATED_FUNCTION_NAME="$(helper::interpolate_function_name "$fn" "3")"
-  assert_same "Returns value '3' given" "$(helper::normalize_test_function_name "$fn")"
+  local interpolated_fn="$(helper::interpolate_function_name "$fn" "3" "4")"
+
+  assert_same "Returns value '3' and '4' given" "$(helper::normalize_test_function_name "$fn" "$interpolated_fn")"
 }

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -225,7 +225,7 @@ function test_to_run_with_filter_matching_string_in_function_name() {
     "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
 }
 
-function test_interpolate_function_name() {
+function test_interpolate_fn_name() {
   local result
   result="$(helper::interpolate_function_name "test_name_::1::_foo" "bar")"
 

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -224,3 +224,17 @@ function test_to_run_with_filter_matching_string_in_function_name() {
     "test_my_awesome_function test_your_awesome_function"\
     "$(helper::get_functions_to_run "test" "awesome" "${functions[*]}")"
 }
+
+function test_interpolate_function_name() {
+  local result
+  result="$(helper::interpolate_function_name "test_name_::1::_foo" "bar")"
+  assert_same "test_name_'bar'_foo" "$result"
+}
+
+function test_normalize_test_function_name_with_interpolation() {
+  local fn="test_returns_value_::1::_given"
+  export BASHUNIT_CURRENT_FUNCTION_NAME="$fn"
+  # shellcheck disable=SC2155
+  export BASHUNIT_INTERPOLATED_FUNCTION_NAME="$(helper::interpolate_function_name "$fn" "3")"
+  assert_same "Returns value '3' given" "$(helper::normalize_test_function_name "$fn")"
+}


### PR DESCRIPTION
## 📚 Description

Fixes: https://github.com/TypedDevs/bashunit/issues/252

## 🔖 Changes

Allow interpolating these arguments in the names of the tests through some special syntax, for example `::1::`, `::2::`...

```bash
# data_provider fizz_numbers
function test_regular_params() {
  echo "$1" "$2"
}

# data_provider fizz_numbers
function test_interpolating_::1::_params_::2::_example() {
  echo "$1"
}

function fizz_numbers() {
  echo 3 4
  echo 3 6
}
```
![Screenshot 2025-05-24 at 00 05 14](https://github.com/user-attachments/assets/6d024c28-6664-4452-94db-f49ad36dad6c)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
