### PR TITLE
Improve assert_have_been_called_with arg matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve `assert_have_been_called_with` with strict argument matching
+
 ## [0.23.0](https://github.com/TypedDevs/bashunit/compare/0.22.3...0.23.0) - 2025-08-03
 
 - Update docs mocks usage

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -117,12 +117,9 @@ function test_failure() {
 :::
 
 ## assert_have_been_called_with
-> `assert_have_been_called_with spy expected [call_index] [--strict]`
+> `assert_have_been_called_with spy expected [call_index]`
 
-Reports an error if `spy` is not called with `expected`. When `call_index` is
-provided, the assertion checks the arguments of that specific call (starting at
-1). Without `call_index` it checks the last invocation. The optional `--strict`
-flag forces an exact match on argument boundaries.
+Reports an error if `spy` is not called with `expected`. When `call_index` is provided, the assertion checks the arguments of that specific call (starting at 1). Without `call_index` it checks the last invocation. Arguments are joined with spaces before comparison.
 
 ::: code-group
 ```bash [Example]
@@ -146,16 +143,6 @@ function test_failure() {
 ```
 :::
 
-### Argument boundaries
-
-By default, `assert_have_been_called_with` joins arguments with spaces before comparison. This means a call like `ps "foo bar"` is indistinguishable from `ps foo bar`. Use the `--strict` flag to force an exact match on argument boundaries:
-
-```bash
-spy ps
-ps "foo bar"
-assert_have_been_called_with ps "foo bar" --strict # succeeds
-assert_have_been_called_with ps foo bar --strict   # fails
-```
 
 ## assert_have_been_called_times
 > assert_have_been_called_times "expected" "spy"

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -87,7 +87,7 @@ function test_example() {
 
   ps foo bar
 
-  assert_have_been_called_with "foo bar" ps
+  assert_have_been_called_with ps "foo bar"
   assert_have_been_called ps
 }
 ```
@@ -117,11 +117,12 @@ function test_failure() {
 :::
 
 ## assert_have_been_called_with
-> `assert_have_been_called_with "expected" "spy" [call_index]`
+> `assert_have_been_called_with spy expected [call_index] [--strict]`
 
 Reports an error if `spy` is not called with `expected`. When `call_index` is
 provided, the assertion checks the arguments of that specific call (starting at
-1). Without `call_index` it checks the last invocation.
+1). Without `call_index` it checks the last invocation. The optional `--strict`
+flag forces an exact match on argument boundaries.
 
 ::: code-group
 ```bash [Example]
@@ -131,8 +132,8 @@ function test_success() {
   ps foo
   ps bar
 
-  assert_have_been_called_with "foo" ps 1
-  assert_have_been_called_with "bar" ps 2
+  assert_have_been_called_with ps "foo" 1
+  assert_have_been_called_with ps "bar" 2
 }
 
 function test_failure() {
@@ -140,10 +141,21 @@ function test_failure() {
 
   ps bar
 
-  assert_have_been_called_with "foo" ps 1
+  assert_have_been_called_with ps "foo" 1
 }
 ```
 :::
+
+### Argument boundaries
+
+By default, `assert_have_been_called_with` joins arguments with spaces before comparison. This means a call like `ps "foo bar"` is indistinguishable from `ps foo bar`. Use the `--strict` flag to force an exact match on argument boundaries:
+
+```bash
+spy ps
+ps "foo bar"
+assert_have_been_called_with ps "foo bar" --strict # succeeds
+assert_have_been_called_with ps foo bar --strict   # fails
+```
 
 ## assert_have_been_called_times
 > assert_have_been_called_times "expected" "spy"

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -151,7 +151,7 @@ function assert_have_been_called_with() {
 }
 
 function assert_have_been_called_times() {
-  local expected=$1
+  local expected_count=$1
   local command=$2
   local variable
   variable="$(helper::normalize_variable_name "$command")"
@@ -161,10 +161,10 @@ function assert_have_been_called_times() {
     times=$(cat "${!file_var}")
   fi
   local label="${3:-$(helper::normalize_test_function_name "${FUNCNAME[1]}")}"
-  if [[ $times -ne $expected ]]; then
+  if [[ $times -ne $expected_count ]]; then
     state::add_assertions_failed
     console_results::print_failed_test "${label}" "${command}" \
-      "to have been called" "${expected} times" \
+      "to have been called" "${expected_count} times" \
       "actual" "${times} times"
     return
   fi

--- a/tests/unit/dependencies_test.sh
+++ b/tests/unit/dependencies_test.sh
@@ -4,14 +4,14 @@ function test_has_perl_search_path_for_perl() {
   spy command
   dependencies::has_perl
 
-  assert_have_been_called_with "-v perl" command
+  assert_have_been_called_with command "-v perl"
 }
 
 function test_has_adjtimex() {
   spy command
   dependencies::has_adjtimex
 
-  assert_have_been_called_with "-v adjtimex" command
+  assert_have_been_called_with command "-v adjtimex"
 }
 
 function test_has_bc() {
@@ -19,33 +19,33 @@ function test_has_bc() {
 
   dependencies::has_bc
 
-  assert_have_been_called_with "-v bc" command
+  assert_have_been_called_with command "-v bc"
 }
 
 function test_has_awk() {
   spy command
   dependencies::has_awk
 
-  assert_have_been_called_with "-v awk" command
+  assert_have_been_called_with command "-v awk"
 }
 
 function test_has_git() {
   spy command
   dependencies::has_git
 
-  assert_have_been_called_with "-v git" command
+  assert_have_been_called_with command "-v git"
 }
 
 function test_has_python() {
   spy command
   dependencies::has_python
 
-  assert_have_been_called_with "-v python" command
+  assert_have_been_called_with command "-v python"
 }
 
 function test_has_node() {
   spy command
   dependencies::has_node
 
-  assert_have_been_called_with "-v node" command
+  assert_have_been_called_with command "-v node"
 }

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -148,16 +148,6 @@ function test_spy_called_with_different_arguments() {
   assert_have_been_called_with ps "second" 2
 }
 
-function test_strict_argument_matching() {
-  spy ps
-
-  ps "arg1 arg2"
-  ps arg1 arg2
-
-  assert_have_been_called_with ps "arg1 arg2" 1 --strict
-  assert_have_been_called_with ps arg1 arg2 2 --strict
-}
-
 function test_spy_successful_not_called() {
   spy ps
 

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -33,7 +33,7 @@ function test_successful_spy() {
   spy ps
   ps a_random_parameter_1 a_random_parameter_2
 
-  assert_have_been_called_with "a_random_parameter_1 a_random_parameter_2" ps
+  assert_have_been_called_with ps "a_random_parameter_1 a_random_parameter_2"
   assert_have_been_called ps
 }
 
@@ -122,7 +122,7 @@ function test_spy_called_in_subshell() {
   assert_same "done" "$result"
   assert_have_been_called spy_called_in_subshell
   assert_have_been_called_times 2 spy_called_in_subshell
-  assert_have_been_called_with "2025-05-23" spy_called_in_subshell
+  assert_have_been_called_with spy_called_in_subshell "2025-05-23"
 }
 
 function test_mock_called_in_subshell() {
@@ -144,8 +144,18 @@ function test_spy_called_with_different_arguments() {
   ps first_a first_b
   ps second
 
-  assert_have_been_called_with "first_a first_b" ps 1
-  assert_have_been_called_with "second" ps 2
+  assert_have_been_called_with ps "first_a first_b" 1
+  assert_have_been_called_with ps "second" 2
+}
+
+function test_strict_argument_matching() {
+  spy ps
+
+  ps "arg1 arg2"
+  ps arg1 arg2
+
+  assert_have_been_called_with ps "arg1 arg2" 1 --strict
+  assert_have_been_called_with ps arg1 arg2 2 --strict
 }
 
 function test_spy_successful_not_called() {


### PR DESCRIPTION
## 📚 Description

Resolves https://github.com/TypedDevs/bashunit/issues/465 by @akinomyoga

## 🔖 Changes

- Enhanced spies to record both raw and serialized arguments, preserving args boundaries for reliable comparisons
- Reworked `assert_have_been_called_with` to accept the spy name first
- Updated docs and examples to describe the new --strict behavior and clarify how argument boundaries are handled

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
