### PR TITLE
Add --init option to get you started quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `--init` option to get you started quickly
 - Fix process time always shows as 0 ms
 - Refactor clock optimizing the implementation used to get the time
 

--- a/bashunit
+++ b/bashunit
@@ -28,6 +28,7 @@ source "$BASHUNIT_ROOT_DIR/src/assertions.sh"
 source "$BASHUNIT_ROOT_DIR/src/reports.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner.sh"
 source "$BASHUNIT_ROOT_DIR/src/bashunit.sh"
+source "$BASHUNIT_ROOT_DIR/src/init.sh"
 source "$BASHUNIT_ROOT_DIR/src/main.sh"
 
 _ASSERT_FN=""
@@ -99,6 +100,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --upgrade)
       upgrade::upgrade
+      trap '' EXIT && exit 0
+      ;;
+    --init)
+      init::init
       trap '' EXIT && exit 0
       ;;
     -h|--help)

--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,7 @@ function build::dependencies() {
     "src/assertions.sh"
     "src/reports.sh"
     "src/runner.sh"
+    "src/init.sh"
     "src/bashunit.sh"
     "src/main.sh"
   )

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -370,6 +370,21 @@ Upgrade **bashunit** to latest version.
 ```
 :::
 
+## Init
+
+> `bashunit --init`
+
+Generates a `tests` folder with a sample test and bootstrap file to get you started quickly.
+
+::: code-group
+```bash [Example]
+./bashunit --init
+```
+```bash [Output]
+> bashunit initialized in tests
+```
+:::
+
 ## Help
 
 > `bashunit --help`

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+function init::init() {
+  local tests_dir="$BASHUNIT_DEFAULT_PATH"
+  mkdir -p "$tests_dir"
+
+  local bootstrap_file="$tests_dir/bootstrap.sh"
+  if [[ ! -f "$bootstrap_file" ]]; then
+    cat >"$bootstrap_file" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+# Place your common test setup here
+SH
+    chmod +x "$bootstrap_file"
+    echo "> Created $bootstrap_file"
+  fi
+
+  local example_test="$tests_dir/example_test.sh"
+  if [[ ! -f "$example_test" ]]; then
+    cat >"$example_test" <<'SH'
+#!/usr/bin/env bash
+
+function test_bashunit_is_installed() {
+  assert_same "bashunit is installed" "bashunit is installed"
+}
+SH
+    chmod +x "$example_test"
+    echo "> Created $example_test"
+  fi
+
+  echo "> bashunit initialized in $tests_dir"
+}

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_DIR="tmp/init"
+function set_up() {
+  rm -rf "$TMP_DIR"
+  mkdir -p "$TMP_DIR"
+}
+
+function tear_down() {
+  rm -rf "$TMP_DIR"
+}
+
+function test_bashunit_init_creates_structure() {
+  # switch into a clean temporary directory
+  pushd "$TMP_DIR" >/dev/null
+  # generate test scaffolding
+  ../../bashunit --init > /tmp/init.log
+  # perform the assertions
+  assert_file_exists tests/example_test.sh
+  assert_file_exists tests/bootstrap.sh
+  # return to the original working directory
+  popd >/dev/null
+}


### PR DESCRIPTION
## 📚 Description

Right now, we have documented how to start with bashunit step by step (see: https://bashunit.typeddevs.com/quickstart#usage), but I thought we could simplify even more with an `--init` option to create the initial setup and faster "onboarding" 🚀 

## 🔖 Changes

- Added a new initialization command that introduces a `--init` option for faster project setup
- Created an initialization script that prepares a bootstrap file and sample test for newcomers
- Documented the new --init option in the command-line guide
- Implemented an acceptance test validating that the initialization command generates the expected files

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
