### PR TITLE
Wrong displayed number of failed tests when error setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Stop executing remaining commands in `set_up`/`tear_down` after first failure
+- Count all tests as failed when `set_up_before_script` fails
 
 ## [0.27.0](https://github.com/TypedDevs/bashunit/compare/0.26.0...0.27.0) - 2025-11-26
 

--- a/src/learn.sh
+++ b/src/learn.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 
 ##
 # Interactive learning module for bashunit

--- a/tests/acceptance/bashunit_setup_before_script_error_test.sh
+++ b/tests/acceptance/bashunit_setup_before_script_error_test.sh
@@ -60,3 +60,30 @@ function test_bashunit_when_set_up_before_script_with_failing_command() {
   assert_contains "$assertions_summary" "$actual"
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
 }
+
+function test_bashunit_when_set_up_before_script_fails_with_multiple_tests() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_setup_before_script_fails_with_multiple_tests.sh
+  local fixture=$test_file
+
+  local header_line="Running $fixture"
+  local error_line="✗ Error: Set up before script"
+  local message_line="    Hook 'set_up_before_script' failed with exit code 1"
+  # When set_up_before_script fails, all test functions should be counted as failed
+  local tests_summary="Tests:      2 failed, 2 total"
+  local assertions_summary="Assertions: 0 failed, 0 total"
+
+  local actual_raw
+  set +e
+  actual_raw="$(./bashunit --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file")"
+  set -e
+
+  local actual
+  actual="$(printf "%s" "$actual_raw" | strip_ansi)"
+
+  assert_contains "$header_line" "$actual"
+  assert_contains "$error_line" "$actual"
+  assert_contains "$message_line" "$actual"
+  assert_contains "$tests_summary" "$actual"
+  assert_contains "$assertions_summary" "$actual"
+  assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+}

--- a/tests/acceptance/fixtures/test_bashunit_when_setup_before_script_fails_with_multiple_tests.sh
+++ b/tests/acceptance/fixtures/test_bashunit_when_setup_before_script_fails_with_multiple_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+  false
+}
+
+function test_asserting_foo_strings() {
+  assert_same "foo" "foo"
+}
+
+function test_asserting_bar_strings() {
+  assert_same "bar" "bar"
+}


### PR DESCRIPTION
## 📚 Description

Fixes https://github.com/TypedDevs/bashunit/issues/518 the displayed number of failed tests when `set_up_before_script` fails. Previously, only 1 failure was counted even when multiple tests couldn't run.

## 🔖 Changes

- Count all test/bench functions as failed when `set_up_before_script` fails
- Add tests to verify correct failure count with multiple tests

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
