### PR TITLE
Add new assert_exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add runtime check for Bash >= 3.2
 - Add fallback for `clock::now` with seconds resolution only
 - Add `set_test_title` to allow custom test titles
+- Add `assert_exec` to validate exit code, stdout and stderr at once
 
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -366,6 +366,31 @@ function test_failure() {
 ```
 :::
 
+## assert_exec
+> `assert_exec "command" [--exit <code>] [--stdout "text"] [--stderr "text"]`
+
+Runs `command` capturing its exit status, standard output and standard error and
+checks all provided expectations. When `--exit` is omitted the expected exit
+status defaults to `0`.
+
+::: code-group
+```bash [Example]
+function sample() {
+  echo "out"
+  echo "err" >&2
+  return 1
+}
+
+function test_success() {
+  assert_exec sample --exit 1 --stdout "out" --stderr "err"
+}
+
+function test_failure() {
+  assert_exec sample --exit 0 --stdout "out" --stderr "err"
+}
+```
+:::
+
 ## assert_array_contains
 > `assert_array_contains "needle" "haystack"`
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -267,6 +267,87 @@ function assert_not_matches() {
   state::add_assertions_passed
 }
 
+function assert_exec() {
+  local cmd="$1"
+  shift
+
+  local expected_exit=0
+  local expected_stdout=""
+  local expected_stderr=""
+  local check_stdout=false
+  local check_stderr=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --exit)
+        expected_exit="$2"
+        shift 2
+        ;;
+      --stdout)
+        expected_stdout="$2"
+        check_stdout=true
+        shift 2
+        ;;
+      --stderr)
+        expected_stderr="$2"
+        check_stderr=true
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+
+  local stdout_file stderr_file
+  stdout_file=$(mktemp)
+  stderr_file=$(mktemp)
+
+  eval "$cmd" >"$stdout_file" 2>"$stderr_file"
+  local exit_code=$?
+
+  local stdout
+  stdout=$(cat "$stdout_file")
+  local stderr
+  stderr=$(cat "$stderr_file")
+
+  rm -f "$stdout_file" "$stderr_file"
+
+  local expected_desc="exit: $expected_exit"
+  local actual_desc="exit: $exit_code"
+  local failed=0
+
+  if [[ "$exit_code" -ne "$expected_exit" ]]; then
+    failed=1
+  fi
+
+  if $check_stdout; then
+    expected_desc+=$'\n'"stdout: $expected_stdout"
+    actual_desc+=$'\n'"stdout: $stdout"
+    if [[ "$stdout" != "$expected_stdout" ]]; then
+      failed=1
+    fi
+  fi
+
+  if $check_stderr; then
+    expected_desc+=$'\n'"stderr: $expected_stderr"
+    actual_desc+=$'\n'"stderr: $stderr"
+    if [[ "$stderr" != "$expected_stderr" ]]; then
+      failed=1
+    fi
+  fi
+
+  if [[ $failed -eq 1 ]]; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+    console_results::print_failed_test "$label" "$expected_desc" "but got " "$actual_desc"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
 function assert_exit_code() {
   local actual_exit_code=${3-"$?"}
   local expected_exit_code="$1"

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -276,6 +276,33 @@ function test_unsuccessful_assert_command_not_found() {
     "$(assert_command_not_found "$(fake_function)")"
 }
 
+function test_successful_assert_exec() {
+  # shellcheck disable=SC2317
+  function fake_command() {
+    echo "Expected output"
+    echo "Expected error" >&2
+    return 1
+  }
+
+  assert_empty "$(assert_exec fake_command --exit 1 --stdout "Expected output" --stderr "Expected error")"
+}
+
+function test_unsuccessful_assert_exec() {
+  # shellcheck disable=SC2317
+  function fake_command() {
+    echo "out"
+    echo "err" >&2
+    return 0
+  }
+
+  local expected="exit: 1"$'\n'"stdout: Expected"$'\n'"stderr: Expected error"
+  local actual="exit: 0"$'\n'"stdout: out"$'\n'"stderr: err"
+
+  assert_same\
+    "$(console_results::print_failed_test "Unsuccessful assert exec" "$expected" "but got " "$actual")"\
+    "$(assert_exec fake_command --exit 1 --stdout "Expected" --stderr "Expected error")"
+}
+
 function test_successful_assert_array_contains() {
   local distros=(Ubuntu 123 Linux\ Mint)
 


### PR DESCRIPTION
## 📚 Description

Related https://github.com/TypedDevs/bashunit/issues/466 

> Idea from @akinomyoga, thanks!

## 🔖 Changes

- Introduced a new assert_exec helper that executes a command, captures exit status, stdout, and stderr, and validates all expectations together for concise command checks

- Added unit tests demonstrating successful and failing scenarios for assert_exec, ensuring coverage of exit codes and output assertions

- Documented assert_exec usage and options in the assertions guide so users can quickly adopt the new helper

- Updated the changelog to highlight the new consolidated execution assertion in the unreleased notes

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
