### PR TITLE
Fix process time always shows as '0 ms'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix process time always shows as 0 ms
+
 ## [0.21.0](https://github.com/TypedDevs/bashunit/compare/0.20.0...0.21.0) - 2025-06-18
 
 - Fix typo "to has been called"

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -100,6 +100,16 @@ function test_now_prefers_perl_over_shell_time() {
   assert_same "999999999999" "$(clock::now)"
 }
 
+function test_now_prefers_python_over_node() {
+  mock perl mock_non_existing_fn
+  mock dependencies::has_python mock_true
+  mock python echo "777777777777"
+  mock dependencies::has_node mock_true
+  mock node echo "888888888888"
+
+  assert_same "777777777777" "$(clock::now)"
+}
+
 function test_runtime_in_milliseconds_when_empty_time() {
   mock_macos
   mock perl mock_non_existing_fn

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -91,6 +91,15 @@ function test_runtime_in_milliseconds_when_not_empty_time() {
   assert_not_empty "$(clock::total_runtime_in_milliseconds)"
 }
 
+function test_now_prefers_perl_over_shell_time() {
+  mock clock::shell_time echo "1234.0"
+  mock perl echo "999999999999"
+  mock dependencies::has_python mock_false
+  mock dependencies::has_node mock_false
+
+  assert_same "999999999999" "$(clock::now)"
+}
+
 function test_runtime_in_milliseconds_when_empty_time() {
   mock_macos
   mock perl mock_non_existing_fn


### PR DESCRIPTION
## 📚 Description

Fixes: #436
Processing time is always shows as 0 ms in version 0.21.0, it was displayed correctly in version 0.20.0

#### v0.21.0
![Screenshot 2025-07-05 at 22 44 33](https://github.com/user-attachments/assets/d584812a-0c46-4c6f-8aea-78dea548eb8d)

#### v0.20.0
![Screenshot 2025-07-05 at 22 44 43](https://github.com/user-attachments/assets/307c1969-7d18-46d0-a5b9-0d71dd38d599)


## 🔖 Changes

- Keep same order as in v0.20.0

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
