### PR TITLE
Update docs for mock usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update docs mocks usage
 - Add support for `.bash` test files
 
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -22,9 +22,24 @@ function test_example() {
 ```
 :::
 
-> `mock "function" "output"`
+> `mock "function" <<< "output"`
 
-Allows you to override the output of a callable.
+Allows you to override the output of a callable. When the mocked output fits on
+a single line you can use a here-string:
+
+```bash
+mock uname <<< "Linux"
+```
+
+For multi-line output rely on a here-document:
+
+```bash
+mock ps <<EOF
+PID TTY          TIME CMD
+13525 pts/7    00:00:01 bash
+24162 pts/7    00:00:00 ps
+EOF
+```
 
 ::: code-group
 ```bash [Example]


### PR DESCRIPTION
## 🔖 Changes

- Documented how to mock function output using a here-string and a here-document, clarifying when each should be used
- Included an example demonstrating a multi-line output mock with a here-document

> Kudos to @akinomyoga who found it.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
