### PR TITLE
fix(parallel): enable parallel test execution on Alpine Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,7 +194,7 @@ jobs:
         run: |
           docker run --rm -v "$(pwd)":/project alpine:latest /bin/sh -c " \
             apk update && \
-            apk add --no-cache bash make git jq coreutils && \
+            apk add --no-cache bash make git jq && \
             adduser -D builder && \
             chown -R builder /project && \
             su - builder -c 'cd /project; ${{ matrix.command }}';"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,9 +168,19 @@ jobs:
         run: ./bashunit --parallel --jobs 4 ${{ matrix.test_path }}
 
   alpine:
-    name: "Alpine - latest"
+    name: "Alpine - ${{ matrix.name }}"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "sequential"
+            command: "make test"
+          - name: "parallel simple"
+            command: "./bashunit --parallel --simple tests/"
+          - name: "parallel extended"
+            command: "./bashunit --parallel tests/"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -184,7 +194,7 @@ jobs:
         run: |
           docker run --rm -v "$(pwd)":/project alpine:latest /bin/sh -c " \
             apk update && \
-            apk add --no-cache bash make git jq && \
+            apk add --no-cache bash make git jq coreutils && \
             adduser -D builder && \
             chown -R builder /project && \
-            su - builder -c 'cd /project; make test';"
+            su - builder -c 'cd /project; ${{ matrix.command }}';"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix invalid `.env.example` coverage threshold entry and copy `.env.example` to `.env` in CI test workflows so configuration parse errors are caught during automated test runs
 - Fix `clock::now` shell-time parsing when `EPOCHREALTIME` uses a comma decimal separator
 - Fix LCOV and HTML coverage reports generating incomplete/empty output due to post-increment operator causing silent exit under `set -e` (#618)
+- Enable parallel test execution on Alpine Linux; previously gated off due to race conditions, now resolved (#370)
 
 ## [0.34.1](https://github.com/TypedDevs/bashunit/compare/0.34.0...0.34.1) - 2026-03-20
 

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -135,7 +135,8 @@ function bashunit::parallel::is_enabled() {
     "requested:$BASHUNIT_PARALLEL_RUN" "os:${_BASHUNIT_OS:-Unknown}"
 
   if bashunit::env::is_parallel_run_enabled &&
-    (bashunit::check_os::is_macos || bashunit::check_os::is_ubuntu || bashunit::check_os::is_windows); then
+    (bashunit::check_os::is_macos || bashunit::check_os::is_ubuntu ||
+      bashunit::check_os::is_alpine || bashunit::check_os::is_windows); then
     return 0
   fi
   return 1

--- a/tests/unit/parallel_test.sh
+++ b/tests/unit/parallel_test.sh
@@ -77,6 +77,16 @@ function test_parallel_enabled_on_ubuntu() {
   bashunit::mock bashunit::check_os::is_windows mock_false
   bashunit::mock bashunit::check_os::is_macos mock_false
   bashunit::mock bashunit::check_os::is_ubuntu mock_true
+  bashunit::mock bashunit::check_os::is_alpine mock_false
+
+  assert_successful_code "$(bashunit::parallel::is_enabled)"
+}
+
+function test_parallel_enabled_on_alpine() {
+  bashunit::mock bashunit::check_os::is_windows mock_false
+  bashunit::mock bashunit::check_os::is_macos mock_false
+  bashunit::mock bashunit::check_os::is_ubuntu mock_false
+  bashunit::mock bashunit::check_os::is_alpine mock_true
 
   assert_successful_code "$(bashunit::parallel::is_enabled)"
 }
@@ -93,6 +103,7 @@ function test_parallel_disabled_on_unsupported_os() {
   bashunit::mock bashunit::check_os::is_windows mock_false
   bashunit::mock bashunit::check_os::is_macos mock_false
   bashunit::mock bashunit::check_os::is_ubuntu mock_false
+  bashunit::mock bashunit::check_os::is_alpine mock_false
 
   assert_general_error "$(bashunit::parallel::is_enabled)"
 }


### PR DESCRIPTION
## Summary
- Enable Alpine Linux in `parallel::is_enabled` — prior race conditions were resolved by later parallel hardening (8c7212d and follow-ups).
- Add unit test `test_parallel_enabled_on_alpine` and extend existing tests to mock `is_alpine`.
- Add Alpine CI matrix with `parallel simple` and `parallel extended` jobs so regressions surface immediately.

## Test plan
- [x] `./bashunit tests/unit/parallel_test.sh` — all green
- [x] `./bashunit --parallel tests/` on macOS — all green
- [x] Alpine Docker `--parallel --simple tests/unit/` — 694 passed, 0 failed (9s vs 32s sequential; 3.5x speedup)
- [x] Alpine Docker `--parallel tests/` — 926 passed, 0 failed (exit 0)
- [x] `make sa && make lint` pass
- [x] `shfmt -d` clean

Closes #370