### PR TITLE
Fix setup and teardown functions when errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add two-way synchronization policy between `AGENTS.md` and `copilot-instructions.md` with automatic validation in task templates and PR checklist
 - Add tasks storage policy clarifying `.tasks/` (versioned) vs `.task/` (private scratch, git-ignored)
 - Include `set_test_title` helper in the single-file library
+- Fix lifecycle hooks capture-and-report flow errors
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add tasks storage policy clarifying `.tasks/` (versioned) vs `.task/` (private scratch, git-ignored)
 - Include `set_test_title` helper in the single-file library
 - Fix lifecycle hooks capture-and-report flow errors
+    - set_up
+    - tear_down
+    - set_up_before_script
+    - tear_down_after_script
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -85,6 +85,8 @@ function tear_down() {
 The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
 This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
 
+If any command inside `set_up_before_script` fails, bashunit now halts the file immediately and reports the error (including the failing command and location) before any test functions run. This ensures misconfigured environments or missing dependencies surface clearly during setup.
+
 ::: code-group
 ```bash [Example]
 function set_up_before_script() {
@@ -98,6 +100,8 @@ function set_up_before_script() {
 The `tear_down_after_script` auxiliary function is called, if it is present in the test file, only once when all the test functions in the test file have been executed.
 This auxiliary function is similar to how `set_up_before_script` works but at the end of the tests.
 It provides a hook for any cleanup that should occur after all tests have run, such as deleting temporary files or releasing resources.
+
+Failures inside `tear_down_after_script` are also surfaced as dedicated errors after the final test output so cleanup problems (for example, missing tools or permissions) are visible in the run summary.
 
 ::: code-group
 ```bash [Example]

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -85,7 +85,7 @@ function tear_down() {
 The `set_up_before_script` auxiliary function is called, if it is present in the test file, only once before all tests functions in the test file begin.
 This is useful for global setup that applies to all test functions in the script, such as loading shared resources.
 
-If any command inside `set_up_before_script` fails, bashunit now halts the file immediately and reports the error (including the failing command and location) before any test functions run. This ensures misconfigured environments or missing dependencies surface clearly during setup.
+If any command inside `set_up_before_script` fails, bashunit halts the file immediately and reports the error (including the failing command and location) before any test functions run. This ensures misconfigured environments or missing dependencies surface clearly during setup.
 
 ::: code-group
 ```bash [Example]

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -137,9 +137,14 @@ function helper::get_functions_to_run() {
 # @param $1 string Eg: "do_something"
 #
 function helper::execute_function_if_exists() {
-  if [[ "$(type -t "$1")" == "function" ]]; then
-    "$1" 2>/dev/null
+  local fn_name="$1"
+
+  if [[ "$(type -t "$fn_name")" == "function" ]]; then
+    "$fn_name"
+    return $?
   fi
+
+  return 0
 }
 
 #

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -294,6 +294,7 @@ function runner::run_test() {
   exec 3>&1
 
   local test_execution_result=$(
+    # shellcheck disable=SC2064
     # shellcheck disable=SC2154
     trap "
       exit_code=\$?

--- a/src/state.sh
+++ b/src/state.sh
@@ -16,6 +16,8 @@ _DUPLICATED_TEST_FUNCTIONS_FOUND=false
 _TEST_OUTPUT=""
 _TEST_TITLE=""
 _TEST_EXIT_CODE=0
+_TEST_HOOK_FAILURE=""
+_TEST_HOOK_MESSAGE=""
 
 function state::get_tests_passed() {
   echo "$_TESTS_PASSED"
@@ -145,6 +147,30 @@ function state::reset_test_title() {
   _TEST_TITLE=""
 }
 
+function state::get_test_hook_failure() {
+  echo "$_TEST_HOOK_FAILURE"
+}
+
+function state::set_test_hook_failure() {
+  _TEST_HOOK_FAILURE="$1"
+}
+
+function state::reset_test_hook_failure() {
+  _TEST_HOOK_FAILURE=""
+}
+
+function state::get_test_hook_message() {
+  echo "$_TEST_HOOK_MESSAGE"
+}
+
+function state::set_test_hook_message() {
+  _TEST_HOOK_MESSAGE="$1"
+}
+
+function state::reset_test_hook_message() {
+  _TEST_HOOK_MESSAGE=""
+}
+
 function state::set_duplicated_functions_merged() {
   state::set_duplicated_test_functions_found
   state::set_file_with_duplicated_function_names "$1"
@@ -159,20 +185,26 @@ function state::initialize_assertions_count() {
     _ASSERTIONS_SNAPSHOT=0
     _TEST_OUTPUT=""
     _TEST_TITLE=""
+    _TEST_HOOK_FAILURE=""
+    _TEST_HOOK_MESSAGE=""
 }
 
 function state::export_subshell_context() {
   local encoded_test_output
   local encoded_test_title
 
+  local encoded_test_hook_message
+
   if base64 --help 2>&1 | grep -q -- "-w"; then
     # Alpine requires the -w 0 option to avoid wrapping
     encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64 -w 0)
     encoded_test_title=$(echo -n "$_TEST_TITLE" | base64 -w 0)
+    encoded_test_hook_message=$(echo -n "$_TEST_HOOK_MESSAGE" | base64 -w 0)
   else
     # macOS and others: default base64 without wrapping
     encoded_test_output=$(echo -n "$_TEST_OUTPUT" | base64)
     encoded_test_title=$(echo -n "$_TEST_TITLE" | base64)
+    encoded_test_hook_message=$(echo -n "$_TEST_HOOK_MESSAGE" | base64)
   fi
 
   cat <<EOF
@@ -182,6 +214,8 @@ function state::export_subshell_context() {
 ##ASSERTIONS_INCOMPLETE=$_ASSERTIONS_INCOMPLETE\
 ##ASSERTIONS_SNAPSHOT=$_ASSERTIONS_SNAPSHOT\
 ##TEST_EXIT_CODE=$_TEST_EXIT_CODE\
+##TEST_HOOK_FAILURE=$_TEST_HOOK_FAILURE\
+##TEST_HOOK_MESSAGE=$encoded_test_hook_message\
 ##TEST_TITLE=$encoded_test_title\
 ##TEST_OUTPUT=$encoded_test_output\
 ##

--- a/tests/acceptance/bashunit_setup_before_script_error_test.sh
+++ b/tests/acceptance/bashunit_setup_before_script_error_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function strip_ansi() {
+  sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+}
+
+function test_bashunit_when_set_up_before_script_errors() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_setup_before_script_errors.sh
+  local fixture=$test_file
+
+  local header_line="Running $fixture"
+  local error_line="✗ Error: Set up before script"
+  local message_line="    $fixture: line 4: invalid_function_name: command not found"
+  local tests_summary="Tests:      1 failed, 1 total"
+  local assertions_summary="Assertions: 0 failed, 0 total"
+
+  local actual_raw
+  set +e
+  actual_raw="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
+  set -e
+
+  local actual
+  actual="$(printf "%s" "$actual_raw" | strip_ansi)"
+
+  assert_contains "$header_line" "$actual"
+  assert_contains "$error_line" "$actual"
+  assert_contains "$message_line" "$actual"
+  assert_contains "$tests_summary" "$actual"
+  assert_contains "$assertions_summary" "$actual"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+}

--- a/tests/acceptance/bashunit_setup_error_test.sh
+++ b/tests/acceptance/bashunit_setup_error_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function strip_ansi() {
+  sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+}
+
+function test_bashunit_when_set_up_errors() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_setup_errors.sh
+  local fixture=$test_file
+
+  local header_line="Running $fixture"
+  local error_line="✗ Error: Set up"
+  local message_line="    $fixture: line 4: invalid_function_name: command not found"
+  local tests_summary="Tests:      1 failed, 1 total"
+  local assertions_summary="Assertions: 0 failed, 0 total"
+
+  local actual_raw
+  set +e
+  actual_raw="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
+  set -e
+
+  local actual
+  actual="$(printf "%s" "$actual_raw" | strip_ansi)"
+
+  assert_contains "$header_line" "$actual"
+  assert_contains "$error_line" "$actual"
+  assert_contains "$message_line" "$actual"
+  assert_contains "$tests_summary" "$actual"
+  assert_contains "$assertions_summary" "$actual"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+}

--- a/tests/acceptance/bashunit_teardown_after_script_error_test.sh
+++ b/tests/acceptance/bashunit_teardown_after_script_error_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function strip_ansi() {
+  sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+}
+
+function test_bashunit_when_tear_down_after_script_errors() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_teardown_after_script_errors.sh
+  local fixture=$test_file
+
+  local header_line="Running $fixture"
+  local error_line="✗ Error: Tear down after script"
+  local message_line="    $fixture: line 4: missing_cleanup_command: command not found"
+  local tests_summary="Tests:      1 passed, 1 failed, 2 total"
+  local assertions_summary="Assertions: 0 passed, 0 failed, 0 total"
+
+  local actual_raw
+  set +e
+  actual_raw="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
+  set -e
+
+  local actual
+  actual="$(printf "%s" "$actual_raw" | strip_ansi)"
+
+  assert_contains "$header_line" "$actual"
+  assert_contains "$error_line" "$actual"
+  assert_contains "$message_line" "$actual"
+  assert_contains "$tests_summary" "$actual"
+  assert_contains "$assertions_summary" "$actual"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+}

--- a/tests/acceptance/bashunit_teardown_error_test.sh
+++ b/tests/acceptance/bashunit_teardown_error_test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function strip_ansi() {
+  sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+}
+
+function test_bashunit_when_tear_down_errors() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_teardown_errors.sh
+  local fixture=$test_file
+
+  local header_line="Running $fixture"
+  local error_line="✗ Error: Tear down"
+  local message_line="    $fixture: line 4: invalid_function_name: command not found"
+  local tests_summary="Tests:      1 failed, 1 total"
+  local assertions_summary="Assertions: 0 failed, 0 total"
+
+  local actual_raw
+  set +e
+  actual_raw="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
+  set -e
+
+  local actual
+  actual="$(printf "%s" "$actual_raw" | strip_ansi)"
+
+  assert_contains "$header_line" "$actual"
+  assert_contains "$error_line" "$actual"
+  assert_contains "$message_line" "$actual"
+  assert_contains "$tests_summary" "$actual"
+  assert_contains "$assertions_summary" "$actual"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+}

--- a/tests/acceptance/fixtures/test_bashunit_when_setup_before_script_errors.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_setup_before_script_errors.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+  invalid_function_name arg1
+}
+
+function test_dummy() {
+  :
+}

--- a/tests/acceptance/fixtures/test_bashunit_when_setup_errors.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_setup_errors.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function set_up() {
+  invalid_function_name arg1
+}
+
+function test_dummy() {
+  :
+}

--- a/tests/acceptance/fixtures/test_bashunit_when_teardown_after_script_errors.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_teardown_after_script_errors.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function tear_down_after_script() {
+  missing_cleanup_command
+}
+
+function test_sample() {
+  :
+}

--- a/tests/acceptance/fixtures/test_bashunit_when_teardown_errors.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_teardown_errors.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function tear_down() {
+  invalid_function_name arg1
+}
+
+function test_dummy() {
+  :
+}

--- a/tests/unit/globals_test.sh
+++ b/tests/unit/globals_test.sh
@@ -19,7 +19,7 @@ function set_up() {
 }
 
 function tear_down() {
-  rm "$BASHUNIT_DEV_LOG"
+  rm -f "$BASHUNIT_DEV_LOG"
 }
 
 function test_globals_current_dir() {

--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 _ERROR_LOG=temp_error.log
 
 function tear_down() {
-  rm $_ERROR_LOG
+  rm -f "$_ERROR_LOG"
 }
 
 function test_redirect_error_with_log() {

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -255,6 +255,8 @@ function test_initialize_assertions_count() {
 ##ASSERTIONS_INCOMPLETE=0\
 ##ASSERTIONS_SNAPSHOT=0\
 ##TEST_EXIT_CODE=0\
+##TEST_HOOK_FAILURE=\
+##TEST_HOOK_MESSAGE=\
 ##TEST_TITLE=\
 ##TEST_OUTPUT=\
 ##"\
@@ -285,6 +287,8 @@ function test_export_assertions_count() {
 ##ASSERTIONS_INCOMPLETE=12\
 ##ASSERTIONS_SNAPSHOT=33\
 ##TEST_EXIT_CODE=1\
+##TEST_HOOK_FAILURE=\
+##TEST_HOOK_MESSAGE=\
 ##TEST_TITLE=\
 ##TEST_OUTPUT=$(echo -n "something" | base64)##"\
     "$export_assertions_count"


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/489 by @carlfriedrich 

If there would be an error in `set_up_before_script` or  similars, then bashunit crash and does not continue with the tests; also, it does not give any feedback about it but stops working.

<img width="999" height="829" alt="Screenshot 2025-09-26 at 14 59 57" src="https://github.com/user-attachments/assets/fff1c78b-d249-484f-807d-77718e75d046" />

You can see in the demo above, that the runner stops without giving any hint why.

## 🔖 Changes

- Do not stop when encountering any error on set_up functions, but keep the error on memory and keep the runner running

## 🖼️  Demo

### Regular output

<img width="919" height="916" alt="Screenshot 2025-09-26 at 15 01 46" src="https://github.com/user-attachments/assets/22793a83-e180-4671-888a-dd0275e118d2" />

### Pararel and simple output

<img width="799" height="413" alt="Screenshot 2025-09-26 at 15 06 13" src="https://github.com/user-attachments/assets/9118a017-e82d-4025-826a-84c6c4d0e34d" />

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
