### PR TITLE
Add assert_unsuccessful_code function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add `assert_unsuccessful_code` assertion to check for non-zero exit codes
 - Fix bench tests missing test_file var
 - Fix compatibility with older python versions for clock::now
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -333,7 +333,7 @@ Reports an error if the exit code of `callable` is not equal to `expected`.
 
 If `callable` is not provided, it takes the last executed command or function instead.
 
-[assert_successful_code](#assert-successful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
+[assert_successful_code](#assert-successful-code), [assert_unsuccessful_code](#assert-unsuccessful-code), [assert_general_error](#assert-general-error) and [assert_command_not_found](#assert-command-not-found)
 are more semantic versions of this assertion, for which you don't need to specify an exit code.
 
 ::: code-group
@@ -449,6 +449,45 @@ function test_failure() {
   }
 
   assert_successful_code "$(foo)"
+}
+```
+:::
+
+## assert_unsuccessful_code
+> `assert_unsuccessful_code ["callable"]`
+
+Reports an error if the exit code of `callable` is not unsuccessful (non-zero).
+
+If `callable` is not provided, it takes the last executed command or function instead.
+
+[assert_exit_code](#assert-exit-code) is the full version of this assertion where you can specify the expected exit code.
+
+::: code-group
+```bash [Example]
+function test_success_with_callable() {
+  function foo() {
+    return 1
+  }
+
+  assert_unsuccessful_code "$(foo)"
+}
+
+function test_success_without_callable() {
+  function foo() {
+    return 2
+  }
+
+  foo # function took instead `callable`
+
+  assert_unsuccessful_code
+}
+
+function test_failure() {
+  function foo() {
+    return 0
+  }
+
+  assert_unsuccessful_code "$(foo)"
 }
 ```
 :::

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -378,6 +378,20 @@ function assert_successful_code() {
   state::add_assertions_passed
 }
 
+function assert_unsuccessful_code() {
+  local actual_exit_code=${3-"$?"}
+
+  if [[ "$actual_exit_code" -eq 0 ]]; then
+    local label
+    label="$(helper::normalize_test_function_name "${FUNCNAME[1]}")"
+    state::add_assertions_failed
+    console_results::print_failed_test "${label}" "${actual_exit_code}" "to be non-zero" "but was 0"
+    return
+  fi
+
+  state::add_assertions_passed
+}
+
 function assert_general_error() {
   local actual_exit_code=${3-"$?"}
   local expected_exit_code=1

--- a/tests/unit/assert_test.sh
+++ b/tests/unit/assert_test.sh
@@ -247,6 +247,24 @@ function test_unsuccessful_assert_successful_code() {
     "$(assert_successful_code "$(fake_function)")"
 }
 
+function test_successful_assert_unsuccessful_code() {
+  function fake_function() {
+    return 2
+  }
+
+  assert_empty "$(assert_unsuccessful_code "$(fake_function)")"
+}
+
+function test_unsuccessful_assert_unsuccessful_code() {
+  function fake_function() {
+    return 0
+  }
+
+  assert_same\
+    "$(console_results::print_failed_test "Unsuccessful assert unsuccessful code" "0" "to be non-zero" "but was 0")"\
+    "$(assert_unsuccessful_code "$(fake_function)")"
+}
+
 function test_successful_assert_general_error() {
   function fake_function() {
     return 1


### PR DESCRIPTION
## 📚 Description

Closes: https://github.com/TypedDevs/bashunit/issues/505 by @jrfnl 

 Add `assert_unsuccessful_code` assertion function to verify that a command or function exits with a non-zero exit code. This complements the existing `assert_successful_code` function, providing a semantic way to assert failures without needing to specify an exact exit code.

## 🔖 Changes

 - Add `assert_unsuccessful_code` function
    - Asserts that the exit code is non-zero (any value other than 0)
    - Follows the same pattern as `assert_successful_code`
    - Accepts optional callable parameter, defaults to `$?` if not provided
  - Add tests and documentation for it

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes
