### PR TITLE
Fix test name interpolation on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix preservation of trailing whitespace in final argument to `data_set`
 - Fix unbound variable error in `parse_data_provider_args` with `set -u`
 - Fix wrong assertion_failed name of test on failure
+- Fix test name interpolation on failure
 
 ## [0.24.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-09-14
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -18,6 +18,15 @@ function helper::normalize_test_function_name() {
     return
   fi
 
+  if [[ -z "${interpolated_fn_name-}" && "${original_fn_name}" == *"::"* ]]; then
+    local state_interpolated_fn_name
+    state_interpolated_fn_name="$(state::get_current_test_interpolated_function_name)"
+
+    if [[ -n "$state_interpolated_fn_name" ]]; then
+      interpolated_fn_name="$state_interpolated_fn_name"
+    fi
+  fi
+
   if [[ -n "${interpolated_fn_name-}" ]]; then
     original_fn_name="$interpolated_fn_name"
   fi

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -305,6 +305,11 @@ function runner::run_test() {
   state::reset_test_title
 
   local interpolated_fn_name="$(helper::interpolate_function_name "$fn_name" "$@")"
+  if [[ "$interpolated_fn_name" != "$fn_name" ]]; then
+    state::set_current_test_interpolated_function_name "$interpolated_fn_name"
+  else
+    state::reset_current_test_interpolated_function_name
+  fi
   local current_assertions_failed="$(state::get_assertions_failed)"
   local current_assertions_snapshot="$(state::get_assertions_snapshot)"
   local current_assertions_incomplete="$(state::get_assertions_incomplete)"
@@ -416,6 +421,7 @@ function runner::run_test() {
   local label
   label="$(helper::normalize_test_function_name "$fn_name" "$interpolated_fn_name")"
   state::reset_test_title
+  state::reset_current_test_interpolated_function_name
 
   local failure_label="$label"
   local failure_function="$fn_name"

--- a/src/state.sh
+++ b/src/state.sh
@@ -18,6 +18,7 @@ _TEST_TITLE=""
 _TEST_EXIT_CODE=0
 _TEST_HOOK_FAILURE=""
 _TEST_HOOK_MESSAGE=""
+_CURRENT_TEST_INTERPOLATED_NAME=""
 
 function state::get_tests_passed() {
   echo "$_TESTS_PASSED"
@@ -145,6 +146,18 @@ function state::set_test_title() {
 
 function state::reset_test_title() {
   _TEST_TITLE=""
+}
+
+function state::get_current_test_interpolated_function_name() {
+  echo "$_CURRENT_TEST_INTERPOLATED_NAME"
+}
+
+function state::set_current_test_interpolated_function_name() {
+  _CURRENT_TEST_INTERPOLATED_NAME="$1"
+}
+
+function state::reset_current_test_interpolated_function_name() {
+  _CURRENT_TEST_INTERPOLATED_NAME=""
 }
 
 function state::get_test_hook_failure() {

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -39,6 +39,17 @@ function test_normalize_test_function_name_custom_title() {
   assert_same "🔥 handles invalid input with 💣" "$(helper::normalize_test_function_name "test_handles_invalid_input")"
 }
 
+function test_normalize_test_function_name_uses_current_interpolated_name_from_state() {
+  local fn_name="test_::1::_interpolated_output"
+  local interpolated_fn="test_'value'_interpolated_output"
+
+  state::set_current_test_interpolated_function_name "$interpolated_fn"
+
+  assert_same "'value' interpolated output" "$(helper::normalize_test_function_name "$fn_name")"
+
+  state::reset_current_test_interpolated_function_name
+}
+
 function test_get_functions_to_run_no_filter_should_return_all_functions() {
   local functions=("prefix_function1" "prefix_function2" "other_function" "prefix_function3")
 


### PR DESCRIPTION
## 📚 Description

Closes https://github.com/TypedDevs/bashunit/issues/499 by @mattness 

When a parameterized test with placeholder tokens in its function name does not pass, the token(s) are not replaced when the failure is output to the console.

## 🔖 Changes

- Tracked the current interpolated test name in shared state so assertions can reuse it when formatting failure labels.

- Updated `helper::normalize_test_function_name` to fall back to the stored interpolated name whenever the original function name still contains provider placeholders.

- Adjusted the runner to set and clear the interpolated name around each test invocation so failure reporting sees the right value.

- Added a regression unit test that exercises normalization when the interpolated name is supplied via state.

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
