### PR TITLE
Support specify which call to assert in have_been_called_with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix asserts on test doubles in subshell
 - Allow interpolating arguments in data providers output
 - Deprecate `# data_provider` in favor of `# @data_provider`
+- Allow `assert_have_been_called_with` to check arguments of specific calls
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -102,26 +102,30 @@ function test_failure() {
 :::
 
 ## assert_have_been_called_with
-> `assert_have_been_called_with "expected" "spy"`
+> `assert_have_been_called_with "expected" "spy" [call_index]`
 
-Reports an error if `callable` is not called with `expected`.
+Reports an error if `spy` is not called with `expected`. When `call_index` is
+provided, the assertion checks the arguments of that specific call (starting at
+1). Without `call_index` it checks the last invocation.
 
 ::: code-group
 ```bash [Example]
 function test_success() {
   spy ps
 
-  ps foo bar
+  ps foo
+  ps bar
 
-  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called_with "foo" ps 1
+  assert_have_been_called_with "bar" ps 2
 }
 
 function test_failure() {
   spy ps
 
-  ps bar foo
+  ps bar
 
-  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called_with "foo" ps 1
 }
 ```
 :::

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -52,7 +52,7 @@ function spy() {
   export "${variable}_params_file"="$params_file"
 
   eval "function $command() {
-    echo \"\$*\" > '$params_file'
+    echo \"\$*\" >> '$params_file'
     local _c=\$(cat '$times_file')
     _c=\$((_c+1))
     echo \"\$_c\" > '$times_file'
@@ -86,14 +86,30 @@ function assert_have_been_called() {
 function assert_have_been_called_with() {
   local expected=$1
   local command=$2
+  local third_arg="${3:-}"
+  local fourth_arg="${4:-}"
+
+  local index=""
+  local label=""
+  if [[ -n $third_arg && $third_arg =~ ^[0-9]+$ ]]; then
+    index=$third_arg
+    label="${fourth_arg:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+  else
+    label="${third_arg:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+    index="$fourth_arg"
+  fi
+
   local variable
   variable="$(helper::normalize_variable_name "$command")"
   local file_var="${variable}_params_file"
   local params=""
   if [[ -f "${!file_var-}" ]]; then
-    params=$(cat "${!file_var}")
+    if [[ -n $index ]]; then
+      params=$(sed -n "${index}p" "${!file_var}")
+    else
+      params=$(tail -n 1 "${!file_var}")
+    fi
   fi
-  local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
 
   if [[ "$expected" != "$params" ]]; then
     state::add_assertions_failed

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -137,3 +137,13 @@ function test_mock_called_in_subshell() {
 
   assert_same "2024-05-01" "$result"
 }
+
+function test_spy_called_with_different_arguments() {
+  spy ps
+
+  ps first_a first_b
+  ps second
+
+  assert_have_been_called_with "first_a first_b" ps 1
+  assert_have_been_called_with "second" ps 2
+}


### PR DESCRIPTION
## 📚 Description

Currently there is no way to assert different param values to a test double

## 🔖 Changes

- Added support for specifying which call to assert in `assert_have_been_called_with`

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
