### PR TITLE
Fix false negative from assert_have_been_called_with with pipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - tear_down
     - set_up_before_script
     - tear_down_after_script
+- Fix false negative from `assert_have_been_called_with` with pipes
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/src/test_doubles.sh
+++ b/src/test_doubles.sh
@@ -59,7 +59,7 @@ function spy() {
       serialized+=\"\$(printf '%q' \"\$arg\")$'\\x1f'\"
     done
     serialized=\${serialized%$'\\x1f'}
-    printf '%s|%s\\n' \"\$raw\" \"\$serialized\" >> '$params_file'
+    printf '%s\x1e%s\\n' \"\$raw\" \"\$serialized\" >> '$params_file'
     local _c=\$(cat '$times_file')
     _c=\$((_c+1))
     echo \"\$_c\" > '$times_file'
@@ -115,7 +115,7 @@ function assert_have_been_called_with() {
   fi
 
   local raw
-  IFS='|' read -r raw _ <<<"$line"
+  IFS=$'\x1e' read -r raw _ <<<"$line"
 
   if [[ "$expected" != "$raw" ]]; then
     state::add_assertions_failed

--- a/tests/unit/test_doubles_test.sh
+++ b/tests/unit/test_doubles_test.sh
@@ -166,3 +166,11 @@ function test_spy_unsuccessful_not_called() {
       "actual" "1 times")" \
     "$(assert_not_called ps)"
 }
+
+function test_spy_with_pipe_in_arguments() {
+  spy grep
+
+  grep -E 'foo|bar'
+
+  assert_have_been_called_with grep '-E foo|bar'
+}


### PR DESCRIPTION
## 📚 Description

Closes https://github.com/TypedDevs/bashunit/issues/494 by @mattness

<img width="923" height="338" alt="Screenshot 2025-10-02 at 11 10 24" src="https://github.com/user-attachments/assets/3bd29986-ea09-406b-a1ca-d3d118d27afb" />


## 🔖 Changes

<img width="1204" height="211" alt="Screenshot 2025-10-02 at 11 09 57" src="https://github.com/user-attachments/assets/1332df92-1f40-4cc8-9021-61f8d17aa804" />

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
