### PR TITLE
Fix broken core snapshot tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix broken core snapshot tests
+
 ## [0.22.1](https://github.com/TypedDevs/bashunit/compare/0.22.0...0.22.1) - 2025-07-23
 
 - Fix prevents writing in src dir during tests

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -41,7 +41,7 @@ function assert_match_snapshot() {
   local snapshot_file="${2-}"
 
   if [[ -z "$snapshot_file" ]]; then
-    local directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+    local directory="$(dirname "${BASH_SOURCE[1]}")/snapshots"
     local test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
     local snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
     snapshot_file="${directory}/${test_file}.${snapshot_name}"
@@ -78,7 +78,7 @@ function assert_match_snapshot_ignore_colors() {
 
   local snapshot_file="${2-}"
   if [[ -z "$snapshot_file" ]]; then
-    local directory="./$(dirname "${BASH_SOURCE[1]}")/snapshots"
+    local directory="$(dirname "${BASH_SOURCE[1]}")/snapshots"
     local test_file="$(helper::normalize_variable_name "$(basename "${BASH_SOURCE[1]}")")"
     local snapshot_name="$(helper::normalize_variable_name "${FUNCNAME[1]}").snapshot"
     snapshot_file="${directory}/${test_file}.${snapshot_name}"


### PR DESCRIPTION

## 🔖 Changes

- Updated snapshot path handling so that both snapshot assertion functions work correctly when tests are run using absolute paths. The directory path is now derived without a prefixed “./”

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
