### PR TITLE
Add fallback for clock with seconds resolution only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Update docs mocks usage
 - Add support for `.bash` test files
 - Add runtime check for Bash >= 3.2
+- Add fallback for clock with seconds resolution only
 
 ## [0.22.3](https://github.com/TypedDevs/bashunit/compare/0.22.2...0.22.3) - 2025-07-27
 

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -51,7 +51,14 @@ function clock::_choose_impl() {
     return 0
   fi
 
-  # 7. All methods failed
+  # 7. Very last fallback: seconds resolution only
+  attempts[${#attempts[@]}]="date-seconds"
+  if date +%s &>/dev/null; then
+    _CLOCK_NOW_IMPL="date-seconds"
+    return 0
+  fi
+
+  # 8. All methods failed
   printf "clock::now implementations tried: %s\n" "${attempts[*]}" >&2
   echo ""
   return 1
@@ -86,6 +93,11 @@ EOF
       ;;
     date)
       date +%s%N
+      ;;
+    date-seconds)
+      local seconds
+      seconds=$(date +%s)
+      math::calculate "$seconds * 1000000000"
       ;;
     shell)
       # shellcheck disable=SC2155

--- a/tests/unit/clock_test.sh
+++ b/tests/unit/clock_test.sh
@@ -14,6 +14,14 @@ function mock_non_existing_fn() {
   return 127;
 }
 
+function mock_date_seconds() {
+  if [[ "$1" == "+%s%N" ]]; then
+    echo "unsupportedN"
+  else
+    echo "1727768951"
+  fi
+}
+
 function test_now_with_perl() {
   mock clock::shell_time mock_non_existing_fn
   mock perl echo "1720705883457"
@@ -68,6 +76,17 @@ function test_now_on_windows_without_without_powershell() {
   assert_same "1727768951" "$(clock::now)"
 }
 
+function test_now_with_date_seconds_fallback() {
+  mock_unknown_linux_os
+  mock perl mock_non_existing_fn
+  mock dependencies::has_python mock_false
+  mock dependencies::has_node mock_false
+  mock clock::shell_time mock_non_existing_fn
+  mock date 'mock_date_seconds "$@"'
+
+  assert_same "1727768951000000000" "$(clock::now)"
+}
+
 function test_now_on_osx_without_perl() {
   if check_os::is_windows; then
     skip && return
@@ -115,6 +134,7 @@ function test_runtime_in_milliseconds_when_empty_time() {
   mock clock::shell_time mock_non_existing_fn
   mock dependencies::has_python mock_false
   mock dependencies::has_node mock_false
+  mock date mock_non_existing_fn
 
   assert_empty "$(clock::total_runtime_in_milliseconds)"
 }


### PR DESCRIPTION

## 🔖 Changes

- Very last fallback: seconds resolution only

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
