### PR TITLE
Add --no-progress flag to suppress real-time progress display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
     - Helps debug test failures without manually capturing output
     - Enabled by default; use `--no-output-on-failure` or `BASHUNIT_SHOW_OUTPUT_ON_FAILURE=false` to disable
     - New CLI options: `--show-output`, `--no-output-on-failure`
+- Add `--no-progress` flag to suppress real-time progress display (Issue #503)
+    - Hides per-test output, file headers, hook messages, and spinner during execution
+    - Shows only the final test summary
+    - Useful for CI/CD pipelines or log-restricted environments
+    - Can also be set via `BASHUNIT_NO_PROGRESS=true` environment variable
 
 ## [0.32.0](https://github.com/TypedDevs/bashunit/compare/0.31.0...0.32.0) - 2026-01-12
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -69,6 +69,7 @@ bashunit test tests/ --parallel --simple
 | `--debug [file]`               | Enable shell debug mode                          |
 | `--no-output`                  | Suppress all output                              |
 | `--failures-only`              | Only show failures                               |
+| `--no-progress`                | Suppress real-time progress, show only summary   |
 | `--show-output`                | Show test output on failure (default)            |
 | `--no-output-on-failure`       | Hide test output on failure                      |
 | `--strict`                     | Enable strict shell mode                         |
@@ -257,6 +258,39 @@ bashunit test tests/ --no-output-on-failure
       Debug: Setting up test
       Running command: my_command
       /path/to/test.sh: line 5: my_command: command not found
+```
+:::
+
+### No Progress
+
+> `bashunit test --no-progress`
+
+Suppress real-time progress display during test execution, showing only the final summary.
+
+When enabled, bashunit hides:
+- Per-test output (pass/fail messages or dots)
+- File headers ("Running tests/...")
+- Hook completion messages
+- Spinner during parallel execution
+
+The final summary with test counts and results is still displayed.
+
+This is useful for:
+- CI/CD pipelines where streaming output causes issues
+- Log-restricted environments
+- Reducing output noise when only the final result matters
+
+::: code-group
+```bash [Example]
+bashunit test tests/ --no-progress
+```
+```[Output]
+bashunit - 0.32.0 | Tests: 10
+Tests:      10 passed, 10 total
+Assertions: 25 passed, 25 total
+
+ All tests passed
+Time taken: 1.23s
 ```
 :::
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -347,6 +347,23 @@ BASHUNIT_FAILURES_ONLY=true
 ```
 :::
 
+## No progress
+
+> `BASHUNIT_NO_PROGRESS=true|false`
+
+Suppress real-time progress display during test execution. `false` by default.
+
+When enabled, bashunit hides per-test output, file headers, hook messages, and spinners,
+showing only the final summary. Useful for CI/CD pipelines or log-restricted environments.
+
+Similar as using `--no-progress` option on the [command line](/command-line#no-progress).
+
+::: code-group
+```bash [Example]
+BASHUNIT_NO_PROGRESS=true
+```
+:::
+
 ## Show output on failure
 
 > `BASHUNIT_SHOW_OUTPUT_ON_FAILURE=true|false`

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -117,6 +117,7 @@ Options:
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output
   --failures-only             Only show failures (suppress passed/skipped/incomplete)
+  --no-progress               Suppress real-time progress, show only final results
   --show-output               Show test output on failure (default: enabled)
   --no-output-on-failure      Hide test output on failure
   --strict                    Enable strict shell mode (set -euo pipefail)

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -172,6 +172,10 @@ function bashunit::console_results::print_hook_completed() {
     return
   fi
 
+  if bashunit::env::is_no_progress_enabled; then
+    return
+  fi
+
   if bashunit::parallel::is_enabled; then
     return
   fi

--- a/src/env.sh
+++ b/src/env.sh
@@ -63,6 +63,7 @@ _BASHUNIT_DEFAULT_LOGIN_SHELL="false"
 _BASHUNIT_DEFAULT_FAILURES_ONLY="false"
 _BASHUNIT_DEFAULT_NO_COLOR="false"
 _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
+_BASHUNIT_DEFAULT_NO_PROGRESS="false"
 
 : "${BASHUNIT_PARALLEL_RUN:=${PARALLEL_RUN:=$_BASHUNIT_DEFAULT_PARALLEL_RUN}}"
 : "${BASHUNIT_SHOW_HEADER:=${SHOW_HEADER:=$_BASHUNIT_DEFAULT_SHOW_HEADER}}"
@@ -82,6 +83,7 @@ _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
 : "${BASHUNIT_LOGIN_SHELL:=${LOGIN_SHELL:=$_BASHUNIT_DEFAULT_LOGIN_SHELL}}"
 : "${BASHUNIT_FAILURES_ONLY:=${FAILURES_ONLY:=$_BASHUNIT_DEFAULT_FAILURES_ONLY}}"
 : "${BASHUNIT_SHOW_OUTPUT_ON_FAILURE:=${SHOW_OUTPUT_ON_FAILURE:=$_BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE}}"
+: "${BASHUNIT_NO_PROGRESS:=${NO_PROGRESS:=$_BASHUNIT_DEFAULT_NO_PROGRESS}}"
 # Support NO_COLOR standard (https://no-color.org)
 if [[ -n "${NO_COLOR:-}" ]]; then
   BASHUNIT_NO_COLOR="true"
@@ -163,6 +165,10 @@ function bashunit::env::is_failures_only_enabled() {
 
 function bashunit::env::is_show_output_on_failure_enabled() {
   [[ "$BASHUNIT_SHOW_OUTPUT_ON_FAILURE" == "true" ]]
+}
+
+function bashunit::env::is_no_progress_enabled() {
+  [[ "$BASHUNIT_NO_PROGRESS" == "true" ]]
 }
 
 function bashunit::env::is_no_color_enabled() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -88,6 +88,9 @@ function bashunit::main::cmd_test() {
       --no-output-on-failure)
         export BASHUNIT_SHOW_OUTPUT_ON_FAILURE=false
         ;;
+      --no-progress)
+        export BASHUNIT_NO_PROGRESS=true
+        ;;
       --strict)
         export BASHUNIT_STRICT_MODE=true
         ;;

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -153,6 +153,12 @@ function bashunit::runner::spinner() {
     return
   fi
 
+  # Don't show spinner in no-progress mode
+  if bashunit::env::is_no_progress_enabled; then
+    while true; do sleep 1; done
+    return
+  fi
+
   if bashunit::env::is_simple_output_enabled; then
     printf "\n"
   fi
@@ -366,6 +372,11 @@ function bashunit::runner::render_running_file_header() {
 
   # Suppress file headers in failures-only mode
   if bashunit::env::is_failures_only_enabled; then
+    return
+  fi
+
+  # Suppress file headers in no-progress mode
+  if bashunit::env::is_no_progress_enabled; then
     return
   fi
 
@@ -1011,6 +1022,7 @@ function bashunit::runner::run_tear_down_after_script() {
     # Add blank line after tests if no tear_down hook
     if ! bashunit::env::is_simple_output_enabled && \
         ! bashunit::env::is_failures_only_enabled && \
+        ! bashunit::env::is_no_progress_enabled && \
         ! bashunit::parallel::is_enabled; then
       echo ""
     fi
@@ -1037,6 +1049,7 @@ function bashunit::runner::run_tear_down_after_script() {
   # Add blank line after tear_down output
   if ! bashunit::env::is_simple_output_enabled && \
       ! bashunit::env::is_failures_only_enabled && \
+      ! bashunit::env::is_no_progress_enabled && \
       ! bashunit::parallel::is_enabled; then
     echo ""
   fi

--- a/src/state.sh
+++ b/src/state.sh
@@ -268,6 +268,10 @@ function bashunit::state::print_line() {
 
   bashunit::state::add_test_output "[$type]$line"
 
+  if bashunit::env::is_no_progress_enabled; then
+    return
+  fi
+
   if ! bashunit::env::is_simple_output_enabled; then
     printf "%s\n" "$line"
     return

--- a/tests/acceptance/bashunit_no_progress_test.sh
+++ b/tests/acceptance/bashunit_no_progress_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+}
+
+function test_no_progress_suppresses_test_output_in_detailed_mode() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+  local output
+
+  output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --no-progress "$test_file" 2>&1)
+
+  # Should NOT contain "Passed" (per-test progress output)
+  assert_not_contains "Passed" "$output"
+  # Should still show final summary
+  assert_contains "Tests:" "$output"
+  assert_contains "4 passed" "$output"
+}
+
+function test_no_progress_suppresses_test_output_in_simple_mode() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+  local output
+
+  output=$(./bashunit --no-parallel --simple --env "$TEST_ENV_FILE" --no-progress "$test_file" 2>&1)
+
+  # Should NOT contain dots for passed tests
+  assert_not_contains "...." "$output"
+  # Should still show final summary
+  assert_contains "Tests:" "$output"
+  assert_contains "4 passed" "$output"
+}
+
+function test_no_progress_suppresses_file_headers() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+  local output
+
+  output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --no-progress "$test_file" 2>&1)
+
+  # Should NOT contain "Running" file headers
+  assert_not_contains "Running" "$output"
+}
+
+function test_no_progress_shows_correct_counts_in_summary() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+  local output
+
+  output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --no-progress "$test_file" 2>&1)
+
+  # Summary should show passed count even though progress was suppressed
+  assert_contains "4 passed" "$output"
+  assert_contains "4 total" "$output"
+}
+
+function test_no_progress_still_shows_failures_in_summary() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+  local output
+
+  output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --no-progress "$test_file" 2>&1) || true
+
+  # Should still show failure summary
+  assert_contains "There was 1 failure" "$output"
+  assert_contains "Tests:" "$output"
+}
+
+function test_no_progress_via_env_variable() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
+  local output
+
+  output=$(BASHUNIT_NO_PROGRESS=true ./bashunit --no-parallel --skip-env-file "$test_file" 2>&1)
+
+  assert_not_contains "Passed" "$output"
+  assert_contains "4 passed" "$output"
+}


