### PR TITLE
Support custom dir to --init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `--init` option to get you started quickly
+- Allow passing a directory to `--init`
 - Fix process time always shows as 0 ms
 - Fixed terminal width detection first tput and fall back stty
 - Refactor clock optimizing the implementation used to get the time

--- a/bashunit
+++ b/bashunit
@@ -103,7 +103,12 @@ while [[ $# -gt 0 ]]; do
       trap '' EXIT && exit 0
       ;;
     --init)
-      init::init
+      if [[ -n ${2:-} && ${2:0:1} != "-" ]]; then
+        init::init "$2"
+        shift
+      else
+        init::init
+      fi
       trap '' EXIT && exit 0
       ;;
     -h|--help)

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -372,16 +372,16 @@ Upgrade **bashunit** to latest version.
 
 ## Init
 
-> `bashunit --init`
+> `bashunit --init [dir]`
 
-Generates a `tests` folder with a sample test and bootstrap file to get you started quickly.
+Generates a `tests` folder (or the provided `dir`) with a sample test and bootstrap file to get you started quickly.
 
 ::: code-group
 ```bash [Example]
-./bashunit --init
+./bashunit --init tests_dir
 ```
 ```bash [Output]
-> bashunit initialized in tests
+> bashunit initialized in tests_dir
 ```
 :::
 

--- a/src/init.sh
+++ b/src/init.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function init::init() {
-  local tests_dir="$BASHUNIT_DEFAULT_PATH"
+  local tests_dir="${1:-$BASHUNIT_DEFAULT_PATH}"
   mkdir -p "$tests_dir"
 
   local bootstrap_file="$tests_dir/bootstrap.sh"

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -22,3 +22,11 @@ function test_bashunit_init_creates_structure() {
   # return to the original working directory
   popd >/dev/null
 }
+
+function test_bashunit_init_custom_directory() {
+  pushd "$TMP_DIR" >/dev/null
+  ../../bashunit --init custom > /tmp/init.log
+  assert_file_exists custom/example_test.sh
+  assert_file_exists custom/bootstrap.sh
+  popd >/dev/null
+}


### PR DESCRIPTION
## 📚 Description

Replace this text with a short description of your feature/bugfix.

## 🔖 Changes

- Added support for passing a directory to the init command by allowing an optional argument in the initialization script
- Updated the main script to forward an optional directory when invoking the init function
- Documented the new optional argument in the command-line guide with an updated example
- Extended the acceptance tests to cover initialization in a custom directory

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
