### PR TITLE
Make installer args more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Support placeholder `::ignore::` in snapshots
 - Add project overview docs
 - Improve clock performance
+- Allow using install.sh with only a version argument
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Support placeholder `::ignore::` in snapshots
 - Add project overview docs
 - Improve clock performance
-- Allow using install.sh with only a version argument
+- Make install.sh args more flexible
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,13 +31,14 @@ https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checks
 
 #### Define custom tag and folder
 
-The installation script can receive two optional arguments:
+The installation script can receive arguments in two forms:
 
 ```bash
 curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
+curl -s https://bashunit.typeddevs.com/install.sh | bash -s [version]
 ```
 - `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
-- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default. When only `[version]` is provided and follows the `N.N.N` pattern, it will be installed in the `lib` directory.
 
 ::: tip
 You can use `beta` as `[version]` to get the next non-stable preview release.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,14 +31,13 @@ https://github.com/TypedDevs/bashunit/releases/download/{{ pkg.version }}/checks
 
 #### Define custom tag and folder
 
-The installation script can receive arguments in two forms:
+The installation script can receive arguments (in any order):
 
 ```bash
 curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
-curl -s https://bashunit.typeddevs.com/install.sh | bash -s [version]
 ```
 - `[dir]`: the destiny directory to save the executable bashunit; `lib` by default
-- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default. When only `[version]` is provided and follows the `N.N.N` pattern, it will be installed in the `lib` directory.
+- `[version]`: the [release](https://github.com/TypedDevs/bashunit/releases) to download, for instance `{{ pkg.version }}`; `latest` by default.
 
 ::: tip
 You can use `beta` as `[version]` to get the next non-stable preview release.

--- a/install.sh
+++ b/install.sh
@@ -63,14 +63,32 @@ function install() {
 ######### MAIN ##########
 #########################
 
-DIR=${1-lib}
-VERSION=${2-latest}
+# Defaults
+DIR="lib"
+VERSION="latest"
 
-# When only one argument is provided, treat it as the version if it matches
-# the pattern N.N.N (e.g. 0.20.0)
-if [[ $# -eq 1 && $DIR =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  VERSION=$DIR
-  DIR="lib"
+function is_version() {
+  [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ || "$1" == "latest" || "$1" == "beta" ]]
+}
+
+# Parse arguments flexibly
+if [[ $# -eq 1 ]]; then
+  if is_version "$1"; then
+    VERSION="$1"
+  else
+    DIR="$1"
+  fi
+elif [[ $# -eq 2 ]]; then
+  if is_version "$1"; then
+    VERSION="$1"
+    DIR="$2"
+  elif is_version "$2"; then
+    DIR="$1"
+    VERSION="$2"
+  else
+    echo "Invalid arguments. Expected version or directory." >&2
+    exit 1
+  fi
 fi
 
 BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"

--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,13 @@ function install() {
 DIR=${1-lib}
 VERSION=${2-latest}
 
+# When only one argument is provided, treat it as the version if it matches
+# the pattern N.N.N (e.g. 0.20.0)
+if [[ $# -eq 1 && $DIR =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  VERSION=$DIR
+  DIR="lib"
+fi
+
 BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
 if is_git_installed; then
     LATEST_BASHUNIT_VERSION="$(get_latest_tag "$BASHUNIT_GIT_REPO")"

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -84,6 +84,26 @@ function test_install_downloads_the_given_version() {
     "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
 }
 
+function test_install_downloads_the_given_version_without_dir() {
+  if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
+    skip "no internet connection" && return
+  fi
+
+  local installed_bashunit="./lib/bashunit"
+  local output
+  output="$(./install.sh 0.19.0)"
+
+  assert_same \
+    "$(printf "> Downloading a concrete version: '0.19.0'\n> bashunit has been installed in the 'lib' folder")" \
+    "$output"
+
+  assert_file_exists "$installed_bashunit"
+
+  assert_same \
+    "$(printf "\e[1m\e[32mbashunit\e[0m - 0.19.0")" \
+    "$("$installed_bashunit" --env "$TEST_ENV_FILE" --version)"
+}
+
 function test_install_downloads_the_non_stable_beta_version() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -94,7 +94,10 @@ function test_install_downloads_the_given_version_without_dir() {
   output="$(./install.sh 0.19.0)"
 
   assert_same \
-    "$(printf "> Downloading a concrete version: '0.19.0'\n> bashunit has been installed in the 'lib' folder")" \
+    "$(printf "%s\n" \
+      "> Downloading a concrete version: '0.19.0'" \
+      "> bashunit has been installed in the 'lib' folder" \
+    )" \
     "$output"
 
   assert_file_exists "$installed_bashunit"


### PR DESCRIPTION
## 📚 Description

RIght now, to install a [custom version](https://bashunit.typeddevs.com/installation#define-custom-tag-and-folder), you have to define the directory
 ```bash
curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
```

<img width="744" alt="Screenshot 2025-06-08 at 16 45 22" src="https://github.com/user-attachments/assets/ee1d6342-bfe9-47e1-8269-85d0e02da73d" />

## 🔖 Changes

- Allow using `install.sh` with only a version argument or both arguments in any order

### 🧪 Examples
 ```bash
curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir]
curl -s https://bashunit.typeddevs.com/install.sh | bash -s [dir] [version]
curl -s https://bashunit.typeddevs.com/install.sh | bash -s [version]
curl -s https://bashunit.typeddevs.com/install.sh | bash -s [version] [dir] 
```

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
