### PR TITLE
Add support for .bash test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Skip `--init` option tests for NixOS
+- Add support for `.bash` test files
 
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -8,7 +8,7 @@
 
 Specifies the `directory` or `file` containing the tests to be run.
 
-If a directory is specified, it will execute tests within files ending in `test.sh`.
+If a directory is specified, it will execute tests within files ending in `test.sh` or `test.bash`.
 
 If you use wildcards, **bashunit** will run any tests it finds.
 

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -7,11 +7,11 @@ In this section, you'll find information about these features along with some he
 
 **bashunit** is flexible about how you name your test files.
 
-You can use a directory name, and bashunit will look for all files (ending with `test.sh`) recursively inside that directory, and execute them.
+You can use a directory name, and bashunit will look for all files (ending with `test.sh` or `test.bash`) recursively inside that directory, and execute them.
 
 If you're using wildcards for scanning your tests, keep in mind that the initial search can slow down if you don't filter the test files in the wildcard.
 
-To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh`).
+To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh` or `**/*test.bash`).
 This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
 
 This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -61,7 +61,7 @@ Usage:
 
 Arguments:
   PATH                      File or directory containing tests.
-                            - Directories: runs all '*test.sh' files.
+                            - Directories: runs all '*test.sh' or '*test.bash' files.
                             - Wildcards: supported to match multiple test files.
                             - Default search path is 'tests'
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -127,10 +127,23 @@ function helper::find_files_recursive() {
   local path="${1%%/}"
   local pattern="${2:-*[tT]est.sh}"
 
+  local alt_pattern=""
+  if [[ $pattern == *test.sh ]] || [[ $pattern =~ \[tT\]est\.sh$ ]]; then
+    alt_pattern="${pattern%.sh}.bash"
+  fi
+
   if [[ "$path" == *"*"* ]]; then
-    eval find "$path" -type f -name "$pattern" | sort -u
+    if [[ -n $alt_pattern ]]; then
+      eval "find $path -type f \( -name \"$pattern\" -o -name \"$alt_pattern\" \)" | sort -u
+    else
+      eval "find $path -type f -name \"$pattern\"" | sort -u
+    fi
   elif [[ -d "$path" ]]; then
-    find "$path" -type f -name "$pattern" | sort -u
+    if [[ -n $alt_pattern ]]; then
+      find "$path" -type f \( -name "$pattern" -o -name "$alt_pattern" \) | sort -u
+    else
+      find "$path" -type f -name "$pattern" | sort -u
+    fi
   else
     echo "$path"
   fi

--- a/tests/acceptance/fixtures/tests_path/bash_test.bash
+++ b/tests/acceptance/fixtures/tests_path/bash_test.bash
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+function test_assert_same() {
+  assert_same 1 1
+}
+
+function test_assert_contains() {
+  assert_contains "foo" "foobar"
+  assert_contains "bar" "foobar"
+}

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -2,11 +2,15 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mRunning ./tests/acceptance/fixtures/tests_path/bash_test.bash[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+
 [1mRunning ./tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[2mTests:     [0m [32m6 passed[0m, 6 total
+[2mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -2,11 +2,15 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mRunning ./tests/acceptance/fixtures/tests_path/bash_test.bash[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+
 [1mRunning ./tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[2mTests:     [0m [32m6 passed[0m, 6 total
+[2mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -2,11 +2,15 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mRunning tests/acceptance/fixtures/tests_path/bash_test.bash[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+
 [1mRunning tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[2mTests:     [0m [32m6 passed[0m, 6 total
+[2mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -2,11 +2,15 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
+[1mRunning tests/acceptance/fixtures/tests_path/bash_test.bash[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+
 [1mRunning tests/acceptance/fixtures/tests_path/other_test.sh[0m
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[2mTests:     [0m [32m6 passed[0m, 6 total
+[2mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_without_path_env_nor_argument.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_without_path_env_nor_argument.snapshot
@@ -4,7 +4,7 @@ Usage:
 
 Arguments:
   PATH                      File or directory containing tests.
-                            - Directories: runs all '*test.sh' files.
+                            - Directories: runs all '*test.sh' or '*test.bash' files.
                             - Wildcards: supported to match multiple test files.
                             - Default search path is 'tests'
 

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_help.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_help.snapshot
@@ -3,7 +3,7 @@ Usage:
 
 Arguments:
   PATH                      File or directory containing tests.
-                            - Directories: runs all '*test.sh' files.
+                            - Directories: runs all '*test.sh' or '*test.bash' files.
                             - Wildcards: supported to match multiple test files.
                             - Default search path is 'tests'
 

--- a/tests/unit/fixtures/find_total_tests/simple_test.bash
+++ b/tests/unit/fixtures/find_total_tests/simple_test.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function test_first() {
+  return 0
+}
+
+function test_second() {
+  return 0
+}

--- a/tests/unit/fixtures/tests/example3_test.bash
+++ b/tests/unit/fixtures/tests/example3_test.bash
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+# intentionally blank

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -188,7 +188,8 @@ function test_find_files_recursive_given_dir() {
   result=$(helper::find_files_recursive "$path")
 
   assert_same "tests/unit/fixtures/tests/example1_test.sh
-tests/unit/fixtures/tests/example2_test.sh"\
+tests/unit/fixtures/tests/example2_test.sh
+tests/unit/fixtures/tests/example3_test.bash"\
   "$result"
 }
 
@@ -200,6 +201,16 @@ function test_find_files_recursive_given_wildcard() {
   result=$(helper::find_files_recursive "$path")
 
   assert_same "tests/unit/fixtures/tests/example2_test.sh" "$result"
+}
+
+function test_find_files_recursive_given_bash_extension() {
+  local path
+  path="$(current_dir)/fixtures/tests/*3_test.bash"
+
+  local result
+  result=$(helper::find_files_recursive "$path")
+
+  assert_same "tests/unit/fixtures/tests/example3_test.bash" "$result"
 }
 
 function test_get_latest_tag() {
@@ -251,6 +262,13 @@ function test_find_total_tests_no_files() {
 function test_find_total_tests_simple_file() {
   local file
   file="$(current_dir)/fixtures/find_total_tests/simple_test.sh"
+
+  assert_same "2" "$(helpers_test::find_total_in_subshell "" "$file")"
+}
+
+function test_find_total_tests_simple_file_bash() {
+  local file
+  file="$(current_dir)/fixtures/find_total_tests/simple_test.bash"
 
   assert_same "2" "$(helpers_test::find_total_in_subshell "" "$file")"
 }


### PR DESCRIPTION
## 📚 Description

Currently, only `*test.sh` files with sh extension are loaded as test files. We should support also `.bash` extension

## 🔖 Changes

- Extended file discovery now handles both “test.sh” and “test.bash” filenames, ensuring paths containing wildcards are correctly evaluated
- Documentation reflects that bashunit searches for “test.sh” or “test.bash” files and recommends using either extension with wildcards
- Help text clarifies that directories run all “test.sh” or “test.bash” files
- New snapshots verify that directories and wildcards include “bash_test.bash” during test execution

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
