### PR TITLE
fix(assert): reject empty bool assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `clock::now` handles `EPOCHREALTIME` values that use a comma decimal separator
 - Invalid `.env.example` coverage threshold entry; CI now copies `.env.example` to `.env` so config parse errors are caught
 - Coverage no longer counts case patterns with trailing comments (e.g. `*thing) # note`) or loop terminators with redirections/pipes (e.g. `done < file`, `done <<<"$var"`, `done | sort`) as executable lines (#634)
+- `assert_true` and `assert_false` now report empty strings as assertion failures instead of trying to execute them
 
 ## [0.34.1](https://github.com/TypedDevs/bashunit/compare/0.34.0...0.34.1) - 2026-03-20
 

--- a/src/assert.sh
+++ b/src/assert.sh
@@ -43,6 +43,10 @@ function assert_true() {
 
   # Check for expected literal values first
   case "$actual" in
+  "")
+    bashunit::handle_bool_assertion_failure "true or 0" "$actual"
+    return
+    ;;
   "true" | "0")
     bashunit::state::add_assertions_passed
     return
@@ -71,6 +75,10 @@ function assert_false() {
 
   # Check for expected literal values first
   case "$actual" in
+  "")
+    bashunit::handle_bool_assertion_failure "false or 1" "$actual"
+    return
+    ;;
   "false" | "1")
     bashunit::state::add_assertions_passed
     return

--- a/tests/unit/assert_basic_test.sh
+++ b/tests/unit/assert_basic_test.sh
@@ -32,6 +32,13 @@ function test_unsuccessful_assert_true() {
     "$(assert_true false)"
 }
 
+function test_unsuccessful_assert_true_with_empty_value() {
+  assert_same "$(bashunit::console_results::print_failed_test "Unsuccessful assert true with empty value" \
+    "true or 0" \
+    "but got " "")" \
+    "$(assert_true "")"
+}
+
 function test_successful_assert_true_on_function() {
   assert_empty "$(assert_true ls)"
 }
@@ -60,6 +67,13 @@ function test_unsuccessful_assert_false() {
     "false or 1" \
     "but got " "true")" \
     "$(assert_false true)"
+}
+
+function test_unsuccessful_assert_false_with_empty_value() {
+  assert_same "$(bashunit::console_results::print_failed_test "Unsuccessful assert false with empty value" \
+    "false or 1" \
+    "but got " "")" \
+    "$(assert_false "")"
 }
 
 function test_successful_assert_false_on_function() {


### PR DESCRIPTION
## Summary
- Treat empty strings as assertion failures in assert_true and assert_false
- Add unit coverage for empty boolean assertion inputs

Closes https://github.com/TypedDevs/bashunit/issues/638 