### PR TITLE
Fix data providers don't work when changing directory in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Custom assertions now display the correct test function name in failure messages
+- Data providers now work when `set_up_before_script` changes directory
 
 ## [0.28.0](https://github.com/TypedDevs/bashunit/compare/0.27.0...0.28.0) - 2025-12-01
 

--- a/bashunit
+++ b/bashunit
@@ -34,6 +34,10 @@ declare -r BASHUNIT_VERSION="0.28.0"
 declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 export BASHUNIT_ROOT_DIR
 
+# Capture working directory at startup (before any test changes it)
+declare -r BASHUNIT_WORKING_DIR="$PWD"
+export BASHUNIT_WORKING_DIR
+
 source "$BASHUNIT_ROOT_DIR/src/dev/debug.sh"
 source "$BASHUNIT_ROOT_DIR/src/check_os.sh"
 source "$BASHUNIT_ROOT_DIR/src/str.sh"

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -130,6 +130,11 @@ function helper::decode_base64() {
 function helper::check_duplicate_functions() {
   local script="$1"
 
+  # Handle directory changes in set_up_before_script (issue #529)
+  if [[ ! -f "$script" && -n "${BASHUNIT_WORKING_DIR:-}" ]]; then
+    script="$BASHUNIT_WORKING_DIR/$script"
+  fi
+
   local filtered_lines
   filtered_lines=$(grep -E '^[[:space:]]*(function[[:space:]]+)?test[a-zA-Z_][a-zA-Z0-9_]*\s*\(\)\s*\{' "$script")
 
@@ -243,6 +248,12 @@ function helper::normalize_variable_name() {
 function helper::get_provider_data() {
   local function_name="$1"
   local script="$2"
+
+  # Handle directory changes in set_up_before_script (issue #529)
+  # If relative path doesn't exist, try with BASHUNIT_WORKING_DIR
+  if [[ ! -f "$script" && -n "${BASHUNIT_WORKING_DIR:-}" ]]; then
+    script="$BASHUNIT_WORKING_DIR/$script"
+  fi
 
   if [[ ! -f "$script" ]]; then
     return

--- a/tests/functional/provider_with_cd_test.sh
+++ b/tests/functional/provider_with_cd_test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for https://github.com/TypedDevs/bashunit/issues/529
+# Data providers should work even when set_up_before_script changes directory
+
+function set_up_before_script() {
+  cd "$(temp_dir)" || return 1
+}
+
+# @data_provider provide_data
+function test_data_provider_works_after_cd_in_set_up_before_script() {
+  local value="$1"
+
+  assert_equals "expected_value" "$value"
+}
+
+function provide_data() {
+  echo "expected_value"
+}


### PR DESCRIPTION
## 📚 Description

Fixes #529 - Data providers now work correctly when `set_up_before_script` changes the working directory.

When a test file uses `set_up_before_script` to change directories (e.g., `cd "$(temp_dir)"`), data providers were failing because the script path became relative to the new directory instead of the original working directory.

## 🔖 Changes

- Added `BASHUNIT_WORKING_DIR` environment variable to capture the original working directory at startup
- Updated `helper::get_provider_data()` to resolve script paths against the original working directory when relative paths fail
- Updated `helper::check_duplicate_functions()` with the same path resolution fix
- Added functional test to verify data providers work after directory changes

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes (N/A - bug fix with no user-facing API changes)