### PR TITLE
Fix negative widths with rpad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix prevents writing in src dir during tests
+- Fix negative widths with rpad
 
 ## [0.22.0](https://github.com/TypedDevs/bashunit/compare/0.21.0...0.22.0) - 2025-07-20
 

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -34,20 +34,21 @@ function snapshot::match_with_placeholder() {
   fi
 }
 
+# shellcheck disable=SC2155
 function assert_match_snapshot() {
   local actual
   actual=$(echo -n "$1" | tr -d '\r')
-  local directory
-  directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
-  local test_file
-  test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
-  local snapshot_name
-  snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
-  local snapshot_file
-  snapshot_file="${directory}/${test_file}.${snapshot_name}"
+  local snapshot_file="${2-}"
+
+  if [[ -z "$snapshot_file" ]]; then
+    local directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+    local test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
+    local snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
+    snapshot_file="${directory}/${test_file}.${snapshot_name}"
+  fi
 
   if [[ ! -f "$snapshot_file" ]]; then
-    mkdir -p "$directory"
+    mkdir -p "$(dirname "$snapshot_file")"
     echo "$actual" > "$snapshot_file"
 
     state::add_assertions_snapshot
@@ -70,21 +71,21 @@ function assert_match_snapshot() {
   state::add_assertions_passed
 }
 
+# shellcheck disable=SC2155
 function assert_match_snapshot_ignore_colors() {
   local actual
   actual=$(echo -n "$1" | sed -r 's/\x1B\[[0-9;]*[mK]//g' | tr -d '\r')
 
-  local directory
-  directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
-  local test_file
-  test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
-  local snapshot_name
-  snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
-  local snapshot_file
-  snapshot_file="${directory}/${test_file}.${snapshot_name}"
+  local snapshot_file="${2-}"
+  if [[ -z "$snapshot_file" ]]; then
+    local directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+    local test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
+    local snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
+    snapshot_file="${directory}/${test_file}.${snapshot_name}"
+  fi
 
   if [[ ! -f "$snapshot_file" ]]; then
-    mkdir -p "$directory"
+    mkdir -p "$(dirname "$snapshot_file")"
     echo "$actual" > "$snapshot_file"
 
     state::add_assertions_snapshot

--- a/src/str.sh
+++ b/src/str.sh
@@ -6,6 +6,9 @@ function str::rpad() {
   local width_padding="${3:-$TERMINAL_WIDTH}"
   # Subtract 1 more to account for the extra space
   local padding=$((width_padding - ${#right_word} - 1))
+  if (( padding < 0 )); then
+    padding=0
+  fi
 
   # Remove ANSI escape sequences (non-visible characters) for length calculation
   # shellcheck disable=SC2155
@@ -14,7 +17,7 @@ function str::rpad() {
   local is_truncated=false
   # If the visible left text exceeds the padding, truncate it and add "..."
   if [[ ${#clean_left_text} -gt $padding ]]; then
-    local truncation_length=$((padding - 3))  # Subtract 3 for "..."
+    local truncation_length=$((padding < 3 ? 0 : padding - 3))
     clean_left_text="${clean_left_text:0:$truncation_length}"
     is_truncated=true
   fi

--- a/tests/unit/str_test.sh
+++ b/tests/unit/str_test.sh
@@ -50,3 +50,9 @@ function test_rpad_custom_width_padding_text_too_long_and_special_chars() {
     "$(printf "%sok: %svery long... 100" "$_COLOR_PASSED" "$_COLOR_DEFAULT")" \
     "$actual"
 }
+
+function test_rpad_width_smaller_than_right_word() {
+  local actual=$(str::rpad "foo" "verylongword" 5)
+
+  assert_same "... verylongword" "$actual"
+}


### PR DESCRIPTION
## 🔖 Changes

- Fix rpad so negative widths no longer cause substring errors

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
