### PR TITLE
fix(cli): render dim labels with gray so colors show in GitHub Actions (#323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Parallel test execution is now enabled on Alpine Linux (#370)
 
 ### Fixed
+- Dim/faint labels now render as gray (SGR 90) so keywords like `Expected` and `Tests:` stay colored in GitHub Actions logs (#323)
 - Syntax error in a test file now fails the suite instead of passing silently (#220)
 - `--stop-on-failure` now stops on runtime errors such as `command not found` or `illegal option` (#383)
 - Spying on `echo` or `printf` no longer hangs via infinite recursion (#607)

--- a/src/colors.sh
+++ b/src/colors.sh
@@ -37,7 +37,9 @@ if bashunit::env::is_no_color_enabled; then
   _BASHUNIT_COLOR_DEFAULT=""
 else
   _BASHUNIT_COLOR_BOLD="$(bashunit::sgr 1)"
-  _BASHUNIT_COLOR_FAINT="$(bashunit::sgr 2)"
+  # Use SGR 90 (bright black / gray) instead of SGR 2 (faint), since
+  # GitHub Actions' log renderer does not render the faint attribute.
+  _BASHUNIT_COLOR_FAINT="$(bashunit::sgr 90)"
   _BASHUNIT_COLOR_BLACK="$(bashunit::sgr 30)"
   _BASHUNIT_COLOR_FAILED="$(bashunit::sgr 31)"
   _BASHUNIT_COLOR_PASSED="$(bashunit::sgr 32)"

--- a/tests/acceptance/bashunit_execution_error_test.sh
+++ b/tests/acceptance/bashunit_execution_error_test.sh
@@ -10,7 +10,7 @@ function test_bashunit_when_a_execution_error() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
   local color_default="$(bashunit::sgr 0)"
   local color_bold="$(bashunit::sgr 1)"
-  local color_dim="$(bashunit::sgr 2)"
+  local color_dim="$(bashunit::sgr 90)"
   local color_red="$(bashunit::sgr 31)"
 
   function format_summary_title() {

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_advanced_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_advanced_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
 [31m✗ Failed[0m: assert same
-    [2mExpected[0m [1m'foo'[0m
-    [2mbut got [0m [1m'bar'[0m
+    [90mExpected[0m [1m'foo'[0m
+    [90mbut got [0m [1m'bar'[0m

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,3 @@
 [31m✗ Failed[0m: assert same
-    [2mExpected[0m [1m'foo'[0m
-    [2mbut got [0m [1m'bar'[0m
+    [90mExpected[0m [1m'foo'[0m
+    [90mbut got [0m [1m'bar'[0m

--- a/tests/acceptance/snapshots/bashunit_exit_code_test_sh.test_bashunit_when_a_test_returns_non_zero.snapshot
+++ b/tests/acceptance/snapshots/bashunit_exit_code_test_sh.test_bashunit_when_a_test_returns_non_zero.snapshot
@@ -1,12 +1,12 @@
 [1mRunning tests/acceptance/fixtures/test_bashunit_when_a_test_returns_non_zero.sh[0m
 [31m✗ Error[0m: Returns non zero
-    [2m[0m
+    [90m[0m
 
 [1mThere was 1 failure:[0m
 
 |1) tests/acceptance/fixtures/test_bashunit_when_a_test_returns_non_zero.sh:3
 
-[2mTests:     [0m [31m1 failed[0m, 1 total
-[2mAssertions:[0m [31m0 failed[0m, 0 total
+[90mTests:     [0m [31m1 failed[0m, 1 total
+[90mAssertions:[0m [31m0 failed[0m, 0 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_env.snapshot
@@ -4,14 +4,14 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
 |[31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'0'[0m
-|    [2mSource:[0m
-|    [2m13:[0m assert_same 1 0
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
 
 
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_option.snapshot
@@ -4,14 +4,14 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
 |[31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'0'[0m
-|    [2mSource:[0m
-|    [2m13:[0m assert_same 1 0
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
 
 
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -2,8 +2,8 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got [0m [1m'0'[0m
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'0'[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
@@ -11,12 +11,12 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
 |[31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'0'[0m
-|    [2mSource:[0m
-|    [2m13:[0m assert_same 1 0
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -2,8 +2,8 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 [31m✗ Failed[0m: Assert failing
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got [0m [1m'0'[0m
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'0'[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
@@ -11,12 +11,12 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
 |[31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'0'[0m
-|    [2mSource:[0m
-|    [2m13:[0m assert_same 1 0
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
 
-[2mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
-[2mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
@@ -1,12 +1,12 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh[0m
 [31m✗ Error[0m: Error
-    [2m[0m
+    [90m[0m
 
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh:3
 
-[2mTests:     [0m [31m1 failed[0m, 1 total
-[2mAssertions:[0m [31m0 failed[0m, 0 total
+[90mTests:     [0m [31m1 failed[0m, 1 total
+[90mAssertions:[0m [31m0 failed[0m, 0 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
@@ -1,24 +1,24 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh[0m
 [32m✓ Passed[0m: Assert same
 [31m✗ Failed[0m: Assert failing
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got [0m [1m'2'[0m
-[36m✒ Incomplete[0m: Assert todo and skip[2m    foo[0m
-[33m↷ Skipped[0m: Assert todo and skip[2m    bar[0m
-[33m↷ Skipped[0m: Assert skip and todo[2m    baz[0m
-[36m✒ Incomplete[0m: Assert skip and todo[2m    yei[0m
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'2'[0m
+[36m✒ Incomplete[0m: Assert todo and skip[90m    foo[0m
+[33m↷ Skipped[0m: Assert todo and skip[90m    bar[0m
+[33m↷ Skipped[0m: Assert skip and todo[90m    baz[0m
+[36m✒ Incomplete[0m: Assert skip and todo[90m    yei[0m
 
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh:7
 |[31m✗ Failed[0m: Assert failing
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'2'[0m
-|    [2mSource:[0m
-|    [2m8:[0m assert_same 1 2
-|    [2m9:[0m assert_same 3 4
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mSource:[0m
+|    [90m8:[0m assert_same 1 2
+|    [90m9:[0m assert_same 3 4
 
-[2mTests:     [0m [32m1 passed[0m, [33m0 skipped[0m, [36m2 incomplete[0m, [31m1 failed[0m, 4 total
-[2mAssertions:[0m [32m1 passed[0m, [33m2 skipped[0m, [36m2 incomplete[0m, [31m1 failed[0m, 6 total
+[90mTests:     [0m [32m1 passed[0m, [33m0 skipped[0m, [36m2 incomplete[0m, [31m1 failed[0m, 4 total
+[90mAssertions:[0m [32m1 passed[0m, [33m2 skipped[0m, [36m2 incomplete[0m, [31m1 failed[0m, 6 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_with_wildcard.snapshot
@@ -10,7 +10,7 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m6 passed[0m, 6 total
-[2mAssertions:[0m [32m9 passed[0m, 9 total
+[90mTests:     [0m [32m6 passed[0m, 6 total
+[90mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_directory.snapshot
@@ -10,7 +10,7 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m6 passed[0m, 6 total
-[2mAssertions:[0m [32m9 passed[0m, 9 total
+[90mTests:     [0m [32m6 passed[0m, 6 total
+[90mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
+++ b/tests/acceptance/snapshots/bashunit_find_tests_command_line_test_sh.test_all_tests_files_within_a_file.snapshot
@@ -2,7 +2,7 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
-[2mTests:     [0m [32m2 passed[0m, 2 total
-[2mAssertions:[0m [32m3 passed[0m, 3 total
+[90mTests:     [0m [32m2 passed[0m, 2 total
+[90mAssertions:[0m [32m3 passed[0m, 3 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -1,19 +1,19 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Failure
-    [2mExpected[0m [1m'2'[0m
-    [2mbut got [0m [1m'3'[0m
+    [90mExpected[0m [1m'2'[0m
+    [90mbut got [0m [1m'3'[0m
 
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7
 |[31m✗ Failed[0m: Failure
-|    [2mExpected[0m [1m'2'[0m
-|    [2mbut got [0m [1m'3'[0m
-|    [2mSource:[0m
-|    [2m8:[0m assert_same 2 3
+|    [90mExpected[0m [1m'2'[0m
+|    [90mbut got [0m [1m'3'[0m
+|    [90mSource:[0m
+|    [90m8:[0m assert_same 2 3
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -1,19 +1,19 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Failure
-    [2mExpected[0m [1m'2'[0m
-    [2mbut got [0m [1m'3'[0m
+    [90mExpected[0m [1m'2'[0m
+    [90mbut got [0m [1m'3'[0m
 
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7
 |[31m✗ Failed[0m: Failure
-|    [2mExpected[0m [1m'2'[0m
-|    [2mbut got [0m [1m'3'[0m
-|    [2mSource:[0m
-|    [2m8:[0m assert_same 2 3
+|    [90mExpected[0m [1m'2'[0m
+|    [90mbut got [0m [1m'3'[0m
+|    [90mSource:[0m
+|    [90m8:[0m assert_same 2 3
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m1 passed[0m, [31m1 failed[0m, 2 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_env.snapshot
@@ -1,6 +1,6 @@
 ....
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[90mTests:     [0m [32m4 passed[0m, 4 total
+[90mAssertions:[0m [32m6 passed[0m, 6 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_simple_output_option.snapshot
@@ -1,6 +1,6 @@
 ....
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[90mTests:     [0m [32m4 passed[0m, 4 total
+[90mAssertions:[0m [32m6 passed[0m, 6 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_env.snapshot
@@ -4,7 +4,7 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[90mTests:     [0m [32m4 passed[0m, 4 total
+[90mAssertions:[0m [32m6 passed[0m, 6 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_pass_test_sh.test_bashunit_when_a_test_passes_verbose_output_option.snapshot
@@ -4,7 +4,7 @@
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
-[2mTests:     [0m [32m4 passed[0m, 4 total
-[2mAssertions:[0m [32m6 passed[0m, 6 total
+[90mTests:     [0m [32m4 passed[0m, 4 total
+[90mAssertions:[0m [32m6 passed[0m, 6 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
@@ -1,4 +1,4 @@
-[2mTests:     [0m 0 total
-[2mAssertions:[0m 0 total
+[90mTests:     [0m 0 total
+[90mAssertions:[0m 0 total
 
 [41m[30m[1m No tests found [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_argument_path.snapshot
@@ -10,7 +10,7 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m6 passed[0m, 6 total
-[2mAssertions:[0m [32m9 passed[0m, 9 total
+[90mTests:     [0m [32m6 passed[0m, 6 total
+[90mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_with_env_default_path.snapshot
@@ -10,7 +10,7 @@
 [32m✓ Passed[0m: Assert same
 [32m✓ Passed[0m: Assert contains
 
-[2mTests:     [0m [32m6 passed[0m, 6 total
-[2mAssertions:[0m [32m9 passed[0m, 9 total
+[90mTests:     [0m [32m6 passed[0m, 6 total
+[90mAssertions:[0m [32m9 passed[0m, 9 total
 
 [42m[30m[1m All tests passed [0m

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -1,8 +1,8 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Fail
-    [2mExpected[0m [1m'to be empty'[0m
-    [2mbut got [0m [1m'non empty'[0m
+    [90mExpected[0m [1m'to be empty'[0m
+    [90mbut got [0m [1m'non empty'[0m
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
@@ -10,12 +10,12 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7
 |[31m✗ Failed[0m: Fail
-|    [2mExpected[0m [1m'to be empty'[0m
-|    [2mbut got [0m [1m'non empty'[0m
-|    [2mSource:[0m
-|    [2m8:[0m assert_empty "non empty"
+|    [90mExpected[0m [1m'to be empty'[0m
+|    [90mbut got [0m [1m'non empty'[0m
+|    [90mSource:[0m
+|    [90m8:[0m assert_empty "non empty"
 
-[2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
-[2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+[90mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+[90mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -1,8 +1,8 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh[0m
 [32m✓ Passed[0m: Success
 [31m✗ Failed[0m: Fail
-    [2mExpected[0m [1m'to be empty'[0m
-    [2mbut got [0m [1m'non empty'[0m
+    [90mExpected[0m [1m'to be empty'[0m
+    [90mbut got [0m [1m'non empty'[0m
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
@@ -10,12 +10,12 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7
 |[31m✗ Failed[0m: Fail
-|    [2mExpected[0m [1m'to be empty'[0m
-|    [2mbut got [0m [1m'non empty'[0m
-|    [2mSource:[0m
-|    [2m8:[0m assert_empty "non empty"
+|    [90mExpected[0m [1m'to be empty'[0m
+|    [90mbut got [0m [1m'non empty'[0m
+|    [90mSource:[0m
+|    [90m8:[0m assert_empty "non empty"
 
-[2mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
-[2mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+[90mTests:     [0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
+[90mAssertions:[0m [32m1 passed[0m, [33m1 skipped[0m, [36m1 incomplete[0m, [31m1 failed[0m, 4 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
@@ -1,22 +1,22 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
 [32m✓ Passed[0m: A success
 [31m✗ Failed[0m: B error
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got [0m [1m'2'[0m
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'2'[0m
 
 [33mStop on failure enabled...[0m
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6
 |[31m✗ Failed[0m: B error
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'2'[0m
-|    [2mSource:[0m
-|    [2m7:[0m assert_same 1 1
-|    [2m8:[0m assert_same 1 2 # error
-|    [2m9:[0m assert_same 2 2
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mSource:[0m
+|    [90m7:[0m assert_same 1 1
+|    [90m8:[0m assert_same 1 2 # error
+|    [90m9:[0m assert_same 2 2
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env_simple_output.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env_simple_output.snapshot
@@ -6,16 +6,16 @@
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6
 |[31m✗ Failed[0m: B error
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'2'[0m
-|    [2mSource:[0m
-|    [2m7:[0m assert_same 1 1
-|    [2m8:[0m assert_same 1 2 # error
-|    [2m9:[0m assert_same 2 2
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mSource:[0m
+|    [90m7:[0m assert_same 1 1
+|    [90m8:[0m assert_same 1 2 # error
+|    [90m9:[0m assert_same 2 2
 
 
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
@@ -1,22 +1,22 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
 [32m✓ Passed[0m: A success
 [31m✗ Failed[0m: B error
-    [2mExpected[0m [1m'1'[0m
-    [2mbut got [0m [1m'2'[0m
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'2'[0m
 
 [33mStop on failure enabled...[0m
 [1mThere was 1 failure:[0m
 
 |1) ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6
 |[31m✗ Failed[0m: B error
-|    [2mExpected[0m [1m'1'[0m
-|    [2mbut got [0m [1m'2'[0m
-|    [2mSource:[0m
-|    [2m7:[0m assert_same 1 1
-|    [2m8:[0m assert_same 1 2 # error
-|    [2m9:[0m assert_same 2 2
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mSource:[0m
+|    [90m7:[0m assert_same 1 1
+|    [90m8:[0m assert_same 1 2 # error
+|    [90m9:[0m assert_same 2 2
 
-[2mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
-[2mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
 
 [41m[30m[1m Some tests failed [0m

--- a/tests/unit/colors_test.sh
+++ b/tests/unit/colors_test.sh
@@ -36,3 +36,9 @@ function test_sgr_bold_code() {
 
   assert_equals $'\e[1m' "$result"
 }
+
+function test_faint_color_uses_bright_black_for_ci_compatibility() {
+  # SGR 2 (faint/dim) is not rendered by GitHub Actions log UI.
+  # Use SGR 90 (bright black / gray) which renders everywhere.
+  assert_same $'\e[90m' "$_BASHUNIT_COLOR_FAINT"
+}


### PR DESCRIPTION
## Summary
- Swap `_BASHUNIT_COLOR_FAINT` from SGR 2 (faint) to SGR 90 (bright black / gray) so keywords like `Expected`, `Tests:` and `Assertions:` stay colored in GitHub Actions logs, which don't render the faint attribute.
- Update the `bashunit_execution_error_test.sh` helper and the 27 acceptance snapshots that captured the previous `\e[2m` sequence.
- Add a regression test pinning `_BASHUNIT_COLOR_FAINT` to the gray code.

## Why
Per #323, `Expected` / `to contain` were colored locally on macOS/iTerm but invisible in GitHub Actions logs. The root cause is that the GitHub Actions web log renderer does not render SGR 2 (faint/dim). SGR 90 is supported everywhere and looks visually similar.

## Test plan

### BEFORE
<img width="549" height="66" alt="Screenshot 2026-04-19 at 16 31 58" src="https://github.com/user-attachments/assets/209bf5df-48b0-4f33-9113-4c5227685431" />

### AFTER
<img width="542" height="61" alt="Screenshot 2026-04-19 at 16 32 19" src="https://github.com/user-attachments/assets/873f0bf1-a42d-415e-817c-963d765cda34" />


Closes #323