### PR TITLE
Enable parallel tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
-          ./bashunit tests/${{ matrix.test_chunk }}/*_test.sh
+          ./bashunit --parallel tests/${{ matrix.test_chunk }}/*_test.sh
 
   alpine:
     name: "On alpine-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix asserts on test doubles in subshell
 - Allow interpolating arguments in data providers output
 - Deprecate `# data_provider` in favor of `# @data_provider`
+- Enable parallel tests on Windows
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -130,9 +130,9 @@ Creates a report XML file that follows the JUnit XML format and contains informa
 bashunit provides an option to run each test in a separate child process, allowing you to parallelize the test execution and potentially speed up the testing process. When running in parallel mode, the execution order of tests is randomized.
 
 ::: warning
-Parallel mode is currently only supported on **macOS** and **Ubuntu**. On other
-systems (like Alpine Linux or Windows) the option is automatically disabled due
-to inconsistent results. In those environments consider using `--no-parallel`.
+Parallel mode is supported on **macOS**, **Ubuntu**, and **Windows**. On other
+systems (like Alpine Linux) the option is automatically disabled due to
+inconsistent results. In those environments consider using `--no-parallel`.
 :::
 
 ::: code-group

--- a/src/main.sh
+++ b/src/main.sh
@@ -20,8 +20,8 @@ function main::exec_tests() {
   trap '[[ $? -eq $EXIT_CODE_STOP_ON_FAILURE ]] && main::handle_stop_on_failure_sync' EXIT
 
   if env::is_parallel_run_enabled && ! parallel::is_enabled; then
-    printf "%sWarning: Parallel tests are working only for macOS and Ubuntu.\n" "${_COLOR_INCOMPLETE}"
-    printf "For other OS (Linux/Alpine, Windows), --parallel is not enabled due to inconsistent results,\n"
+    printf "%sWarning: Parallel tests are supported on macOS, Ubuntu and Windows.\n" "${_COLOR_INCOMPLETE}"
+    printf "For other OS (like Alpine), --parallel is not enabled due to inconsistent results,\n"
     printf "particularly involving race conditions.%s " "${_COLOR_DEFAULT}"
     printf "%sFallback using --no-parallel%s\n" "${_COLOR_SKIPPED}" "${_COLOR_DEFAULT}"
   fi

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -87,7 +87,8 @@ function parallel::reset() {
 }
 
 function parallel::is_enabled() {
-  if env::is_parallel_run_enabled && (check_os::is_macos || check_os::is_ubuntu); then
+  if env::is_parallel_run_enabled && \
+    (check_os::is_macos || check_os::is_ubuntu || check_os::is_windows); then
     return 0
   fi
   return 1

--- a/tests/unit/parallel_test.sh
+++ b/tests/unit/parallel_test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function tear_down() {
+  export BASHUNIT_PARALLEL_RUN=$original_parallel_run
+}
+
+function set_up() {
+  original_parallel_run=$BASHUNIT_PARALLEL_RUN
+  export BASHUNIT_PARALLEL_RUN=true
+}
+
+function test_parallel_enabled_on_windows() {
+  mock check_os::is_windows mock_true
+  mock check_os::is_macos mock_false
+  mock check_os::is_ubuntu mock_false
+
+  assert_successful_code "$(parallel::is_enabled)"
+}


### PR DESCRIPTION
## Summary
- enable parallel mode for Windows
- update docs and CI workflow
- add a unit test for parallel::is_enabled on Windows
- document change in changelog
