### PR TITLE
Optimize runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add `assert_not_called`
 - Improve `find_total_tests` performance
 - Added `assert_match_snapshot_ignore_colors`
+- Optimize `runner::parse_result_sync`
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -354,21 +354,28 @@ function runner::parse_result_sync() {
   local result_line
   result_line=$(echo "$execution_result" | tail -n 1)
 
-  local regex='ASSERTIONS_FAILED=([0-9]*)##ASSERTIONS_PASSED=([0-9]*)##ASSERTIONS_SKIPPED=([0-9]*)##ASSERTIONS_INCOMPLETE=([0-9]*)##ASSERTIONS_SNAPSHOT=([0-9]*)##TEST_EXIT_CODE=([0-9]*)'
+  local assertions_failed=0
+  local assertions_passed=0
+  local assertions_skipped=0
+  local assertions_incomplete=0
+  local assertions_snapshot=0
+  local test_exit_code=0
+
+  local regex
+  regex='ASSERTIONS_FAILED=([0-9]*)##'
+  regex+='ASSERTIONS_PASSED=([0-9]*)##'
+  regex+='ASSERTIONS_SKIPPED=([0-9]*)##'
+  regex+='ASSERTIONS_INCOMPLETE=([0-9]*)##'
+  regex+='ASSERTIONS_SNAPSHOT=([0-9]*)##'
+  regex+='TEST_EXIT_CODE=([0-9]*)'
+
   if [[ $result_line =~ $regex ]]; then
-    local assertions_failed="${BASH_REMATCH[1]}"
-    local assertions_passed="${BASH_REMATCH[2]}"
-    local assertions_skipped="${BASH_REMATCH[3]}"
-    local assertions_incomplete="${BASH_REMATCH[4]}"
-    local assertions_snapshot="${BASH_REMATCH[5]}"
-    local test_exit_code="${BASH_REMATCH[6]}"
-  else
-    local assertions_failed=0
-    local assertions_passed=0
-    local assertions_skipped=0
-    local assertions_incomplete=0
-    local assertions_snapshot=0
-    local test_exit_code=0
+    assertions_failed="${BASH_REMATCH[1]}"
+    assertions_passed="${BASH_REMATCH[2]}"
+    assertions_skipped="${BASH_REMATCH[3]}"
+    assertions_incomplete="${BASH_REMATCH[4]}"
+    assertions_snapshot="${BASH_REMATCH[5]}"
+    test_exit_code="${BASH_REMATCH[6]}"
   fi
 
   log "debug" "[SYNC]" "fn_name:$fn_name" "execution_result:$execution_result"


### PR DESCRIPTION
## 🔖 Changes

- Calculate assertions with regex instead of subshells for each number

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

