### PR TITLE
Rename helpers functions to helper prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 - Allow `assert_have_been_called_with` to check arguments of specific calls
 - Enable parallel tests on Windows
 - Add `assert_not_called`
-- Improve `find_total_tests` performance
+- Improve `helper::find_total_tests` performance
 - Added `assert_match_snapshot_ignore_colors`
 - Optimize `runner::parse_result_sync`
 - Fix `parse_result_parallel` template

--- a/docs/blog/2025-06-01-release-0-20.md
+++ b/docs/blog/2025-06-01-release-0-20.md
@@ -95,7 +95,7 @@ Parallel execution is now enabled on Windows, greatly reducing running time for 
 ## 🌾 Miscellaneous
 
 * Deprecate `# data_provider` in favor of `# @data_provider`
-* Improve `find_total_tests` and `runner::parse_result_sync` performance
+* Improve `helper::find_total_tests` and `runner::parse_result_sync` performance
 
 ---
 

--- a/docs/blog/2025-06-18-release-0-21.md
+++ b/docs/blog/2025-06-18-release-0-21.md
@@ -46,7 +46,7 @@ ID: {{ignore}}
 
 ### Count data providers accurately
 
-`find_total_tests` now includes cases provided by `@data_provider`, giving a more accurate count of total executed tests.
+`helper::find_total_tests` now includes cases provided by `@data_provider`, giving a more accurate count of total executed tests.
 
 ## 🐛 Bugfix
 

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -26,7 +26,7 @@ function console_header::print_version() {
   if [[ ${#files[@]} -eq 0 ]]; then
     total_tests=0
   else
-    total_tests=$(helpers::find_total_tests "$filter" "${files[@]}")
+    total_tests=$(helper::find_total_tests "$filter" "${files[@]}")
   fi
 
   if env::is_header_ascii_art_enabled; then

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -210,7 +210,7 @@ function helper::trim() {
   echo "$trimmed_string"
 }
 
-function helpers::get_latest_tag() {
+function helper::get_latest_tag() {
   if ! dependencies::has_git; then
     return 1
   fi
@@ -222,7 +222,7 @@ function helpers::get_latest_tag() {
     head -n 1
 }
 
-function helpers::find_total_tests() {
+function helper::find_total_tests() {
     local filter=${1:-}
     local files=("${@:2}")
 

--- a/src/upgrade.sh
+++ b/src/upgrade.sh
@@ -4,7 +4,7 @@ function upgrade::upgrade() {
   local script_path
   script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   local latest_tag
-  latest_tag="$(helpers::get_latest_tag)"
+  latest_tag="$(helper::get_latest_tag)"
 
   if [[ "$BASHUNIT_VERSION" == "$latest_tag" ]]; then
     echo "> You are already on latest version"

--- a/tests/acceptance/bashunit_upgrade_test.sh
+++ b/tests/acceptance/bashunit_upgrade_test.sh
@@ -29,7 +29,7 @@ function tear_down_after_script() {
 function set_up() {
   ./build.sh "$TMP_DIR" >/dev/null
   if [[ "$ACTIVE_INTERNET" == true ]] && [[ "$HAS_GIT" == true ]]; then
-    LATEST_VERSION="$(helpers::get_latest_tag)"
+    LATEST_VERSION="$(helper::get_latest_tag)"
   else
     LATEST_VERSION="${BASHUNIT_VERSION}"
   fi

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -227,7 +227,7 @@ a17e6816669ec8d0f18ed8c6d5564df9fc699bf9        refs/tags/0.10.0
 b546c693198870dd75d1a102b94f4ddad6f4f3ea        refs/tags/0.2.0
 732ea5e8b16c3c05f0a6977b794ed7098e1839e2        refs/tags/0.3.0
 EOF
-  assert_same "0.10.1" "$(helpers::get_latest_tag)"
+  assert_same "0.10.1" "$(helper::get_latest_tag)"
   unset -f git # remove the mock
 }
 
@@ -258,7 +258,7 @@ function test_normalize_test_function_name_with_interpolation() {
 }
 
 function helpers_test::find_total_in_subshell() {
-  bash -c 'source "$1"; shift; helpers::find_total_tests "$@"' bash "$BASHUNIT_ROOT_DIR/src/helpers.sh" "$@"
+  bash -c 'source "$1"; shift; helper::find_total_tests "$@"' bash "$BASHUNIT_ROOT_DIR/src/helpers.sh" "$@"
 }
 
 function test_find_total_tests_no_files() {


### PR DESCRIPTION
I was testing Codex to see if it could be useful for us in bashunit. I asked it to look for errors in the code, and it found a small inconsistency in the helpers namespaces. Then I had it fix the issue. You can see its full workflow at [this link](https://chatgpt.com/codex/tasks/task_e_6891c5fde50c8324afe47cd3789cd236). Here's the PR with the final result.

## Summary
- rename helpers::get_latest_tag and helpers::find_total_tests to helper:: namespace
- update code, tests, and docs for new helper:: names