### PR TITLE
Reporting display mins over 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Display execution time in minutes format when tests run over 60 seconds (e.g., "2m 1s")
+
 ### Fixed
 - Internal flaky tests when running `--strict`
 - Visible stdout/stderr during normal execution `set_up_before_script` and `tear_down_after_script`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,11 @@ BASHUNIT_HEADER_ASCII_ART=true
 
 Specify if you want to display the execution time after running **bashunit**. `true` by default.
 
+The time format adapts based on duration:
+- Under 1 second: displayed in milliseconds (e.g., `14 ms`)
+- 1-59 seconds: displayed in seconds (e.g., `5 s`)
+- 60+ seconds: displayed in minutes and seconds (e.g., `2m 1s`)
+
 ::: code-group
 ```-vue [With execution time]
 ✓ Passed: foo bar

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -127,6 +127,15 @@ function bashunit::console_results::print_execution_time() {
   fi
 
   local time_in_seconds=$(( time / 1000 ))
+
+  if [[ "$time_in_seconds" -ge 60 ]]; then
+    local minutes=$(( time_in_seconds / 60 ))
+    local seconds=$(( time_in_seconds % 60 ))
+    printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
+      "Time taken: ${minutes}m ${seconds}s"
+    return
+  fi
+
   local remainder_ms=$(( time % 1000 ))
   local formatted_seconds=$(echo "$time_in_seconds.$remainder_ms" | awk '{printf "%.0f", $1}')
 

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -320,7 +320,7 @@ function test_render_execution_time() {
 
     bashunit::console_results::render_result || true
   )
-  assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? (ms|s)" "$render_result"
+  assert_matches "Time taken: ([[:digit:]]+(\.[[:digit:]]+)? (ms|s)|[[:digit:]]+m [[:digit:]]+s)" "$render_result"
 }
 
 function test_not_render_execution_time() {
@@ -349,7 +349,7 @@ function test_render_execution_time_on_osx_without_perl() {
     bashunit::console_results::render_result || true
   )
 
-  assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? (ms|s)" "$render_result"
+  assert_matches "Time taken: ([[:digit:]]+(\.[[:digit:]]+)? (ms|s)|[[:digit:]]+m [[:digit:]]+s)" "$render_result"
 }
 
 function test_render_execution_time_on_osx_with_perl() {
@@ -371,6 +371,28 @@ function test_render_execution_time_on_osx_with_perl() {
   )
 
   assert_matches "Time taken: [[:digit:]]+(\.[[:digit:]]+)? ms" "$render_result"
+}
+
+function test_render_execution_time_in_minutes() {
+  local render_result
+  render_result=$(
+    # shellcheck disable=SC2034
+    BASHUNIT_SHOW_EXECUTION_TIME=true
+    bashunit::mock bashunit::clock::total_runtime_in_milliseconds echo "121000"
+    bashunit::console_results::print_execution_time
+  )
+  assert_matches "Time taken: 2m 1s" "$render_result"
+}
+
+function test_render_execution_time_in_minutes_exact_minute() {
+  local render_result
+  render_result=$(
+    # shellcheck disable=SC2034
+    BASHUNIT_SHOW_EXECUTION_TIME=true
+    bashunit::mock bashunit::clock::total_runtime_in_milliseconds echo "120000"
+    bashunit::console_results::print_execution_time
+  )
+  assert_matches "Time taken: 2m 0s" "$render_result"
 }
 
 function test_render_file_with_duplicated_functions_if_found_true() {


### PR DESCRIPTION
## 📚 Description

Display execution time in minutes and seconds format when test suite runs for 60 seconds or more.
Closes: https://github.com/TypedDevs/bashunit/issues/366 

## 🔖 Changes

- Add minutes format display for execution times >= 60 seconds (e.g., "2m 1s")
- Update existing seconds/milliseconds display to handle the new threshold
- Add unit tests for minutes display format
- Update documentation to describe all time format variations

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes

## 🖼️  Demo

#### Even for single tests 
CC @carlfriedrich

<img width="805" height="534" alt="Screenshot 2025-12-09 at 13 09 25" src="https://github.com/user-attachments/assets/7879fc8c-3ade-4f94-98f7-44ba6d863db4" />
