### PR TITLE
Document bootstrap argument passing pattern

### DIFF
--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -46,7 +46,7 @@ bashunit test tests/ --parallel --simple
 | Option | Description |
 |--------|-------------|
 | `-a, --assert <fn> <args>` | Run a standalone assert function |
-| `-e, --env, --boot <file>` | Load custom env/bootstrap file |
+| `-e, --env, --boot <file>` | Load custom env/bootstrap file (supports args) |
 | `-f, --filter <name>` | Only run tests matching name |
 | `--log-junit <file>` | Write JUnit XML report |
 | `-p, --parallel` | Run tests in parallel (default) |
@@ -93,6 +93,42 @@ Run only tests matching the given name.
 bashunit test tests/ --filter "user_login"
 ```
 :::
+
+### Environment / Bootstrap
+
+> `bashunit test -e|--env|--boot <file>`
+> `bashunit test --env "file arg1 arg2"`
+
+Load a custom environment or bootstrap file before running tests.
+
+::: code-group
+```bash [Basic usage]
+bashunit test --env tests/bootstrap.sh tests/
+```
+```bash [With arguments]
+# Pass arguments to the bootstrap file
+bashunit test --env "tests/bootstrap.sh staging verbose" tests/
+```
+:::
+
+Arguments are available as positional parameters (`$1`, `$2`, etc.) in your bootstrap script:
+
+```bash
+#!/usr/bin/env bash
+# tests/bootstrap.sh
+ENVIRONMENT="${1:-production}"
+VERBOSE="${2:-false}"
+
+export API_URL="https://${ENVIRONMENT}.api.example.com"
+```
+
+You can also set arguments via environment variable:
+
+```bash
+BASHUNIT_BOOTSTRAP_ARGS="staging verbose" bashunit test tests/
+```
+
+See [Configuration: Bootstrap](/configuration#bootstrap) for more details.
 
 ### Inline Filter Syntax
 
@@ -263,7 +299,7 @@ bashunit bench --filter "parse"
 
 | Option | Description |
 |--------|-------------|
-| `-e, --env, --boot <file>` | Load custom env/bootstrap file |
+| `-e, --env, --boot <file>` | Load custom env/bootstrap file (supports args) |
 | `-f, --filter <name>` | Only run benchmarks matching name |
 | `-s, --simple` | Simple output |
 | `--detailed` | Detailed output (default) |

--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -660,6 +660,52 @@ export DB_NAME=test_db
 ```
 :::
 
+### Bootstrap Files with Arguments
+
+Pass configuration to your bootstrap file for different test scenarios:
+
+::: code-group
+```bash [tests/bootstrap.sh]
+#!/usr/bin/env bash
+
+# Receive arguments passed to bootstrap
+ENVIRONMENT="${1:-production}"
+VERBOSE="${2:-false}"
+
+# Configure based on environment
+case "$ENVIRONMENT" in
+  staging)
+    export API_URL="https://staging.api.example.com"
+    export DB_NAME="test_staging_db"
+    ;;
+  ci)
+    export API_URL="https://ci.api.example.com"
+    export DB_NAME="test_ci_db"
+    ;;
+  *)
+    export API_URL="https://api.example.com"
+    export DB_NAME="test_db"
+    ;;
+esac
+
+[[ "$VERBOSE" == "true" ]] && export LOG_LEVEL=debug
+```
+
+```bash [Run with arguments]
+# Pass arguments inline with --env
+./bashunit --env "tests/bootstrap.sh staging true" tests/
+
+# Or via environment variable
+BASHUNIT_BOOTSTRAP_ARGS="staging true" ./bashunit tests/
+```
+:::
+
+::: tip
+Use bootstrap arguments to avoid duplicating bootstrap files for different
+environments. A single bootstrap file can configure staging, CI, or local
+development based on the arguments passed.
+:::
+
 ## Testing Private Functions
 
 When you need to test functions that aren't exported:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -237,6 +237,33 @@ BASHUNIT_BOOTSTRAP="tests/bootstrap.sh"
 ```
 :::
 
+## Bootstrap arguments
+
+> `BASHUNIT_BOOTSTRAP_ARGS=arguments`
+
+Pass arguments to the bootstrap file. Arguments are space-separated and available
+as positional parameters (`$1`, `$2`, etc.) in your bootstrap script.
+
+::: code-group
+```bash [.env]
+BASHUNIT_BOOTSTRAP="tests/bootstrap.sh"
+BASHUNIT_BOOTSTRAP_ARGS="staging verbose"
+```
+```bash [bootstrap.sh]
+#!/usr/bin/env bash
+ENVIRONMENT="${1:-production}"
+VERBOSE="${2:-false}"
+
+export API_URL="https://${ENVIRONMENT}.api.example.com"
+```
+:::
+
+You can also pass arguments inline via the [--env](/command-line#environment) option:
+
+```bash
+bashunit --env "tests/bootstrap.sh staging verbose" tests/
+```
+
 ## Dev log
 
 > `BASHUNIT_DEV_LOG=file`


### PR DESCRIPTION
## 📚 Description

Documents the bootstrap argument passing pattern in the common-patterns documentation, providing practical examples for configuring test environments dynamically.

Related https://github.com/TypedDevs/bashunit/issues/546

## 🔖 Changes

- Add documentation for passing arguments to bootstrap files via `BASHUNIT_BOOTSTRAP_ARGS` environment variable
- Include example showing environment-based configuration (staging, CI, production)
- Document both `--env` inline syntax and environment variable approaches
- Add tip about avoiding bootstrap file duplication for different environments

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes