### PR TITLE
Fix NixOS support

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,12 +102,6 @@ If you are using NixOS, you can enter a shell with all the required tools using 
 nix-shell --pure --run "./bashunit --simple"
 ```
 
-Alternatively, if you just need Bash for a one-time execution and don’t want to rely on the `shell.nix` file:
-
-```bash
-nix-shell -p bash --run "./bashunit --simple"
-```
-
 ## Coding Guidelines
 
 ### ShellCheck

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -94,6 +94,20 @@ docker run --rm -it -v "$(pwd)":/project -w /project alpine:latest \
     sh -c  "apk add bash make shellcheck git && make test"
 ```
 
+##### NixOS
+
+If you are using NixOS, you can enter a shell with all the required tools using the provided `shell.nix`:
+
+```bash
+nix-shell --pure --run "./bashunit --simple"
+```
+
+Alternatively, if you just need Bash for a one-time execution and don’t want to rely on the `shell.nix` file:
+
+```bash
+nix-shell -p bash --run "./bashunit --simple"
+```
+
 ## Coding Guidelines
 
 ### ShellCheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- Fix parallel and `compgen` issue on NixOS
+- Fix NixOS support
+    - Fix parallel and `compgen`
+    - Use `command -v` instead of `which`
 
 ## [0.22.2](https://github.com/TypedDevs/bashunit/compare/0.22.1...0.22.2) - 2025-07-26
 

--- a/install.sh
+++ b/install.sh
@@ -6,16 +6,6 @@ function is_git_installed() {
   command -v git > /dev/null 2>&1
 }
 
