### PR TITLE
docs/fix: interpolate frontmatter variables during local search index generation

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -122,7 +122,17 @@ export default defineConfig({
     }],
 
     search: {
-      provider: 'local'
+      provider: 'local',
+      options: {
+        _render(src, env, md) {
+          const html = md.render(src, env)
+
+          return html.replace(
+            /{{\s*\$frontmatter\.(\w+)\s*}}/g,
+            (_, key) => env.frontmatter[key]?.toString() || ''
+          )
+        }
+      }
     },
 
     footer: {


### PR DESCRIPTION
## 📚 Description

This PR fixes an issue where {{ $frontmatter.* }} variables were not being interpolated in the Markdown content during the local search index generation, leading to incomplete or incorrect entries.

![imagen](https://github.com/user-attachments/assets/1c397e5f-a5fc-4eb7-8be8-27a33539ab05)

## 🔖 Changes

- Applied frontmatter variable interpolation to rendered HTML before indexing
- 
## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