### PR DESCRIPTION
## 📚 Description

Add a new `--no-progress` flag that suppresses real-time progress display during test execution, showing only the final summary. This addresses Issue #503.

When enabled, bashunit hides:
- Per-test output (pass/fail messages or dots)
- File headers ("Running tests/...")
- Hook completion messages
- Spinner during parallel execution

The final summary with test counts and results is still displayed.

This is useful for:
- CI/CD pipelines where streaming output causes issues
- Log-restricted environments
- Reducing output noise when only the final result matters

## 🔖 Changes

- Add `--no-progress` CLI flag in `src/main.sh`
- Add `BASHUNIT_NO_PROGRESS` environment variable support in `src/env.sh`
- Add `bashunit::env::is_no_progress_enabled` helper function
- Suppress per-test output in `src/state.sh` when flag is enabled
- Suppress file headers in `src/runner.sh` when flag is enabled
- Suppress hook completion messages in `src/console_results.sh` when flag is enabled
- Suppress spinner in `src/runner.sh` when flag is enabled
- Add help text for the new option in `src/console_header.sh`
- Add comprehensive acceptance tests in `tests/acceptance/bashunit_no_progress_test.sh`
- Update documentation in `docs/command-line.md` and `docs/configuration.md`
- Update `CHANGELOG.md` with the new feature

## ✅ To-do list

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [x] I updated the documentation to reflect the changes