### PR TITLE
Add minimum supported Bash version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Skip `--init` option tests for NixOS
+- Add runtime check for Bash >= 3.2
 
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ It boasts hundreds of assertions and functionalities like spies, mocks, provider
 
 You can find the complete documentation for **bashunit** online, including installation instructions and the various features it provides, in the [official bashunit documentation](https://bashunit.typeddevs.com).
 
+## Requirements
+
+bashunit requires **Bash 3.2** or newer.
+
 ## Contribute
 
 You are welcome to contribute reporting issues, sharing ideas,

--- a/bashunit
+++ b/bashunit
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+declare -r BASHUNIT_MIN_BASH_VERSION="3.2"
+
+function _check_bash_version() {
+  local current_version
+  current_version="${BASH_VERSION}"
+  if [[ -n ${BASHUNIT_TEST_BASH_VERSION:-} ]]; then
+    current_version="${BASHUNIT_TEST_BASH_VERSION}"
+  fi
+
+  local major minor
+  IFS=. read -r major minor _ <<< "$current_version"
+
+  if (( major < 3 )) || { (( major == 3 )) && (( minor < 2 )); }; then
+    printf 'Bashunit requires Bash >= %s. Current version: %s\n' "$BASHUNIT_MIN_BASH_VERSION" "$current_version" >&2
+    exit 1
+  fi
+}
+
+_check_bash_version
+
 # shellcheck disable=SC2034
 declare -r BASHUNIT_VERSION="0.22.3"
 

--- a/bashunit
+++ b/bashunit
@@ -5,7 +5,7 @@ declare -r BASHUNIT_MIN_BASH_VERSION="3.2"
 
 function _check_bash_version() {
   local current_version
-  current_version="${BASH_VERSION}"
+  current_version="$(bash --version | head -n1 | cut -d' ' -f4 | cut -d. -f1,2)"
   if [[ -n ${BASHUNIT_TEST_BASH_VERSION:-} ]]; then
     current_version="${BASHUNIT_TEST_BASH_VERSION}"
   fi

--- a/bashunit
+++ b/bashunit
@@ -5,9 +5,15 @@ declare -r BASHUNIT_MIN_BASH_VERSION="3.2"
 
 function _check_bash_version() {
   local current_version
-  current_version="$(bash --version | head -n1 | cut -d' ' -f4 | cut -d. -f1,2)"
   if [[ -n ${BASHUNIT_TEST_BASH_VERSION:-} ]]; then
+    # Checks if BASHUNIT_TEST_BASH_VERSION is set (typically for testing purposes)
     current_version="${BASHUNIT_TEST_BASH_VERSION}"
+  elif [[ -n ${BASH_VERSINFO+set} ]]; then
+    # Checks if the special Bash array BASH_VERSINFO exists. This array is only defined in Bash.
+    current_version="${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}"
+  else
+    # If not in Bash (e.g., running from Zsh). The pipeline extracts just the major.minor version (e.g., 3.2).
+    current_version="$(bash --version | head -n1 | cut -d' ' -f4 | cut -d. -f1,2)"
   fi
 
   local major minor

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,6 +5,10 @@ you can add **bashunit** as a dependency in your repository according to your pr
 
 Here, we provide different options that you can use to install **bashunit** in your application.
 
+## Requirements
+
+bashunit requires **Bash 3.2** or newer.
+
 ## install.sh
 
 There is a tool that will generate an executable with the whole library in a single file:

--- a/tests/unit/bash_version_test.sh
+++ b/tests/unit/bash_version_test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+function test_fail_with_old_bash_version() {
+  output=$(BASHUNIT_TEST_BASH_VERSION=3.1 ./bashunit --version 2>&1)
+  exit_code=$?
+  assert_contains "Bashunit requires Bash >= 3.2. Current version: 3.1" "$output"
+  assert_general_error "$output" "" "$exit_code"
+}


### PR DESCRIPTION
## 📚 Description

 Add support for detecting the minimum Bash version and exiting gracefully if unsupported.

> Idea from @akinomyoga, thanks!

## 🔖 Changes

- Documented the minimum Bash requirement in the README, stating that bashunit requires Bash 3.2 or newer
- Added a “Requirements” section in the installation guide with the same version information
- Implemented a runtime version check in the bashunit entrypoint to exit if the Bash version is below 3.2
- Logged this new feature in the changelog under Unreleased
- Created a new unit test ensuring bashunit exits with an error for unsupported versions

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes


## 🏗️  Follow up idea

Add support for *Bash 3.0* and newer