### PR TITLE
fix: typo "to has been called"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix typo "to has been called"
+
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 
 - Fix asserts on test doubles in subshell

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -76,7 +76,7 @@ function assert_have_been_called() {
 
   if [[ $times -eq 0 ]]; then
     state::add_assertions_failed
-    console_results::print_failed_test "${label}" "${command}" "to has been called" "once"
+    console_results::print_failed_test "${label}" "${command}" "to have been called" "once"
     return
   fi
 
@@ -134,7 +134,7 @@ function assert_have_been_called_times() {
   if [[ $times -ne $expected ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${command}" \
-      "to has been called" "${expected} times" \
+      "to have been called" "${expected} times" \
       "actual" "${times} times"
     return
   fi

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -41,7 +41,7 @@ function test_unsuccessful_spy_called() {
   spy ps
 
   assert_same\
-    "$(console_results::print_failed_test "Unsuccessful spy called" "ps" "to has been called" "once")"\
+    "$(console_results::print_failed_test "Unsuccessful spy called" "ps" "to have been called" "once")"\
     "$(assert_have_been_called ps)"
 }
 
@@ -63,7 +63,7 @@ function test_unsuccessful_spy_called_times() {
 
   assert_same\
     "$(console_results::print_failed_test "Unsuccessful spy called times" "ps" \
-    "to has been called" "1 times" \
+    "to have been called" "1 times" \
     "actual" "2 times")"\
     "$(assert_have_been_called_times 1 ps)"
 }
@@ -90,7 +90,7 @@ function test_unsuccessful_spy_with_source_function_have_been_called() {
     "$(console_results::print_failed_test \
     "Unsuccessful spy with source function have been called"\
     "function_to_be_spied_on" \
-    "to has been called" "1 times" \
+    "to have been called" "1 times" \
     "actual" "2 times")"\
     "$(assert_have_been_called_times 1 function_to_be_spied_on)"
 }
@@ -161,7 +161,7 @@ function test_spy_unsuccessful_not_called() {
 
   assert_same \
     "$(console_results::print_failed_test "Spy unsuccessful not called" "ps" \
-      "to has been called" "0 times" \
+      "to have been called" "0 times" \
       "actual" "1 times")" \
     "$(assert_not_called ps)"
 }


### PR DESCRIPTION
## 📚 Description

fix: typo "to has been called"

## 🔖 Changes

- fix: typo "to has been called"

## ✅ To-do list

- [X] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [X] I updated the documentation to reflect the changes