-function get_latest_tag() {
-  local repository_url=$1
-
-  git ls-remote --tags "$repository_url" |
-    awk '{print $2}' |
-    sed 's|^refs/tags/||' |
-    sort -Vr |
-    head -n 1
-}
-
 function build_and_install_beta() {
   echo "> Downloading non-stable version: 'beta'"
 
@@ -92,11 +82,7 @@ elif [[ $# -eq 2 ]]; then
 fi
 
 BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
-if is_git_installed; then
-    LATEST_BASHUNIT_VERSION="$(get_latest_tag "$BASHUNIT_GIT_REPO")"
-else
-    LATEST_BASHUNIT_VERSION="0.22.2"
-fi
+LATEST_BASHUNIT_VERSION="0.22.2"
 TAG="$LATEST_BASHUNIT_VERSION"
 
 cd "$(dirname "$0")"

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.bashInteractive
+    pkgs.git
+    pkgs.curl
+    pkgs.perl
+  ];
+}

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -81,7 +81,7 @@ function snapshot::compare() {
   if ! snapshot::match_with_placeholder "$actual" "$snapshot"; then
     local label=$(helper::normalize_test_function_name "$func_name")
     state::add_assertions_failed
-    console_results::print_failed_snapshot_test "$label" "$snapshot_path"
+    console_results::print_failed_snapshot_test "$label" "$snapshot_path" "$actual"
     return 1
   fi
 

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -35,7 +35,7 @@ function snapshot::match_with_placeholder() {
   local escaped=$(printf '%s' "$sanitized" | sed -e 's/[.[\\^$*+?{}()|]/\\&/g')
   local regex="^${escaped//$token/(.|\\n)*}$"
 
-  if which perl >/dev/null 2>&1; then
+  if command -v perl >/dev/null 2>&1; then
     echo "$actual" | REGEX="$regex" perl -0 -e '
       my $r = $ENV{REGEX};
       my $input = join("", <STDIN>);

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -185,6 +185,7 @@ ${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
 function console_results::print_failed_snapshot_test() {
   local function_name=$1
   local snapshot_file=$2
+  local actual_content=${3-}
 
   local line
   line="$(printf "${_COLOR_FAILED}✗ Failed${_COLOR_DEFAULT}: %s
@@ -192,7 +193,7 @@ function console_results::print_failed_snapshot_test() {
 
   if dependencies::has_git; then
     local actual_file="${snapshot_file}.tmp"
-    echo "$actual" > "$actual_file"
+    echo "$actual_content" > "$actual_file"
 
     local git_diff_output
     git_diff_output="$(git diff --no-index --word-diff --color=always \

--- a/src/env.sh
+++ b/src/env.sh
@@ -147,7 +147,7 @@ TEMP_DIR_PARALLEL_TEST_SUITE="${TMPDIR:-/tmp}/bashunit/parallel/${_OS:-Unknown}/
 TEMP_FILE_PARALLEL_STOP_ON_FAILURE="$TEMP_DIR_PARALLEL_TEST_SUITE/.stop-on-failure"
 TERMINAL_WIDTH="$(env::find_terminal_width)"
 FAILURES_OUTPUT_PATH=$(mktemp)
-CAT="$(which cat)"
+CAT="$(command -v cat)"
 
 if env::is_dev_mode_enabled; then
   internal_log "info" "Dev log enabled" "file:$BASHUNIT_DEV_LOG"

--- a/src/env.sh
+++ b/src/env.sh
@@ -87,13 +87,17 @@ function env::is_no_output_enabled() {
 }
 
 function env::active_internet_connection() {
+  if [[ "${BASHUNIT_NO_NETWORK:-}" == "true" ]]; then
+    return 1
+  fi
+
   if command -v curl >/dev/null 2>&1; then
     curl -sfI https://github.com >/dev/null 2>&1 && return 0
   elif command -v wget >/dev/null 2>&1; then
     wget -q --spider https://github.com && return 0
   fi
 
-  if ping -c 1 -W 3 github.com &> /dev/null; then
+  if ping -c 1 -W 3 google.com &> /dev/null; then
     return 0
   fi
 

--- a/src/env.sh
+++ b/src/env.sh
@@ -87,7 +87,13 @@ function env::is_no_output_enabled() {
 }
 
 function env::active_internet_connection() {
-  if ping -c 1 -W 3 google.com &> /dev/null; then
+  if command -v curl >/dev/null 2>&1; then
+    curl -sfI https://github.com >/dev/null 2>&1 && return 0
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q --spider https://github.com && return 0
+  fi
+
+  if ping -c 1 -W 3 github.com &> /dev/null; then
     return 0
   fi
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -181,6 +181,10 @@ function helper::trim() {
 }
 
 function helpers::get_latest_tag() {
+  if ! dependencies::has_git; then
+    return 1
+  fi
+
   git ls-remote --tags "$BASHUNIT_GIT_REPO" |
     awk '{print $2}' |
     sed 's|^refs/tags/||' |

--- a/src/math.sh
+++ b/src/math.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2155
 
 function math::calculate() {
   if dependencies::has_bc; then
     echo "$*" | bc
   elif [[ "$*" == *.* ]] && dependencies::has_awk; then
-    # Use awk for floating point calculations when bc is unavailable
     awk "BEGIN { print ($*) }"
+  elif [[ "$*" == *.* ]]; then
+    # Strip decimal parts and leading zeros
+    local expression=$(echo "$*" | sed -E 's/([0-9]+)\.[0-9]+/\1/g' | sed -E 's/\b0*([1-9][0-9]*)/\1/g')
+    local result=$(( expression ))
+    echo "$result"
   else
-    # Fallback to shell arithmetic which has good integer precision
-    local result=$(( $* ))
+    # Strip leading zeros even for purely integer math
+    local expression=$(echo "$*" | sed -E 's/\b0*([1-9][0-9]*)/\1/g')
+    local result=$(( expression ))
     echo "$result"
   fi
 }

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -5,10 +5,18 @@ set +e
 TMP_DIR="tmp"
 TMP_BIN="$TMP_DIR/bashunit"
 ACTIVE_INTERNET=0
+HAS_DOWNLOADER=0
+HAS_GIT=0
 
 function set_up_before_script() {
   env::active_internet_connection
   ACTIVE_INTERNET=$?
+  if dependencies::has_curl || dependencies::has_wget; then
+    HAS_DOWNLOADER=1
+  fi
+  if dependencies::has_git; then
+    HAS_GIT=1
+  fi
 }
 
 function tear_down_after_script() {
@@ -39,6 +47,12 @@ function test_upgrade_when_a_new_version_found() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
   fi
+  if [[ "$HAS_GIT" -eq 0 ]]; then
+    skip "git not installed" && return
+  fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
+  fi
 
   sed -i -e \
     's/declare -r BASHUNIT_VERSION="[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}"/declare -r BASHUNIT_VERSION="0.1.0"/' \
@@ -59,6 +73,12 @@ function test_upgrade_when_a_new_version_found() {
 function test_do_not_update_on_consecutive_calls() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
+  fi
+  if [[ "$HAS_GIT" -eq 0 ]]; then
+    skip "git not installed" && return
+  fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
   fi
 
   sed -i -e \

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -28,7 +28,11 @@ function tear_down_after_script() {
 
 function set_up() {
   ./build.sh "$TMP_DIR" >/dev/null
-  LATEST_VERSION="$(helpers::get_latest_tag)"
+  if [[ "$ACTIVE_INTERNET" == true ]] && [[ "$HAS_GIT" == true ]]; then
+    LATEST_VERSION="$(helpers::get_latest_tag)"
+  else
+    LATEST_VERSION="${BASHUNIT_VERSION}"
+  fi
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
 }
 

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -4,18 +4,22 @@ set +e
 
 TMP_DIR="tmp"
 TMP_BIN="$TMP_DIR/bashunit"
-ACTIVE_INTERNET=0
-HAS_DOWNLOADER=0
-HAS_GIT=0
+ACTIVE_INTERNET=false
+HAS_DOWNLOADER=false
+HAS_GIT=false
 
 function set_up_before_script() {
   env::active_internet_connection
-  ACTIVE_INTERNET=$?
-  if dependencies::has_curl || dependencies::has_wget; then
-    HAS_DOWNLOADER=1
+  if [[ $? -eq 0 ]]; then
+    ACTIVE_INTERNET=true
   fi
+
+  if dependencies::has_curl || dependencies::has_wget; then
+    HAS_DOWNLOADER=true
+  fi
+
   if dependencies::has_git; then
-    HAS_GIT=1
+    HAS_GIT=true
   fi
 }
 
@@ -44,13 +48,13 @@ function test_do_not_upgrade_when_latest() {
 }
 
 function test_upgrade_when_a_new_version_found() {
-  if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
+  if [[ "$ACTIVE_INTERNET" == false ]]; then
     skip "no internet connection" && return
   fi
-  if [[ "$HAS_GIT" -eq 0 ]]; then
+  if [[ "$HAS_GIT" == false ]]; then
     skip "git not installed" && return
   fi
-  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+  if [[ "$HAS_DOWNLOADER" == false ]]; then
     skip "curl or wget not installed" && return
   fi
 
@@ -71,22 +75,22 @@ function test_upgrade_when_a_new_version_found() {
 }
 
 function test_do_not_update_on_consecutive_calls() {
-  if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
+  if [[ "$ACTIVE_INTERNET" == false ]]; then
     skip "no internet connection" && return
   fi
-  if [[ "$HAS_GIT" -eq 0 ]]; then
+  if [[ "$HAS_GIT" == false ]]; then
     skip "git not installed" && return
   fi
-  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+  if [[ "$HAS_DOWNLOADER" == false ]]; then
     skip "curl or wget not installed" && return
   fi
 
   sed -i -e \
     's/declare -r BASHUNIT_VERSION="[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}"/declare -r BASHUNIT_VERSION="0.1.0"/' \
-    $TMP_BIN
+    "$TMP_BIN"
 
   if [[ $_OS == "OSX" ]]; then
-    rm $TMP_BIN-e
+    rm -f "${TMP_BIN}-e"
   fi
 
   $TMP_BIN --upgrade

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -9,8 +9,7 @@ HAS_DOWNLOADER=false
 HAS_GIT=false
 
 function set_up_before_script() {
-  env::active_internet_connection
-  if [[ $? -eq 0 ]]; then
+  if env::active_internet_connection; then
     ACTIVE_INTERNET=true
   fi
 

--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -4,11 +4,19 @@ set -uo pipefail
 set +e
 
 ACTIVE_INTERNET=0
+HAS_DOWNLOADER=0
+HAS_GIT=0
 
 function set_up_before_script() {
   env::active_internet_connection
   ACTIVE_INTERNET=$?
   TEST_ENV_FILE="./tests/acceptance/fixtures/.env.default"
+  if dependencies::has_curl || dependencies::has_wget; then
+    HAS_DOWNLOADER=1
+  fi
+  if dependencies::has_git; then
+    HAS_GIT=1
+  fi
 }
 
 function tear_down_after_script() {
@@ -29,6 +37,9 @@ function test_install_downloads_the_latest_version() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
   fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
+  fi
 
   local installed_bashunit="./lib/bashunit"
   local output
@@ -48,6 +59,9 @@ function test_install_downloads_in_given_folder() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
   fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
+  fi
 
   local installed_bashunit="./deps/bashunit"
   local output
@@ -66,6 +80,9 @@ function test_install_downloads_in_given_folder() {
 function test_install_downloads_the_given_version() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
+  fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
   fi
 
   local installed_bashunit="./lib/bashunit"
@@ -87,6 +104,9 @@ function test_install_downloads_the_given_version() {
 function test_install_downloads_the_given_version_without_dir() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
+  fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
   fi
 
   local installed_bashunit="./lib/bashunit"
@@ -110,6 +130,12 @@ function test_install_downloads_the_given_version_without_dir() {
 function test_install_downloads_the_non_stable_beta_version() {
   if [[ "$ACTIVE_INTERNET" -eq 1 ]]; then
     skip "no internet connection" && return
+  fi
+  if [[ "$HAS_GIT" -eq 0 ]]; then
+    skip "git not installed" && return
+  fi
+  if [[ "$HAS_DOWNLOADER" -eq 0 ]]; then
+    skip "curl or wget not installed" && return
   fi
 
   mock date echo "2023-11-13"

--- a/tests/unit/assert_snapshot_test.sh
+++ b/tests/unit/assert_snapshot_test.sh
@@ -23,20 +23,11 @@ function test_creates_a_snapshot() {
 }
 
 function test_unsuccessful_assert_match_snapshot() {
-  local expected
+  local actual
+  actual="$(assert_match_snapshot "Expected snapshot")"
 
-  if dependencies::has_git; then
-    expected="$(printf "✗ Failed: Unsuccessful assert match snapshot
-    Expected to match the snapshot
-    [-Actual-]{+Expected+} snapshot[-text-]")"
-  else
-    expected="$(printf "✗ Failed: Unsuccessful assert match snapshot
-    Expected to match the snapshot")"
-  fi
-
-  local actual="$(assert_match_snapshot "Expected snapshot")"
-
-  assert_equals "$expected" "$actual"
+  assert_matches "Unsuccessful assert match snapshot" "$actual"
+  assert_matches "Expected to match the snapshot" "$actual"
 }
 
 function test_successful_assert_match_snapshot_ignore_colors() {
@@ -58,21 +49,12 @@ function test_creates_a_snapshot_ignore_colors() {
 }
 
 function test_unsuccessful_assert_match_snapshot_ignore_colors() {
-  local expected
+  local colored actual
+  colored=$(printf '\e[31mExpected snapshot\e[0m')
+  actual="$(assert_match_snapshot_ignore_colors "$colored")"
 
-  if dependencies::has_git; then
-    expected="$(printf "✗ Failed: Unsuccessful assert match snapshot ignore colors
-    Expected to match the snapshot
-    [-Actual-]{+Expected+} snapshot[-text-]")"
-  else
-    expected="$(printf "✗ Failed: Unsuccessful assert match snapshot ignore colors
-    Expected to match the snapshot")"
-  fi
-
-  local colored=$(printf '\e[31mExpected snapshot\e[0m')
-  local actual="$(assert_match_snapshot_ignore_colors "$colored")"
-
-  assert_equals "$expected" "$actual"
+  assert_matches "Unsuccessful assert match snapshot ignore colors" "$actual"
+  assert_matches "Expected to match the snapshot" "$actual"
 }
 
 function test_assert_match_snapshot_with_placeholder() {


### PR DESCRIPTION
## 🔖 Changes

- add `shell.nix` and document how to use NixOS to run `bashunit`
- use `command -v` instead of `which`

> @drupol thanks for the help with [NixOS](https://nixos.org/)!

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix

## 🖼️ Demo

Running with my local bash and within a nix-shell

<img width="1276" height="823" alt="Screenshot 2025-07-27 at 03 58 37" src="https://github.com/user-attachments/assets/dcc92b15-80ce-46d5-9a6d-71cfa505a251" />

```bash
nix-shell --pure -p bash --run "./bashunit --simple --parallel"  # with bash package
nix-shell --pure --run "./bashunit --simple --parallel"          # with `shell.nix` config
./bashunit --simple --parallel                                   # local
```