### PR TITLE
Improve suffix assertion checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix prevents writing in src dir during tests
 - Fix negative widths with rpad
 - Fix internal assert_line_count and call_test_functions
+- Improve suffix assertion checks to use shell pattern matching
 - Include calling function name in dev log output for easier debugging
 - Add more internal dev log messages and prefix them with [INTERNAL]
     - Toggle internal log messages with `BASHUNIT_INTERNAL_LOG=true|false`

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -333,7 +333,7 @@ function assert_string_starts_with() {
   local actual
   actual=$(printf '%s\n' "${actual_arr[@]}")
 
-  if ! [[ $actual =~ ^"$expected"* ]]; then
+  if [[ $actual != "$expected"* ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
@@ -348,7 +348,7 @@ function assert_string_not_starts_with() {
   local expected="$1"
   local actual="$2"
 
-  if [[ $actual =~ ^"$expected"* ]]; then
+  if [[ $actual == "$expected"* ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
@@ -365,7 +365,7 @@ function assert_string_ends_with() {
   local actual
   actual=$(printf '%s\n' "${actual_arr[@]}")
 
-  if ! [[ $actual =~ .*"$expected"$ ]]; then
+  if [[ $actual != *"$expected" ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed
@@ -382,7 +382,7 @@ function assert_string_not_ends_with() {
   local actual
   actual=$(printf '%s\n' "${actual_arr[@]}")
 
-  if [[ $actual =~ .*"$expected"$ ]]; then
+  if [[ $actual == *"$expected" ]]; then
     local label
     label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
     state::add_assertions_failed

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -354,6 +354,23 @@ function test_unsuccessful_assert_string_not_ends_with() {
     "$(assert_string_not_ends_with "bar" "foobar")"
 }
 
+function test_assert_string_start_end_with_special_chars() {
+  assert_empty "$(assert_string_starts_with "foo." "foo.bar")"
+  assert_empty "$(assert_string_ends_with ".bar" "foo.bar")"
+}
+
+function test_assert_string_start_end_with_special_chars_fail() {
+  assert_same\
+    "$(console_results::print_failed_test\
+      "Assert string start end with special chars fail" "fooX" "to start with" "foo.")"\
+    "$(assert_string_starts_with "foo." "fooX")"
+
+  assert_same\
+    "$(console_results::print_failed_test\
+      "Assert string start end with special chars fail" "fooX" "to end with" ".bar")"\
+    "$(assert_string_ends_with ".bar" "fooX")"
+}
+
 function test_successful_assert_less_than() {
   assert_empty "$(assert_less_than "3" "1")"
 }


### PR DESCRIPTION

## 🔖 Changes

- Improve suffix assertion checks to use shell pattern matching

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
