### PR TITLE
Add assert_not_called test double

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -156,3 +156,26 @@ function test_failure() {
 }
 ```
 :::
+
+## assert_not_called
+> `assert_not_called "spy"`
+
+Reports an error if `spy` has been executed at least once.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  spy ps
+
+  assert_not_called ps
+}
+
+function test_failure() {
+  spy ps
+
+  ps
+
+  assert_not_called ps
+}
+```
+:::

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -141,3 +141,9 @@ function assert_have_been_called_times() {
 
   state::add_assertions_passed
 }
+
+function assert_not_called() {
+  local command=$1
+  local label="${2:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
+  assert_have_been_called_times 0 "$command" "$label"
+}

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -147,3 +147,19 @@ function test_spy_called_with_different_arguments() {
   assert_have_been_called_with "first_a first_b" ps 1
   assert_have_been_called_with "second" ps 2
 }
+
+function test_successful_not_called() {
+  spy ps
+
+  assert_not_called ps
+}
+
+function test_unsuccessful_not_called() {
+  spy ps
+
+  ps
+
+  assert_same \
+    "$(console_results::print_failed_test \"Unsuccessful not called\" \"ps\" \"to has been called\" \"0 times\" \"actual\" \"1 times\")" \
+    "$(assert_not_called ps)"
+}


### PR DESCRIPTION
## Summary
- add `assert_not_called` helper to verify spies were never invoked
- document `assert_not_called`
- exercise `assert_not_called` in unit tests

## Testing
- `make test` *(fails: directory permission tests fail when running as root)*

------
https://chatgpt.com/codex/tasks/task_b_683a3912b6a48323a8edef72fde13a0e