### PR TITLE
Fix: support whitespace in data providers

### DIFF
--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -132,7 +132,15 @@ function console_results::print_successful_test() {
   if [[ -z "$*" ]]; then
     line=$(printf "%s✓ Passed%s: %s" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name")
   else
-    line=$(printf "%s✓ Passed%s: %s (%s)" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name" "$*")
+    local quoted_args=""
+    for arg in "$@"; do
+      if [[ -z "$quoted_args" ]]; then
+        quoted_args="'$arg'"
+      else
+        quoted_args="$quoted_args, '$arg'"
+      fi
+    done
+    line=$(printf "%s✓ Passed%s: %s (%s)" "$_COLOR_PASSED" "$_COLOR_DEFAULT" "$test_name" "$quoted_args")
   fi
 
   local full_line=$line

--- a/src/globals.sh
+++ b/src/globals.sh
@@ -102,3 +102,18 @@ function print_line() {
   local char="${2:--}"      # Default to '-' if not passed
   printf '%*s\n' "$length" '' | tr ' ' "$char"
 }
+
+function data_set() {
+  local arg
+  local first=true
+
+  for arg in "$@"; do
+    if [ "$first" = true ]; then
+      printf '%q' "$arg"
+      first=false
+    else
+      printf ' %q' "$arg"
+    fi
+  done
+  printf '\n'
+}

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -116,9 +116,10 @@ function runner::call_test_functions() {
 
     # Execute the test function for each line of data
     for data in "${provider_data[@]}"; do
-      IFS=" " read -r -a args <<< "$data"
-      if [ "${#args[@]}" -gt 1 ]; then
-        runner::run_test "$script" "$fn_name" "${args[@]}"
+      # Use eval with set -- to properly parse quoted arguments
+      eval "set -- $data"
+      if [ "$#" -gt 1 ]; then
+        runner::run_test "$script" "$fn_name" "$@"
       else
         runner::run_test "$script" "$fn_name" "$data"
       fi

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -51,7 +51,7 @@ function test_empty_value_from_data_provider() {
 }
 
 function provide_empty_value() {
-  echo "" "two"
+  data_set "" "two"
 }
 
 # @data_provider provide_value_with_whitespace
@@ -64,5 +64,5 @@ function test_value_with_whitespace_from_data_provider() {
 }
 
 function provide_value_with_whitespace() {
-  echo "first value" "second value"
+  data_set "first value" "second value"
 }

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -40,3 +40,29 @@ function test_single_value_from_data_provider() {
 function provide_single_value() {
   echo "one"
 }
+
+# @data_provider provide_empty_value
+function test_empty_value_from_data_provider() {
+  local first="$1"
+  local second="$2"
+
+  assert_same "" "$first"
+  assert_same "two" "$second"
+}
+
+function provide_empty_value() {
+  echo "" "two"
+}
+
+# @data_provider provide_value_with_whitespace
+function test_value_with_whitespace_from_data_provider() {
+  local first="$1"
+  local second="$2"
+
+  assert_same "first value" "$first"
+  assert_same "second value" "$second"
+}
+
+function provide_value_with_whitespace() {
+  echo "first value" "second value"
+}

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -543,7 +543,7 @@ function test_print_successful_test_output_with_args() {
   local data="foo"
 
   assert_matches \
-    "✓ Passed.*$test_name \($data\).*12 ms" \
+    "✓ Passed.*$test_name \('$data'\).*12 ms" \
     "$(console_results::print_successful_test "$test_name" "12" "$data")"
 
   export BASHUNIT_SIMPLE_OUTPUT=$original_simple_output


### PR DESCRIPTION
## 📚 Description

This PR is a potential fix for #478. It adds a solution for supporting whitespace in data provider values.

## 🔖 Changes

The PR adds a global `data_set` function for declaring data sets in data providers, superseding the previous `echo` solution with a more robust way preserving quotes.

It furthermore changes the way data from data providers is parsed.
Previously the values were simply read using `IFS=" "`, which split the
input on spaces. This made values containing spaces impossible.
Now values are parsed using a combination of `eval` and `set`, which
respects quotes in the input data and hence makes contained spaces
possible. We can also provide empty strings as input data now.
The new parsing is backwards-compatible, so declaring data values using `echo` still works like before.

## ✅ To-do list

- [ ] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes