### PR TITLE
Fix parallel test doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix asserts on test doubles in subshell
+- Fix test doubles when running tests in parallel
 - Allow interpolating arguments in data providers output
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -2,6 +2,8 @@
 
 When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
 
+Temporary files created by spies are isolated per test run, so they work reliably when executing tests in parallel.
+
 ## mock
 > `mock "function" "body"`
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -141,7 +141,7 @@ function runner::run_test() {
   # race conditions when running tests in parallel.
   local sanitized_fn_name
   sanitized_fn_name="$(helper::normalize_variable_name "$fn_name")"
-  export BASHUNIT_CURRENT_TEST_ID="${sanitized_fn_name}_$$"
+  export BASHUNIT_CURRENT_TEST_ID="${sanitized_fn_name}_$$_$(random_str 6)"
 
   local interpolated_fn_name="$(helper::interpolate_function_name "$fn_name" "$@")"
   local current_assertions_failed="$(state::get_assertions_failed)"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -343,6 +343,7 @@ function runner::parse_result_parallel() {
   echo "$execution_result" > "$unique_test_result_file"
 }
 
+# shellcheck disable=SC2295
 function runner::parse_result_sync() {
   local fn_name=$1
   local execution_result=$2


### PR DESCRIPTION
## Summary
- ensure each test run has a unique id for test doubles
- document parallel friendly spy files
- note the fix in the changelog
