### PR TITLE
Improve Windows detection for parallel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add project overview docs
 - Improve clock performance
 - Make install.sh args more flexible
+- Improve Windows detection allowing parallel tests on Git Bash, MSYS and Cygwin
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 

--- a/src/check_os.sh
+++ b/src/check_os.sh
@@ -41,7 +41,14 @@ function check_os::is_macos() {
 }
 
 function check_os::is_windows() {
-  [[ "$(uname)" == *"MINGW"* ]]
+  case "$(uname)" in
+    *MINGW*|*MSYS*|*CYGWIN*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
 }
 
 function check_os::is_busybox() {

--- a/tests/unit/check_os_test.sh
+++ b/tests/unit/check_os_test.sh
@@ -52,6 +52,10 @@ function test_detect_windows_os() {
 function window_linux_variations() {
   echo "MINGW"
   echo "junkMINGWjunk"
+  echo "MSYS_NT-10.0"
+  echo "junkMSYSjunk"
+  echo "CYGWIN_NT-10.0"
+  echo "junkCYGWINjunk"
 }
 
 function test_alpine_is_busybox() {


### PR DESCRIPTION
## Summary
- detect more Windows environments (MSYS, Cygwin) in `check_os::is_windows`
- extend unit tests for Windows detection
- document improved Windows detection in changelog
