### PR TITLE
Fix parallel consistency on arch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Improve `find_total_tests` performance
 - Added `assert_match_snapshot_ignore_colors`
 - Optimize `runner::parse_result_sync`
+- Fix `parse_result_parallel` template
 
 ## [0.19.1](https://github.com/TypedDevs/bashunit/compare/0.19.0...0.19.1) - 2025-05-23
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -376,13 +376,15 @@ function runner::parse_result_parallel() {
   sanitized_args=$(echo "${args[*]}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
   local template
   if [[ -z "$sanitized_args" ]]; then
-    template="${fn_name}.XXXXXX.result"
+    template="${fn_name}.XXXXXX"
   else
-    template="${fn_name}-${sanitized_args}.XXXXXX.result"
+    template="${fn_name}-${sanitized_args}.XXXXXX"
   fi
 
   local unique_test_result_file
   unique_test_result_file=$(mktemp -p "$test_suite_dir" "$template")
+  mv "$unique_test_result_file" "${unique_test_result_file}.result"
+  unique_test_result_file="${unique_test_result_file}.result"
 
   log "debug" "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
 


### PR DESCRIPTION
## 📚 Description

Fix https://github.com/TypedDevs/bashunit/issues/433

## 🔖 Changes

- Fix `runner::parse_result_parallel` template

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

