### PR TITLE
Fix parallel and compgen issue on NixOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix build issue with bashunit on NixOS
+
 ## [0.22.2](https://github.com/TypedDevs/bashunit/compare/0.22.1...0.22.2) - 2025-07-26
 
 - Fix broken core snapshot tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix build issue with bashunit on NixOS
+- Fix parallel and `compgen` issue on NixOS
 
 ## [0.22.2](https://github.com/TypedDevs/bashunit/compare/0.22.1...0.22.2) - 2025-07-26
 

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ test/list:
 	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
 
 test: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
+	@bash ./bashunit $(TEST_SCRIPTS)
 
 test/watch: $(TEST_SCRIPTS)
-	@./bashunit $(TEST_SCRIPTS)
-	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 ./bashunit $(TEST_SCRIPTS)
+	@bash ./bashunit $(TEST_SCRIPTS)
+	@fswatch -m poll_monitor -or $(SRC_SCRIPTS_DIR) $(TEST_SCRIPTS_DIR) .env Makefile | xargs -n1 bash ./bashunit $(TEST_SCRIPTS)
 
 docker/alpine:
 	@docker run --rm -it -v "$(shell pwd)":/project -w /project alpine:latest \

--- a/src/env.sh
+++ b/src/env.sh
@@ -143,7 +143,7 @@ function env::print_verbose() {
 EXIT_CODE_STOP_ON_FAILURE=4
 # Use a unique directory per run to avoid conflicts when bashunit is invoked
 # recursively or multiple instances are executed in parallel.
-TEMP_DIR_PARALLEL_TEST_SUITE="/tmp/bashunit/parallel/${_OS:-Unknown}/$(random_str 8)"
+TEMP_DIR_PARALLEL_TEST_SUITE="${TMPDIR:-/tmp}/bashunit/parallel/${_OS:-Unknown}/$(random_str 8)"
 TEMP_FILE_PARALLEL_STOP_ON_FAILURE="$TEMP_DIR_PARALLEL_TEST_SUITE/.stop-on-failure"
 TERMINAL_WIDTH="$(env::find_terminal_width)"
 FAILURES_OUTPUT_PATH=$(mktemp)

--- a/src/env.sh
+++ b/src/env.sh
@@ -4,7 +4,7 @@
 
 set -o allexport
 # shellcheck source=/dev/null
-[[ -f ".env" ]] && source .env set
+[[ -f ".env" ]] && source .env
 set +o allexport
 
 _DEFAULT_DEFAULT_PATH="tests"

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -39,30 +39,32 @@ function random_str() {
 
 function temp_file() {
   local prefix=${1:-bashunit}
-  mkdir -p /tmp/bashunit/tmp && chmod -R 777 /tmp/bashunit/tmp
+  local base_dir="${TMPDIR:-/tmp}/bashunit/tmp"
+  mkdir -p "$base_dir" && chmod -R 777 "$base_dir"
   local test_prefix=""
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
     test_prefix="${BASHUNIT_CURRENT_TEST_ID}_"
   fi
-  mktemp /tmp/bashunit/tmp/"${test_prefix}${prefix}".XXXXXXX
+  mktemp "$base_dir/${test_prefix}${prefix}.XXXXXXX"
 }
 
 function temp_dir() {
   local prefix=${1:-bashunit}
-  mkdir -p /tmp/bashunit/tmp && chmod -R 777 /tmp/bashunit/tmp
+  local base_dir="${TMPDIR:-/tmp}/bashunit/tmp"
+  mkdir -p "$base_dir" && chmod -R 777 "$base_dir"
   local test_prefix=""
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
     test_prefix="${BASHUNIT_CURRENT_TEST_ID}_"
   fi
-  mktemp -d /tmp/bashunit/tmp/"${test_prefix}${prefix}".XXXXXXX
+  mktemp -d "$base_dir/${test_prefix}${prefix}.XXXXXXX"
 }
 
 function cleanup_temp_files() {
   internal_log "cleanup_temp_files"
   if [[ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]]; then
-    rm -rf /tmp/bashunit/tmp/"${BASHUNIT_CURRENT_TEST_ID}"_*
+    rm -rf "${TMPDIR:-/tmp}/bashunit/tmp/${BASHUNIT_CURRENT_TEST_ID}"_*
   else
-    rm -rf /tmp/bashunit/tmp/*
+    rm -rf "${TMPDIR:-/tmp}/bashunit/tmp"/*
   fi
 }
 

--- a/src/math.sh
+++ b/src/math.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-if dependencies::has_bc; then
-  # bc is better than awk because bc has no integer limits.
-  function math::calculate() {
+function math::calculate() {
+  if dependencies::has_bc; then
     echo "$*" | bc
-  }
-elif dependencies::has_awk; then
-  function math::calculate() {
-    awk "BEGIN { print ""$*"" }"
-  }
-fi
+  elif dependencies::has_awk; then
+    awk "BEGIN { print ($*) }"
+  else
+    local result=$(( $* ))
+    echo "$result"
+  fi
+}

--- a/src/math.sh
+++ b/src/math.sh
@@ -3,9 +3,11 @@
 function math::calculate() {
   if dependencies::has_bc; then
     echo "$*" | bc
-  elif dependencies::has_awk; then
+  elif [[ "$*" == *.* ]] && dependencies::has_awk; then
+    # Use awk for floating point calculations when bc is unavailable
     awk "BEGIN { print ($*) }"
   else
+    # Fallback to shell arithmetic which has good integer precision
     local result=$(( $* ))
     echo "$result"
   fi

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -12,12 +12,16 @@ function parallel::aggregate_test_results() {
   local total_snapshot=0
 
   for script_dir in "$temp_dir_parallel_test_suite"/*; do
-    if ! compgen -G "$script_dir"/*.result > /dev/null; then
+    shopt -s nullglob
+    local result_files=("$script_dir"/*.result)
+    shopt -u nullglob
+
+    if [ ${#result_files[@]} -eq 0 ]; then
       printf "%sNo tests found%s" "$_COLOR_SKIPPED" "$_COLOR_DEFAULT"
       continue
     fi
 
-    for result_file in "$script_dir"/*.result; do
+    for result_file in "${result_files[@]}"; do
       local result_line
       result_line=$(tail -n 1 "$result_file")
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -235,8 +235,8 @@ function runner::run_test() {
   exec 3>&-
 
   local end_time=$(clock::now)
-  local duration_ns=$(math::calculate "($end_time - $start_time) ")
-  local duration=$(math::calculate "$duration_ns / 1000000")
+  local duration_ns=$((end_time - start_time))
+  local duration=$((duration_ns / 1000000))
 
   if env::is_verbose_enabled; then
     if env::is_simple_output_enabled; then

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -19,8 +19,8 @@ function test_bashunit_init_creates_structure() {
   # generate test scaffolding
   ../../bashunit --init > /tmp/init.log
   # perform the assertions
-  assert_file_exists tests/example_test.sh
-  assert_file_exists tests/bootstrap.sh
+  assert_file_exists "tests/example_test.sh"
+  assert_file_exists "tests/bootstrap.sh"
   # return to the original working directory
   popd >/dev/null
 }
@@ -28,8 +28,8 @@ function test_bashunit_init_creates_structure() {
 function test_bashunit_init_custom_directory() {
   pushd "$TMP_DIR" >/dev/null
   ../../bashunit --init custom > /tmp/init.log
-  assert_file_exists custom/example_test.sh
-  assert_file_exists custom/bootstrap.sh
+  assert_file_exists "custom/example_test.sh"
+  assert_file_exists "custom/bootstrap.sh"
   popd >/dev/null
 }
 
@@ -39,8 +39,8 @@ function test_bashunit_init_updates_env() {
   pushd "$TMP_DIR" >/dev/null
   echo "BASHUNIT_BOOTSTRAP=old/bootstrap.sh" > .env
   ../../bashunit --init custom > /tmp/init.log
-  assert_file_exists custom/example_test.sh
-  assert_file_exists custom/bootstrap.sh
+  assert_file_exists "custom/example_test.sh"
+  assert_file_exists "custom/bootstrap.sh"
   assert_file_contains .env "#BASHUNIT_BOOTSTRAP=old/bootstrap.sh"
   assert_file_contains .env "BASHUNIT_BOOTSTRAP=custom/bootstrap.sh"
   popd >/dev/null

--- a/tests/acceptance/parallel_spy_parallel_test.sh
+++ b/tests/acceptance/parallel_spy_parallel_test.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 set -euo pipefail
 
 function test_spies_work_in_parallel() {
-  local file1=tests/acceptance/fixtures/test_parallel_spy_file1.sh
-  local file2=tests/acceptance/fixtures/test_parallel_spy_file2.sh
+  local file1="$(current_dir)/fixtures/test_parallel_spy_file1.sh"
+  local file2="$(current_dir)/fixtures/test_parallel_spy_file2.sh"
 
   ./bashunit --parallel "$file1" "$file2"
   assert_successful_code

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -69,6 +69,10 @@ function test_now_on_windows_without_without_powershell() {
 }
 
 function test_now_on_osx_without_perl() {
+  if check_os::is_windows; then
+    skip && return
+  fi
+
   mock_macos
   mock dependencies::has_perl mock_false
   mock clock::shell_time echo "1727708708.326957"

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -79,7 +79,9 @@ function test_now_on_osx_without_perl() {
   mock dependencies::has_python mock_false
   mock dependencies::has_node mock_false
 
-  assert_same "1727708708326957000" "$(clock::now)"
+  local expected
+  expected=$(math::calculate "(1727708708 * 1000000000) + (326957 * 1000)")
+  assert_same "$expected" "$(clock::now)"
 }
 
 function test_runtime_in_milliseconds_when_not_empty_time() {

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -79,9 +79,7 @@ function test_now_on_osx_without_perl() {
   mock dependencies::has_python mock_false
   mock dependencies::has_node mock_false
 
-  local expected
-  expected=$(math::calculate "(1727708708 * 1000000000) + (326957 * 1000)")
-  assert_same "$expected" "$(clock::now)"
+  assert_same "1727708708326957000" "$(clock::now)"
 }
 
 function test_runtime_in_milliseconds_when_not_empty_time() {

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -69,11 +69,6 @@ function test_now_on_windows_without_without_powershell() {
 }
 
 function test_now_on_osx_without_perl() {
-  if ! check_os::is_macos; then
-    skip
-    return
-  fi
-
   mock_macos
   mock dependencies::has_perl mock_false
   mock clock::shell_time echo "1727708708.326957"

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -289,8 +289,7 @@ function test_not_render_execution_time() {
 
 function test_render_execution_time_on_osx_without_perl() {
   if ! check_os::is_macos; then
-    skip
-    return
+    skip && return
   fi
 
   mock_macos
@@ -308,8 +307,7 @@ function test_render_execution_time_on_osx_without_perl() {
 
 function test_render_execution_time_on_osx_with_perl() {
   if ! check_os::is_macos; then
-    skip
-    return
+    skip && return
   fi
 
   local render_result


### PR DESCRIPTION
## 📚 Description

<img width="1215" height="288" alt="Screenshot 2025-07-26 at 23 41 13" src="https://github.com/user-attachments/assets/2cc8e362-09d4-4ea7-9c5a-08cb84755887" />
CC @drupol 

## 🔖 Changes

- Temporary files now respect `$TMPDIR`, ensuring writable directories during Nix builds
  - Parallel test directories likewise use `$TMPDIR` for compatibility with sandboxed environments
  - Test targets explicitly run bashunit with bash, avoiding shell mismatch issues during package checks
- Replaced the reliance on `compgen` with a safer globbing approach so parallel result aggregation works even when programmable completion isn’t available
  - Updated `math::calculate` to fall back to native shell arithmetic when `bc` or` awk` missing, avoiding precision loss

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
