### PR TITLE
Split macos and ubuntu ci jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,15 +7,33 @@ on:
       - main
 
 jobs:
-  ubuntu-macos:
-    name: "On ${{ matrix.os }}"
+  ubuntu:
+    name: "Ubuntu - ${{ matrix.version }}"
+    runs-on: ${{ matrix.version }}
     timeout-minutes: 10
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
+        version:
           - ubuntu-latest
+          - ubuntu-22.04  # one version before latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Tests
+        run: make test
+
+  macos:
+    name: "macOS - ${{ matrix.version }}"
+    runs-on: ${{ matrix.version }}
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        version:
           - macos-latest
+          - macos-13  # one version before latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improve clock performance
 - Make install.sh args more flexible
 - Improve Windows detection allowing parallel tests on Git Bash, MSYS and Cygwin
+- Add more CI jobs for different ubuntu and macos versions
 
 ## [0.20.0](https://github.com/TypedDevs/bashunit/compare/0.19.1...0.20.0) - 2025-06-01
 


### PR DESCRIPTION
## 📚 Description

Related: https://github.com/TypedDevs/bashunit/issues/433

## 🔖 Changes

- Add more CI tests for diff versions of ubuntu and macos to improve the test coverage in diff OS

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
