### PR TITLE
fix: add compatibility with older python versions for clock::now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix bench tests missing test_file var
+- Fix compatibility with older python versions for clock::now
 
 ## [0.25.0](https://github.com/TypedDevs/bashunit/compare/0.23.0...0.24.0) - 2025-10-05
 

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -76,7 +76,7 @@ function clock::now() {
     python)
       python - <<'EOF'
 import time, sys
-sys.stdout.write(str(int(time.time() * 1_000_000_000)))
+sys.stdout.write(str(int(time.time() * 1000000000)))
 EOF
       ;;
     node)


### PR DESCRIPTION
## 📚 Description

PEP 515 (Underscores in Numeric Literals) is supported only in Python 3.6+.

## 🔖 Changes

- Replace the PEP 515 notation `1_000_000_000` with the plain number `1000000000`.
  - https://peps.python.org/pep-0515/

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
