### PR TITLE
Fix: support tabs in data set values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Improve `assert_have_been_called_with` with strict argument matching
 - Make Windows install clearer in the docs by adding an option for Linux/Mac and another one for Windows.
-- Add support for empty values and values containing spaces in data providers via new `data_set` function
+- Add support for empty values and values containing spaces or tabs in data providers via new `data_set` function
 - Document workaround for global function name collisions when sourcing scripts in tests by copying the original function
 - Fix `temp_dir` and `temp_file` data not being cleaned up when created in `set_up_before_script`
 - Fix `/tmp/bashunit/parallel` not being cleaned after test run

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -106,12 +106,27 @@ function runner::parse_data_provider_args() {
   for ((i=0; i<${#input}; i++)); do
     local char="${input:$i:1}"
     if [ "$escaped" = true ]; then
-      current_arg+="$char"
+      case "$char" in
+        t) current_arg+=$'\t' ;;
+        n) current_arg+=$'\n' ;;
+        *) current_arg+="$char" ;;
+      esac
       escaped=false
     elif [ "$char" = "\\" ]; then
       escaped=true
     elif [ "$in_quotes" = false ]; then
       case "$char" in
+        "$")
+          # Handle $'...' syntax
+          if [[ "${input:$i:2}" == "$'" ]]; then
+            in_quotes=true
+            quote_char="'"
+            # Skip the $
+            i=$((i + 1))
+          else
+            current_arg+="$char"
+          fi
+          ;;
         "'" | '"')
           in_quotes=true
           quote_char="$char"

--- a/tests/functional/provider_test.sh
+++ b/tests/functional/provider_test.sh
@@ -54,6 +54,17 @@ function provide_empty_value() {
   data_set "" "two"
 }
 
+# @data_provider provide_value_with_tabs
+function test_value_with_tabs_from_data_provider() {
+  local value="$1"
+
+  assert_same "value	with	tabs" "$value"
+}
+
+function provide_value_with_tabs() {
+  data_set "value	with	tabs"
+}
+
 # @data_provider provide_value_with_whitespace
 function test_value_with_whitespace_from_data_provider() {
   local first="$1"


### PR DESCRIPTION
## 📚 Description

This PR adds support for tabs in `data_set` values in data providers.

It also adds a unit test that fails without the fix and now passes.

## 🔖 Changes

- Extend `runner::parse_data_provider_args` to correctly handle the `$'...'` which "printf '%q'" uses
when the string contains escape sequences.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
