### PR TITLE
Fix wrong assertion_failed name of test on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,14 @@
     - Add tasks storage policy clarifying `.tasks/` (versioned) vs `.task/` (git-ignored)
 - Include `set_test_title` helper in the single-file library
 - Fix lifecycle hooks capture-and-report flow errors
-    - set_up
-    - tear_down
-    - set_up_before_script
-    - tear_down_after_script
+    - `set_up`
+    - `tear_down`
+    - `set_up_before_script`
+    - `tear_down_after_script`
 - Fix false negative from `assert_have_been_called_with` with pipes
 - Fix preservation of trailing whitespace in final argument to `data_set`
 - Fix unbound variable error in `parse_data_provider_args` with `set -u`
+- Fix wrong assertion_failed name of test on failure
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/src/bashunit.sh
+++ b/src/bashunit.sh
@@ -10,7 +10,7 @@ function bashunit::assertion_failed() {
   local failure_condition_message=${3:-"but got "}
 
   local label
-  label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+  label="$(helper::normalize_test_function_name "${FUNCNAME[2]}")"
   state::add_assertions_failed
   console_results::print_failed_test "${label}" "${expected}" \
     "$failure_condition_message" "${actual}"

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -12,7 +12,7 @@ function test_assert_foo_passed() {
 
 function test_assert_foo_failed() {
   assert_same\
-    "$(console_results::print_failed_test "Assert foo" "foo" "but got " "bar")"\
+    "$(console_results::print_failed_test "Assert foo failed" "foo" "but got " "bar")"\
     "$(assert_foo "bar")"
 }
 
@@ -22,6 +22,6 @@ function test_assert_positive_number_passed() {
 
 function test_assert_positive_number_failed() {
   assert_same\
-    "$(console_results::print_failed_test "Assert positive number" "positive number" "got" "0")"\
+    "$(console_results::print_failed_test "Assert positive number failed" "positive number" "got" "0")"\
     "$(assert_positive_number "0")"
 }


### PR DESCRIPTION
## 📚 Description

Closes https://github.com/TypedDevs/bashunit/issues/500

Custom assert output to be consistent with bashunit's built-in assertions.

## 🔖 Changes

- Changing `${FUNCNAME[1]}` to `${FUNCNAME[2]}` by @mattness [source](https://github.com/TypedDevs/bashunit/issues/500#issuecomment-3368668111)

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
