### PR TITLE
Fix parallel spy temp file conflicts

### DIFF
--- a/src/runner.sh
+++ b/src/runner.sh
@@ -136,6 +136,13 @@ function runner::run_test() {
   local fn_name="$1"
   shift
 
+  # Export a unique test identifier so that test doubles can
+  # create temporary files scoped per test run. This prevents
+  # race conditions when running tests in parallel.
+  local sanitized_fn_name
+  sanitized_fn_name="$(helper::normalize_variable_name "$fn_name")"
+  export BASHUNIT_CURRENT_TEST_ID="${sanitized_fn_name}_$$"
+
   local interpolated_fn_name="$(helper::interpolate_function_name "$fn_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -48,8 +48,9 @@ function spy() {
   export "${variable}_params"
 
   local times_file params_file
-  times_file=$(temp_file "${variable}_times")
-  params_file=$(temp_file "${variable}_params")
+  local test_id="${BASHUNIT_CURRENT_TEST_ID:-global}"
+  times_file=$(temp_file "${test_id}_${variable}_times")
+  params_file=$(temp_file "${test_id}_${variable}_params")
   echo 0 > "$times_file"
   : > "$params_file"
   export "${variable}_times_file"="$times_file"

--- a/tests/acceptance/fixtures/test_parallel_spy_file1.sh
+++ b/tests/acceptance/fixtures/test_parallel_spy_file1.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+function test_spy_file1() {
+  spy date
+  date
+  assert_have_been_called_times 1 date
+}

--- a/tests/acceptance/fixtures/test_parallel_spy_file2.sh
+++ b/tests/acceptance/fixtures/test_parallel_spy_file2.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+function test_spy_file2() {
+  spy date
+  date
+  assert_have_been_called_times 1 date
+}

--- a/tests/acceptance/parallel_spy_parallel_test.sh
+++ b/tests/acceptance/parallel_spy_parallel_test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function test_spies_work_in_parallel() {
+  local file1=tests/acceptance/fixtures/test_parallel_spy_file1.sh
+  local file2=tests/acceptance/fixtures/test_parallel_spy_file2.sh
+
+  ./bashunit --parallel "$file1" "$file2"
+  assert_successful_code
+}


### PR DESCRIPTION
## Summary
- scope spy temp files by test id
- expose current test id to spies via `BASHUNIT_CURRENT_TEST_ID`
- add a regression test covering spies running in parallel

## Testing
- `./bashunit tests/unit/test_doubles_test.sh tests/acceptance/parallel_spy_parallel_test.sh`
- `./bashunit --parallel tests/unit/test_doubles_test.sh tests/acceptance/parallel_spy_parallel_test.sh`