### PR TITLE
fix(runner): honour --stop-on-failure on runtime errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow most assert functions to accept an optional trailing label parameter to override the failure message title (e.g. `assert_same "a" "$b" "checking user name"`) (#77)
 
 ### Fixed
+- Fix `--stop-on-failure` not stopping when a test errors with a runtime error (e.g. `command not found`, `illegal option`) (#383)
 - Fix spying on `echo` or `printf` causing bashunit to hang due to infinite recursion (#607)
 - Fix invalid `.env.example` coverage threshold entry and copy `.env.example` to `.env` in CI test workflows so configuration parse errors are caught during automated test runs
 - Fix `clock::now` shell-time parsing when `EPOCHREALTIME` uses a comma decimal separator

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -782,6 +782,14 @@ function bashunit::runner::run_test() {
     bashunit::reports::add_test_failed "$test_file" "$failure_label" "$duration" "$total_assertions" "$error_message"
     bashunit::runner::write_failure_result_output "$test_file" "$failure_function" "$error_message" "$runtime_output"
     bashunit::internal_log "Test error" "$failure_label" "$error_message"
+
+    if bashunit::env::is_stop_on_failure_enabled; then
+      if bashunit::parallel::is_enabled; then
+        bashunit::parallel::mark_stop_on_failure
+      else
+        exit "$EXIT_CODE_STOP_ON_FAILURE"
+      fi
+    fi
     return
   fi
 

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -31,3 +31,13 @@ function test_bashunit_when_stop_on_failure_env_simple_output() {
   assert_match_snapshot "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_STOP_ON_FAILURE" "$test_file" --simple)"
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_STOP_ON_FAILURE" "$test_file" --simple)"
 }
+
+function test_bashunit_stop_on_failure_with_runtime_error() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_stop_on_failure_runtime_error.sh
+  local output
+  output="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --stop-on-failure "$test_file")"
+
+  assert_general_error "$?"
+  assert_contains "A runtime error" "$output"
+  assert_not_contains "B not executed" "$output"
+}

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -34,10 +34,12 @@ function test_bashunit_when_stop_on_failure_env_simple_output() {
 
 function test_bashunit_stop_on_failure_with_runtime_error() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_stop_on_failure_runtime_error.sh
-  local output
-  output="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --stop-on-failure "$test_file")"
+  local output=""
+  local exit_code=0
 
-  assert_general_error "$?"
+  output="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --stop-on-failure "$test_file")" || exit_code=$?
+
+  assert_same 1 "$exit_code"
   assert_contains "A runtime error" "$output"
   assert_not_contains "B not executed" "$output"
 }

--- a/tests/acceptance/fixtures/test_bashunit_stop_on_failure_runtime_error.sh
+++ b/tests/acceptance/fixtures/test_bashunit_stop_on_failure_runtime_error.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function test_a_runtime_error() {
+  nonexistent_command_bashunit_383_xyz
+}
+
+function test_b_not_executed() {
+  assert_same 1 1
+}


### PR DESCRIPTION
## Summary
- Runtime errors (e.g. `command not found`, `illegal option`, `unbound variable`) were not stopping the runner when `--stop-on-failure` / `BASHUNIT_STOP_ON_FAILURE=true` was enabled. Only assertion failures triggered the stop.
- The runtime-error branch in `bashunit::runner::process_test_result` now checks `bashunit::env::is_stop_on_failure_enabled` and exits (or marks the parallel runner) the same way the assertion-failure branch does.

Closes #383
