### PR TITLE
Cache downloads endpoint 24h in localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix typo "to has been called"
 - Add weekly downloads to the docs
+- Cache weekly downloads on localStorage
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 


### PR DESCRIPTION
## 📚 Description

The homepage is doing a API call to get all download graph

![Screenshot 2025-06-02 at 17 22 02](https://github.com/user-attachments/assets/fb5c2daa-fa45-4487-92dc-f80573b7c4d6)

## 🔖 Changes

- Cache downloads endpoint 24h in localStorage

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

## 📹 Demo


https://github.com/user-attachments/assets/f25715f2-f68e-4b61-9a25-f7af2d9996a3



