### PR TITLE
Count data providers when counting total tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix typo "to has been called"
 - Add weekly downloads to the docs
 - Fix parallel runner
+- Count data providers when counting total tests
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -36,7 +36,7 @@ EOF
     if [ "$total_tests" -eq 0 ]; then
       printf "%s\n" "$BASHUNIT_VERSION"
     else
-      printf "%s | Tests: ~%s\n" "$BASHUNIT_VERSION" "$total_tests"
+      printf "%s | Tests: %s\n" "$BASHUNIT_VERSION" "$total_tests"
     fi
     return
   fi
@@ -44,7 +44,7 @@ EOF
   if [ "$total_tests" -eq 0 ]; then
     printf "${_COLOR_BOLD}${_COLOR_PASSED}bashunit${_COLOR_DEFAULT} - %s\n" "$BASHUNIT_VERSION"
   else
-    printf "${_COLOR_BOLD}${_COLOR_PASSED}bashunit${_COLOR_DEFAULT} - %s | Tests: ~%s\n"\
+    printf "${_COLOR_BOLD}${_COLOR_PASSED}bashunit${_COLOR_DEFAULT} - %s | Tests: %s\n"\
       "$BASHUNIT_VERSION"\
       "$total_tests"
   fi

--- a/tests/unit/fixtures/find_total_tests/provider_test.sh
+++ b/tests/unit/fixtures/find_total_tests/provider_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# @data_provider provider_lines
+function test_with_provider() {
+  return 0
+}
+
+function provider_lines() {
+  echo "alpha beta"
+  echo "gamma"
+  echo "delta epsilon zeta"
+}

--- a/tests/unit/fixtures/find_total_tests/simple_test.sh
+++ b/tests/unit/fixtures/find_total_tests/simple_test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function test_first() {
+  return 0
+}
+
+function test_second() {
+  return 0
+}

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -239,3 +239,43 @@ function test_normalize_test_function_name_with_interpolation() {
 
   assert_same "Returns value '3' and '4' given" "$(helper::normalize_test_function_name "$fn" "$interpolated_fn")"
 }
+
+function helpers_test::find_total_in_subshell() {
+  bash -c 'source "$1"; shift; helpers::find_total_tests "$@"' bash "$BASHUNIT_ROOT_DIR/src/helpers.sh" "$@"
+}
+
+function test_find_total_tests_no_files() {
+  assert_same "0" "$(helpers_test::find_total_in_subshell)"
+}
+
+function test_find_total_tests_simple_file() {
+  local file
+  file="$(current_dir)/fixtures/find_total_tests/simple_test.sh"
+
+  assert_same "2" "$(helpers_test::find_total_in_subshell "" "$file")"
+}
+
+function test_find_total_tests_with_provider() {
+  local file
+  file="$(current_dir)/fixtures/find_total_tests/provider_test.sh"
+
+  assert_same "3" "$(helpers_test::find_total_in_subshell "" "$file")"
+}
+
+function test_find_total_tests_multiple_files() {
+  local file1
+  local file2
+  file1="$(current_dir)/fixtures/find_total_tests/simple_test.sh"
+  file2="$(current_dir)/fixtures/find_total_tests/provider_test.sh"
+
+  assert_same "5" "$(helpers_test::find_total_in_subshell "" "$file1" "$file2")"
+}
+
+function test_find_total_tests_with_filter() {
+  local file1
+  local file2
+  file1="$(current_dir)/fixtures/find_total_tests/simple_test.sh"
+  file2="$(current_dir)/fixtures/find_total_tests/provider_test.sh"
+
+  assert_same "3" "$(helpers_test::find_total_in_subshell "with_provider" "$file1" "$file2")"
+}


### PR DESCRIPTION
## 📚 Description

The `find_total_tests` was looking for the "test" only, ignoring the data provider tests

## 🔖 Changes


### BEFORE

![Screenshot 2025-06-05 at 21 41 20](https://github.com/user-attachments/assets/8debb5f4-ff59-44ab-843b-544a01758c45)

### AFTER

Not ~360 anymore, but actually counting the data provider cases 🥳 

![Screenshot 2025-06-05 at 21 41 33](https://github.com/user-attachments/assets/f30d461a-2f20-4726-8739-cb6669025050)


## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
