### PR TITLE
Improve placeholder snapshot fallback without perl

### DIFF
--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -42,8 +42,10 @@ function snapshot::match_with_placeholder() {
       exit($input =~ /$r/s ? 0 : 1);
     ' && return 0 || return 1
   else
-    local fallback=$(printf '%s' "$snapshot" | sed -e "s|$placeholder|.*|g" -e 's/[][\.^$*+?{}|()]/\\&/g')
-    fallback="^${fallback}$"
+    local sanitized_fallback="${snapshot//$placeholder/$token}"
+    local escaped_fallback
+    escaped_fallback=$(printf '%s' "$sanitized_fallback" | sed -e 's/[][\\.^$*+?{}|()]/\\&/g')
+    local fallback="^${escaped_fallback//$token/.*/}$"
     echo "$actual" | grep -Eq "$fallback" && return 0 || return 1
   fi
 }

--- a/tests/unit/assert_snapshot_test.sh
+++ b/tests/unit/assert_snapshot_test.sh
@@ -97,3 +97,14 @@ function test_assert_match_snapshot_with_custom_placeholder() {
   export BASHUNIT_SNAPSHOT_PLACEHOLDER='__ANY__'
   assert_empty "$(assert_match_snapshot "Value 42" "$snapshot_path")"
 }
+
+function test_assert_match_snapshot_with_placeholder_without_perl() {
+  mock dependencies::has_perl mock_false
+
+  local snapshot_path
+  snapshot_path="$(temp_dir)/assert_snapshot_test_sh.test_assert_match_snapshot_with_placeholder_without_perl.snapshot"
+  echo 'Value __ANY__' > "$snapshot_path"
+
+  export BASHUNIT_SNAPSHOT_PLACEHOLDER='__ANY__'
+  assert_empty "$(assert_match_snapshot "Value 42" "$snapshot_path")"
+}


### PR DESCRIPTION
## 🔖 Changes

- Updated the snapshot placeholder logic so custom placeholders now work without Perl by sanitizing the snapshot and converting the token to “.*” before constructing the fallback regex

- Added a test that mocks the absence of Perl to verify that custom placeholders still match correctly in this scenario

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
