### PR TITLE
Improve assert display result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     - All `assert_*` functions remain unchanged (public API)
 
 ### Fixed
+- Improve `assert` command output: show `assert <fn>` instead of internal function name in failure messages
 - Custom assertions now display the correct test function name in failure messages
 - Data providers now work when `set_up_before_script` changes directory
 - Subsequent test files now run when `set_up_before_script` changes directory

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -37,7 +37,7 @@ The prefix `assert_` is optional.
 ./bashunit -a not_equals "foo" "foo"
 ```
 ```[Output]
-✗ Failed: Main::exec not_equals
+✗ Failed: assert not_equals
     Expected 'foo'
     but got  'foo'
 ```
@@ -88,7 +88,7 @@ This way you can control the FD and redirect the output as you need.
 Testing.php:3:Method Testing::bar() has no return type specified.
 ```
 ```[/tmp/error.log]
-✗ Failed: Main::exec assert
+✗ Failed: assert exit_code
     Expected '0'
     but got  '1'
 ```

--- a/src/main.sh
+++ b/src/main.sh
@@ -496,6 +496,9 @@ function bashunit::main::exec_assert() {
     assert_fn="assert_same"
   fi
 
+  # Set a friendly test title for CLI assert command output
+  bashunit::state::set_test_title "assert ${original_assert_fn#assert_}"
+
   # Run the assertion function and write into stderr
   "$assert_fn" "${args[@]}" 1>&2
   bashunit_exit_code=$?

--- a/tests/acceptance/bashunit_direct_fn_call_test.sh
+++ b/tests/acceptance/bashunit_direct_fn_call_test.sh
@@ -106,7 +106,7 @@ function test_bashunit_assert_exit_code_error_with_inner_func() {
   assert_empty "$output"
 
   assert_file_contains "$temp" \
-    "$(bashunit::console_results::print_failed_test "Main::exec assert" "0" "to be" "1")"
+    "$(bashunit::console_results::print_failed_test "assert exit_code" "0" "to be" "1")"
 }
 
 function test_bashunit_assert_exit_code_str_successful_code() {
@@ -127,7 +127,7 @@ function test_bashunit_assert_exit_code_str_successful_but_exit_code_error() {
   assert_same "something to stdout" "$output"
 
   assert_file_contains "$temp" \
-    "$(bashunit::console_results::print_failed_test "Main::exec assert" "1" "but got " "0")"
+    "$(bashunit::console_results::print_failed_test "assert exit_code" "1" "but got " "0")"
 }
 
 # shellcheck disable=SC2155

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
-[31m✗ Failed[0m: Bashunit::main::exec assert
+[31m✗ Failed[0m: assert same
     [2mExpected[0m [1m'foo'[0m
     [2mbut got [0m [1m'bar'[0m


### PR DESCRIPTION
## 📚 Description

Improves the `assert` subcommand output by showing user-friendly assertion names instead of internal function names in failure messages.

Before: `✗ Failed: Main::exec assert` or `✗ Failed: Bashunit::main::exec assert`
After: `✗ Failed: assert same` or `✗ Failed: assert exit_code`

## 🔖 Changes

- Set a friendly test title for CLI assert command output using `bashunit::state::set_test_title`
- Updated documentation in `docs/standalone.md` to reflect the new output format
- Updated tests and snapshots to match the new assertion output format

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes