### PR TITLE
Include test_title.sh in build depenedencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `AGENTS.md` for external developer tools integration
 - Add two-way synchronization policy between `AGENTS.md` and `copilot-instructions.md` with automatic validation in task templates and PR checklist
 - Add tasks storage policy clarifying `.tasks/` (versioned) vs `.task/` (private scratch, git-ignored)
+- Include `set_test_title` helper in the single-file library
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/build.sh
+++ b/build.sh
@@ -98,6 +98,7 @@ function build::dependencies() {
     "src/console_header.sh"
     "src/console_results.sh"
     "src/helpers.sh"
+    "src/test_title.sh"
     "src/upgrade.sh"
     "src/assertions.sh"
     "src/reports.sh"


### PR DESCRIPTION
## 📚 Description

`set_test_title` helper is not available in the single file library because it's not being pulled in by the build script. Fix it.

## 🔖 Changes

(see above)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes (nothing to be done)
