### PR TITLE
Fix: clean parallel temp folder after test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for empty values and values containing spaces in data providers via new `data_set` function
 - Document workaround for global function name collisions when sourcing scripts in tests by copying the original function
 - Fix `temp_dir` and `temp_file` data not being cleaned up when created in `set_up_before_script`
+- Fix `/tmp/bashunit/parallel` not being cleaned after test run
 
 ## [0.23.0](https://github.com/TypedDevs/bashunit/compare/0.22.3...0.23.0) - 2025-08-03
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -29,7 +29,7 @@ function main::exec_tests() {
   fi
 
   if parallel::is_enabled; then
-    parallel::reset
+    parallel::init
   fi
 
   console_header::print_version_with_env "$filter" "${test_files[@]}"
@@ -70,6 +70,10 @@ function main::exec_tests() {
     reports::generate_report_html "$BASHUNIT_REPORT_HTML"
   fi
 
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
+
   internal_log "Finished tests" "exit_code:$exit_code"
   exit $exit_code
 }
@@ -105,6 +109,9 @@ function main::cleanup() {
   # Kill all child processes of this script
   pkill -P $$
   cleanup_script_temp_files
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
   exit 1
 }
 
@@ -113,6 +120,9 @@ function main::handle_stop_on_failure_sync() {
   console_results::print_failing_tests_and_reset
   console_results::render_result
   cleanup_script_temp_files
+  if parallel::is_enabled; then
+    parallel::cleanup
+  fi
   exit 1
 }
 

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -101,11 +101,14 @@ function parallel::must_stop_on_failure() {
   [[ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ]]
 }
 
-function parallel::reset() {
+function parallel::cleanup() {
   # shellcheck disable=SC2153
   rm -rf "$TEMP_DIR_PARALLEL_TEST_SUITE"
+}
+
+function parallel::init() {
+  parallel::cleanup
   mkdir -p "$TEMP_DIR_PARALLEL_TEST_SUITE"
-  [ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ] && rm "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE"
 }
 
 function parallel::is_enabled() {

--- a/tests/acceptance/bashunit_script_temp_file_cleanup_test.sh
+++ b/tests/acceptance/bashunit_script_temp_file_cleanup_test.sh
@@ -5,6 +5,7 @@ function test_script_temp_files_are_cleaned_up_after_test_run() {
   local mode="$1"
   local fixture_file="tests/acceptance/fixtures/script_with_setup_temp_file.sh"
   local temp_base_dir="${TMPDIR:-/tmp}/bashunit/tmp"
+  local parallel_temp_base_dir="${TMPDIR:-/tmp}/bashunit/parallel/${_OS:-Unknown}"
   local output
 
   if [[ "$mode" == "parallel" ]]; then
@@ -26,6 +27,19 @@ function test_script_temp_files_are_cleaned_up_after_test_run() {
     # Manually clean up remaining files
     if [[ -n "$remaining_files" ]]; then
       echo "$remaining_files" | xargs rm -rf 2>/dev/null || true
+    fi
+  fi
+
+  # Check that no parallel temp files remain in the temp directory
+
+  if [[ -d "$parallel_temp_base_dir" ]]; then
+    remaining_files=$(find "$parallel_temp_base_dir" -name "script_with_setup_temp_file" 2>/dev/null || true)
+
+    assert_empty "$remaining_files"
+
+    # Manually clean up remaining files
+    if [[ -n "$remaining_files" ]]; then
+      dirname "$remaining_files" | xargs rm -rf 2>/dev/null || true
     fi
   fi
 }


### PR DESCRIPTION
## 📚 Description

This PR resolves an issue where temporary files and directories bashunit creates implicitly during a parallel run were not properly cleaned up.

It adds both a unit test an an acceptance test that fail without the fix and now pass.

This issue already existed before my changes in #483 .

## 🔖 Changes

- Add a new function `parallel::cleanup` and call it in each exit point when parallel mode is enabled

*Side note*: the previous `parallel::reset` function (which I renamed to `parallel::init` now) contained the following line:

```bash
[ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ] && rm "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE"
```

IMO the condition `[ -f "$TEMP_FILE_PARALLEL_STOP_ON_FAILURE" ]` could never be true, as the containing directory is deleted right before the line. Hence I removed it. If it served any purpose I overlooked, please tell me.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
