### PR TITLE
Skip --init option tests for NixOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Skip `--init` option tests for NixOS
+
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27
 
 - Fix NixOS support

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -14,6 +14,10 @@ function tear_down() {
 }
 
 function test_bashunit_init_creates_structure() {
+  if check_os::is_nixos; then
+    skip && return
+  fi
+
   # switch into a clean temporary directory
   pushd "$TMP_DIR" >/dev/null
   # generate test scaffolding
@@ -26,6 +30,10 @@ function test_bashunit_init_creates_structure() {
 }
 
 function test_bashunit_init_custom_directory() {
+  if check_os::is_nixos; then
+    skip && return
+  fi
+
   pushd "$TMP_DIR" >/dev/null
   ../../bashunit --init custom > /tmp/init.log
   assert_file_exists "custom/example_test.sh"


### PR DESCRIPTION
## 📚 Description

When ` nix run github:NixOS/nixpkgs#bashunit -- -v` using `bashunit 0.22.3` I get an error for the --init tests due to lack of permission to create directory/files // CC @drupol 

<img width="995" height="699" alt="Screenshot 2025-07-27 at 12 53 00" src="https://github.com/user-attachments/assets/f8dcd5d0-db65-41d0-bdaf-b9becdd5a8f7" />

## 🔖 Changes

- Skip `--init` option tests for NixOS

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
