### PR TITLE
Add --preserve-env flag to use shell env only 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add bootstrap argument passing support via `--env "file.sh arg1 arg2"` or `BASHUNIT_BOOTSTRAP_ARGS` (fixes #546)
+- Add `--preserve-env` flag to skip `.env` loading and use shell environment only (fixes #546)
 - Add `--strict` flag to enable strict shell mode (`set -euo pipefail`) for tests (fixes #540)
 - Add `BASHUNIT_STRICT_MODE` configuration option (default: `false`)
 - Add `-R, --run-all` flag to run all assertions even when one fails (fixes #536)

--- a/bashunit
+++ b/bashunit
@@ -38,6 +38,14 @@ export BASHUNIT_ROOT_DIR
 declare -r BASHUNIT_WORKING_DIR="$PWD"
 export BASHUNIT_WORKING_DIR
 
+# Early scan for --preserve-env before loading env.sh
+for arg in "$@"; do
+  if [[ "$arg" == "--preserve-env" ]]; then
+    export BASHUNIT_PRESERVE_ENV=true
+    break
+  fi
+done
+
 source "$BASHUNIT_ROOT_DIR/src/dev/debug.sh"
 source "$BASHUNIT_ROOT_DIR/src/check_os.sh"
 source "$BASHUNIT_ROOT_DIR/src/str.sh"

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -62,6 +62,7 @@ bashunit test tests/ --parallel --simple
 | `--debug [file]` | Enable shell debug mode |
 | `--no-output` | Suppress all output |
 | `--strict` | Enable strict shell mode |
+| `--preserve-env` | Skip `.env` loading, use shell environment only |
 
 ### Standalone Assert
 
@@ -194,6 +195,24 @@ potential issues like uninitialized variables and unchecked command failures.
 ::: code-group
 ```bash [Example]
 bashunit test tests/ --strict
+```
+:::
+
+### Preserve Environment
+
+> `bashunit test --preserve-env`
+
+Skip loading the `.env` file and use the current shell environment only.
+
+By default, bashunit loads variables from `.env` which can override environment
+variables set in your shell. Use `--preserve-env` when you want to:
+- Run in CI/CD where environment is pre-configured
+- Override `.env` values with shell environment variables
+- Avoid `.env` interfering with your current settings
+
+::: code-group
+```bash [Example]
+BASHUNIT_SIMPLE_OUTPUT=true ./bashunit test tests/ --preserve-env
 ```
 :::
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,6 +310,24 @@ BASHUNIT_STRICT_MODE=true
 ```
 :::
 
+## Preserve environment
+
+> `BASHUNIT_PRESERVE_ENV=true|false`
+
+Skip loading the `.env` file and use the current shell environment only. `false` by default.
+
+By default, bashunit loads variables from `.env` which can override environment
+variables set in your shell. Enable this option when running in CI/CD pipelines
+or when you want shell environment variables to take precedence.
+
+Similar as using `--preserve-env` option on the [command line](/command-line#preserve-environment).
+
+::: code-group
+```bash [Example]
+BASHUNIT_PRESERVE_ENV=true ./bashunit tests/
+```
+:::
+
 <script setup>
 import pkg from '../package.json'
 </script>

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -115,6 +115,7 @@ Options:
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output
   --strict                    Enable strict shell mode (set -euo pipefail)
+  --preserve-env              Skip .env loading, use shell environment only
   -h, --help                  Show this help message
 
 Examples:
@@ -140,6 +141,7 @@ Options:
   -s, --simple                Simple output
   --detailed                  Detailed output (default)
   -vvv, --verbose             Show execution details
+  --preserve-env              Skip .env loading, use shell environment only
   -h, --help                  Show this help message
 
 Examples:

--- a/src/env.sh
+++ b/src/env.sh
@@ -2,10 +2,13 @@
 
 # shellcheck disable=SC2034
 
-set -o allexport
-# shellcheck source=/dev/null
-[[ -f ".env" ]] && source .env
-set +o allexport
+# Load .env file (skip if --preserve-env is used to keep shell environment intact)
+if [[ "${BASHUNIT_PRESERVE_ENV:-false}" != "true" ]]; then
+  set -o allexport
+  # shellcheck source=/dev/null
+  [[ -f ".env" ]] && source .env
+  set +o allexport
+fi
 
 _BASHUNIT_DEFAULT_DEFAULT_PATH="tests"
 _BASHUNIT_DEFAULT_BOOTSTRAP="tests/bootstrap.sh"
@@ -35,6 +38,7 @@ _BASHUNIT_DEFAULT_SHOW_SKIPPED="false"
 _BASHUNIT_DEFAULT_SHOW_INCOMPLETE="false"
 _BASHUNIT_DEFAULT_STRICT_MODE="false"
 _BASHUNIT_DEFAULT_STOP_ON_ASSERTION_FAILURE="true"
+_BASHUNIT_DEFAULT_PRESERVE_ENV="false"
 
 : "${BASHUNIT_PARALLEL_RUN:=${PARALLEL_RUN:=$_BASHUNIT_DEFAULT_PARALLEL_RUN}}"
 : "${BASHUNIT_SHOW_HEADER:=${SHOW_HEADER:=$_BASHUNIT_DEFAULT_SHOW_HEADER}}"
@@ -50,6 +54,7 @@ _BASHUNIT_DEFAULT_STOP_ON_ASSERTION_FAILURE="true"
 : "${BASHUNIT_SHOW_INCOMPLETE:=${SHOW_INCOMPLETE:=$_BASHUNIT_DEFAULT_SHOW_INCOMPLETE}}"
 : "${BASHUNIT_STRICT_MODE:=${STRICT_MODE:=$_BASHUNIT_DEFAULT_STRICT_MODE}}"
 : "${BASHUNIT_STOP_ON_ASSERTION_FAILURE:=${STOP_ON_ASSERTION_FAILURE:=$_BASHUNIT_DEFAULT_STOP_ON_ASSERTION_FAILURE}}"
+: "${BASHUNIT_PRESERVE_ENV:=${PRESERVE_ENV:=$_BASHUNIT_DEFAULT_PRESERVE_ENV}}"
 
 function bashunit::env::is_parallel_run_enabled() {
   [[ "$BASHUNIT_PARALLEL_RUN" == "true" ]]
@@ -111,6 +116,10 @@ function bashunit::env::is_stop_on_assertion_failure_enabled() {
   [[ "$BASHUNIT_STOP_ON_ASSERTION_FAILURE" == "true" ]]
 }
 
+function bashunit::env::is_preserve_env_enabled() {
+  [[ "$BASHUNIT_PRESERVE_ENV" == "true" ]]
+}
+
 function bashunit::env::active_internet_connection() {
   if [[ "${BASHUNIT_NO_NETWORK:-}" == "true" ]]; then
     return 1
@@ -162,6 +171,7 @@ function bashunit::env::print_verbose() {
     "BASHUNIT_VERBOSE"
     "BASHUNIT_STRICT_MODE"
     "BASHUNIT_STOP_ON_ASSERTION_FAILURE"
+    "BASHUNIT_PRESERVE_ENV"
   )
 
   local max_length=0

--- a/src/main.sh
+++ b/src/main.sh
@@ -84,6 +84,9 @@ function bashunit::main::cmd_test() {
       -R|--run-all)
         export BASHUNIT_STOP_ON_ASSERTION_FAILURE=false
         ;;
+      --preserve-env)
+        export BASHUNIT_PRESERVE_ENV=true
+        ;;
       *)
         raw_args+=("$1")
         ;;
@@ -201,6 +204,9 @@ function bashunit::main::cmd_bench() {
         ;;
       -vvv|--verbose)
         export BASHUNIT_VERBOSE=true
+        ;;
+      --preserve-env)
+        export BASHUNIT_PRESERVE_ENV=true
         ;;
       -h|--help)
         bashunit::console_header::print_bench_help

--- a/tests/acceptance/bashunit_preserve_env_test.sh
+++ b/tests/acceptance/bashunit_preserve_env_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function test_preserve_env_skips_dotenv_loading() {
+  # The project .env sets BASHUNIT_BOOTSTRAP="" which would override this
+  local output
+  output=$(BASHUNIT_BOOTSTRAP="tests/acceptance/fixtures/bootstrap_with_args.sh" \
+    BASHUNIT_BOOTSTRAP_ARGS="hello world" \
+    BASHUNIT_PRESERVE_ENV=true \
+    ./bashunit --no-parallel --simple \
+    tests/acceptance/fixtures/test_bootstrap_args.sh 2>&1) || true
+
+  assert_contains "All tests passed" "$output"
+}
+
+function test_preserve_env_via_flag() {
+  local output
+  output=$(BASHUNIT_BOOTSTRAP="tests/acceptance/fixtures/bootstrap_with_args.sh" \
+    BASHUNIT_BOOTSTRAP_ARGS="hello world" \
+    ./bashunit --no-parallel --simple --preserve-env \
+    tests/acceptance/fixtures/test_bootstrap_args.sh 2>&1) || true
+
+  assert_contains "All tests passed" "$output"
+}
+
+function test_without_preserve_env_loads_dotenv() {
+  # Without --preserve-env, the .env should be loaded
+  # This test verifies normal behavior still works
+  local output
+  output=$(./bashunit --no-parallel --simple --env "$TEST_ENV_FILE" \
+    tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh 2>&1) || true
+
+  assert_contains "All tests passed" "$output"
+}


### PR DESCRIPTION
## 📚 Description

Adds a `--preserve-env` flag that allows users to skip automatic `.env` file loading and use their shell environment variables instead. This is useful when you want to run tests with specific environment variables set in your shell without having them overwritten by the project's `.env` file.

Related #546

## 🔖 Changes

- Add `--preserve-env` flag to `bashunit` and `bashunit bench` commands
- Add early detection of `--preserve-env` in main script before `env.sh` is sourced
- Skip `.env` file loading when `BASHUNIT_PRESERVE_ENV=true`
- Add `BASHUNIT_PRESERVE_ENV` configuration variable with default value `false`
- Add `bashunit::env::is_preserve_env_enabled()` helper function
- Include `BASHUNIT_PRESERVE_ENV` in verbose output
- Add acceptance tests for the new flag

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes