### PR TITLE
Further profiling and optimisation #636

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)
 - Replace `echo | sed` / `echo | grep` subshells in `bashunit::coverage::extract_functions` with bash native regex matching and parameter expansion (#636)
+- Speed up coverage report generation by replacing per-line `sed` lookups with pre-loaded indexed arrays in `get_hit_lines` and `generate_file_html` (#636)
+- Speed up coverage report generation by caching pre-computed file stats across text/lcov/html reports (#636)
 
 ## [0.35.0](https://github.com/TypedDevs/bashunit/compare/0.34.1...0.35.0) - 2026-04-26
 

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -190,6 +190,57 @@ function bashunit::coverage::get_file_stats() {
   echo "${executable}:${hit}:${pct}:${class}"
 }
 
+# Pre-computed file stats cache (avoids redundant per-file reads across reports)
+_BASHUNIT_COVERAGE_STATS_FILES=()
+_BASHUNIT_COVERAGE_STATS_EXEC=()
+_BASHUNIT_COVERAGE_STATS_HIT=()
+_BASHUNIT_COVERAGE_STATS_PCT=()
+_BASHUNIT_COVERAGE_STATS_CLASS=()
+_BASHUNIT_COVERAGE_STATS_COUNT=0
+
+# Pre-compute stats for all tracked files (call once before reports)
+function bashunit::coverage::precompute_file_stats() {
+  _BASHUNIT_COVERAGE_STATS_FILES=()
+  _BASHUNIT_COVERAGE_STATS_EXEC=()
+  _BASHUNIT_COVERAGE_STATS_HIT=()
+  _BASHUNIT_COVERAGE_STATS_PCT=()
+  _BASHUNIT_COVERAGE_STATS_CLASS=()
+  _BASHUNIT_COVERAGE_STATS_COUNT=0
+
+  local file
+  while IFS= read -r file; do
+    { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
+
+    local executable hit pct class
+    executable=$(bashunit::coverage::get_executable_lines "$file")
+    hit=$(bashunit::coverage::get_hit_lines "$file")
+    pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
+    class=$(bashunit::coverage::get_coverage_class "$pct")
+
+    local idx="$_BASHUNIT_COVERAGE_STATS_COUNT"
+    _BASHUNIT_COVERAGE_STATS_FILES[idx]="$file"
+    _BASHUNIT_COVERAGE_STATS_EXEC[idx]="$executable"
+    _BASHUNIT_COVERAGE_STATS_HIT[idx]="$hit"
+    _BASHUNIT_COVERAGE_STATS_PCT[idx]="$pct"
+    _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$class"
+    _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
+  done < <(bashunit::coverage::get_tracked_files)
+}
+
+# Look up cached stats for a file, returns "executable:hit:pct:class"
+function bashunit::coverage::get_cached_stats() {
+  local file="$1"
+  local i
+  for ((i = 0; i < _BASHUNIT_COVERAGE_STATS_COUNT; i++)); do
+    if [ "${_BASHUNIT_COVERAGE_STATS_FILES[i]}" = "$file" ]; then
+      echo "${_BASHUNIT_COVERAGE_STATS_EXEC[i]}:${_BASHUNIT_COVERAGE_STATS_HIT[i]}:${_BASHUNIT_COVERAGE_STATS_PCT[i]}:${_BASHUNIT_COVERAGE_STATS_CLASS[i]}"
+      return 0
+    fi
+  done
+  # Fallback: compute if not cached
+  bashunit::coverage::get_file_stats "$file"
+}
+
 function bashunit::coverage::record_line() {
   local file="$1"
   local lineno="$2"
@@ -710,16 +761,24 @@ function bashunit::coverage::get_percentage() {
   local total_executable=0
   local total_hit=0
 
-  while IFS= read -r file; do
-    { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
+  if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
+    local i
+    for ((i = 0; i < _BASHUNIT_COVERAGE_STATS_COUNT; i++)); do
+      total_executable=$((total_executable + _BASHUNIT_COVERAGE_STATS_EXEC[i]))
+      total_hit=$((total_hit + _BASHUNIT_COVERAGE_STATS_HIT[i]))
+    done
+  else
+    while IFS= read -r file; do
+      { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
-    local executable hit
-    executable=$(bashunit::coverage::get_executable_lines "$file")
-    hit=$(bashunit::coverage::get_hit_lines "$file")
+      local executable hit
+      executable=$(bashunit::coverage::get_executable_lines "$file")
+      hit=$(bashunit::coverage::get_hit_lines "$file")
 
-    total_executable=$((total_executable + executable))
-    total_hit=$((total_hit + hit))
-  done < <(bashunit::coverage::get_tracked_files)
+      total_executable=$((total_executable + executable))
+      total_hit=$((total_hit + hit))
+    done < <(bashunit::coverage::get_tracked_files)
+  fi
 
   bashunit::coverage::calculate_percentage "$total_hit" "$total_executable"
 }
@@ -742,14 +801,26 @@ function bashunit::coverage::report_text() {
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
     has_files=true
 
-    local stats executable hit pct class
-    stats=$(bashunit::coverage::get_file_stats "$file")
-    executable="${stats%%:*}"
-    stats="${stats#*:}"
-    hit="${stats%%:*}"
-    stats="${stats#*:}"
-    pct="${stats%%:*}"
-    class="${stats##*:}"
+    local executable hit pct class
+    if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
+      local stats
+      stats=$(bashunit::coverage::get_cached_stats "$file")
+      executable="${stats%%:*}"
+      local rest="${stats#*:}"
+      hit="${rest%%:*}"
+      rest="${rest#*:}"
+      pct="${rest%%:*}"
+      class="${rest#*:}"
+    else
+      local stats
+      stats=$(bashunit::coverage::get_file_stats "$file")
+      executable="${stats%%:*}"
+      stats="${stats#*:}"
+      hit="${stats%%:*}"
+      stats="${stats#*:}"
+      pct="${stats%%:*}"
+      class="${stats##*:}"
+    fi
 
     total_executable=$((total_executable + executable))
     total_hit=$((total_hit + hit))
@@ -887,7 +958,11 @@ function bashunit::coverage::report_html() {
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
     local stats executable hit pct
-    stats=$(bashunit::coverage::get_file_stats "$file")
+    if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
+      stats=$(bashunit::coverage::get_cached_stats "$file")
+    else
+      stats=$(bashunit::coverage::get_file_stats "$file")
+    fi
     executable="${stats%%:*}"
     stats="${stats#*:}"
     hit="${stats%%:*}"
@@ -1295,9 +1370,21 @@ function bashunit::coverage::generate_file_html() {
 
   local display_file="${file#"$(pwd)"/}"
   local executable hit pct class
-  executable=$(bashunit::coverage::get_executable_lines "$file")
-  hit=$(bashunit::coverage::get_hit_lines "$file")
-  pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
+  if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
+    local stats
+    stats=$(bashunit::coverage::get_cached_stats "$file")
+    executable="${stats%%:*}"
+    local _rest="${stats#*:}"
+    hit="${_rest%%:*}"
+    _rest="${_rest#*:}"
+    pct="${_rest%%:*}"
+    class="${_rest#*:}"
+  else
+    executable=$(bashunit::coverage::get_executable_lines "$file")
+    hit=$(bashunit::coverage::get_hit_lines "$file")
+    pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
+    class=$(bashunit::coverage::get_coverage_class "$pct")
+  fi
   class=$(bashunit::coverage::get_coverage_class "$pct")
   local uncovered=$((executable - hit))
 

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -863,26 +863,14 @@ function bashunit::coverage::report_text() {
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
     has_files=true
 
-    local executable hit pct class
-    if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
-      local stats
-      stats=$(bashunit::coverage::get_cached_stats "$file")
-      executable="${stats%%:*}"
-      local rest="${stats#*:}"
-      hit="${rest%%:*}"
-      rest="${rest#*:}"
-      pct="${rest%%:*}"
-      class="${rest#*:}"
-    else
-      local stats
-      stats=$(bashunit::coverage::get_file_stats "$file")
-      executable="${stats%%:*}"
-      stats="${stats#*:}"
-      hit="${stats%%:*}"
-      stats="${stats#*:}"
-      pct="${stats%%:*}"
-      class="${stats##*:}"
-    fi
+    local executable hit pct class stats rest
+    stats=$(bashunit::coverage::get_cached_stats "$file")
+    executable="${stats%%:*}"
+    rest="${stats#*:}"
+    hit="${rest%%:*}"
+    rest="${rest#*:}"
+    pct="${rest%%:*}"
+    class="${rest#*:}"
 
     total_executable=$((total_executable + executable))
     total_hit=$((total_hit + hit))
@@ -1026,11 +1014,7 @@ function bashunit::coverage::report_html() {
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
     local stats executable hit pct
-    if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
-      stats=$(bashunit::coverage::get_cached_stats "$file")
-    else
-      stats=$(bashunit::coverage::get_file_stats "$file")
-    fi
+    stats=$(bashunit::coverage::get_cached_stats "$file")
     executable="${stats%%:*}"
     stats="${stats#*:}"
     hit="${stats%%:*}"
@@ -1437,22 +1421,14 @@ function bashunit::coverage::generate_file_html() {
   local output_file="$2"
 
   local display_file="${file#"$(pwd)"/}"
-  local executable hit pct class
-  if [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]; then
-    local stats
-    stats=$(bashunit::coverage::get_cached_stats "$file")
-    executable="${stats%%:*}"
-    local _rest="${stats#*:}"
-    hit="${_rest%%:*}"
-    _rest="${_rest#*:}"
-    pct="${_rest%%:*}"
-    class="${_rest#*:}"
-  else
-    executable=$(bashunit::coverage::get_executable_lines "$file")
-    hit=$(bashunit::coverage::get_hit_lines "$file")
-    pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
-    class=$(bashunit::coverage::get_coverage_class "$pct")
-  fi
+  local executable hit pct class stats rest
+  stats=$(bashunit::coverage::get_cached_stats "$file")
+  executable="${stats%%:*}"
+  rest="${stats#*:}"
+  hit="${rest%%:*}"
+  rest="${rest#*:}"
+  pct="${rest%%:*}"
+  class="${rest#*:}"
   local uncovered=$((executable - hit))
 
   # Pre-load all line hits into indexed array (performance optimization)

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -708,7 +708,7 @@ function bashunit::coverage::extract_functions() {
 
         # Single-line function: braces balance on same line and both present
         if [ "$brace_count" -eq 0 ] && [ "$open_count" -gt 0 ] && [ "$close_count" -gt 0 ]; then
-          echo "${current_fn}:${fn_start}:${lineno}"
+          echo "${current_fn}|${fn_start}|${lineno}"
           in_function=0
           current_fn=""
         fi

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -499,13 +499,22 @@ function bashunit::coverage::get_hit_lines() {
 
   # Only count hits that correspond to executable lines
   # This prevents >100% coverage when DEBUG trap fires on non-executable lines
+
+  # Pre-load file lines into indexed array (avoids sed per line)
+  local -a file_lines=()
+  local _idx=0 _fl
+  while IFS= read -r _fl || [ -n "$_fl" ]; do
+    file_lines[_idx]="$_fl"
+    _idx=$((_idx + 1))
+  done <"$file"
+
   local count=0
   local line_num
   for line_num in $hit_lines; do
-    local line_content
-    line_content=$(sed -n "${line_num}p" "$file" 2>/dev/null) || continue
+    local line_content="${file_lines[$((line_num - 1))]:-}"
+    [ -z "$line_content" ] && continue
     if bashunit::coverage::is_executable_line "$line_content" "$line_num"; then
-      ((++count))
+      count=$((count + 1))
     fi
   done
 
@@ -1299,6 +1308,14 @@ function bashunit::coverage::generate_file_html() {
     hits_by_line[_ln]=$_cnt
   done < <(bashunit::coverage::get_all_line_hits "$file")
 
+  # Pre-load all file lines into indexed array (avoids sed per line)
+  local -a file_lines=()
+  local _fli=0 _fl
+  while IFS= read -r _fl || [ -n "$_fl" ]; do
+    file_lines[_fli]="$_fl"
+    _fli=$((_fli + 1))
+  done <"$file"
+
   # Pre-load test hits data into indexed array (for tooltips)
   # Index: line number, Value: newline-separated list of "test_file:test_function"
   # Using indexed array for Bash 3.0 compatibility (no associative arrays)
@@ -1567,7 +1584,7 @@ EOF
         local ln
         for ((ln = fn_start; ln <= fn_end; ln++)); do
           local ln_content
-          ln_content=$(sed -n "${ln}p" "$file" 2>/dev/null) || continue
+          ln_content="${file_lines[$((ln - 1))]}"
           if bashunit::coverage::is_executable_line "$ln_content" "$ln"; then
             ((++fn_executable))
             local ln_hits=${hits_by_line[$ln]:-0}
@@ -1622,8 +1639,8 @@ EOF
 
     local lineno=0
     local line
-    while IFS= read -r line || [ -n "$line" ]; do
-      ((++lineno))
+    for line in "${file_lines[@]}"; do
+      lineno=$((lineno + 1))
 
       local escaped_line
       escaped_line=$(bashunit::coverage::html_escape "$line")
@@ -1666,7 +1683,7 @@ EOF
       echo "            <td class=\"hits\">$hits_display</td>"
       echo "            <td class=\"code\">$escaped_line</td>"
       echo "          </tr>"
-    done <"$file"
+    done
 
     cat <<'EOF'
         </table>

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -99,6 +99,13 @@ function bashunit::coverage::init() {
   _BASHUNIT_COVERAGE_TRACK_CACHE=""
   _BASHUNIT_COVERAGE_PATH_CACHE=""
   _BASHUNIT_COVERAGE_IS_PARALLEL=""
+  _BASHUNIT_COVERAGE_STATS_FILES=()
+  _BASHUNIT_COVERAGE_STATS_EXEC=()
+  _BASHUNIT_COVERAGE_STATS_HIT=()
+  _BASHUNIT_COVERAGE_STATS_PCT=()
+  _BASHUNIT_COVERAGE_STATS_CLASS=()
+  _BASHUNIT_COVERAGE_STATS_COUNT=0
+  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
 
   export _BASHUNIT_COVERAGE_DATA_FILE
   export _BASHUNIT_COVERAGE_TRACKED_FILES
@@ -1446,7 +1453,6 @@ function bashunit::coverage::generate_file_html() {
     pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
     class=$(bashunit::coverage::get_coverage_class "$pct")
   fi
-  class=$(bashunit::coverage::get_coverage_class "$pct")
   local uncovered=$((executable - hit))
 
   # Pre-load all line hits into indexed array (performance optimization)

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -197,6 +197,7 @@ _BASHUNIT_COVERAGE_STATS_HIT=()
 _BASHUNIT_COVERAGE_STATS_PCT=()
 _BASHUNIT_COVERAGE_STATS_CLASS=()
 _BASHUNIT_COVERAGE_STATS_COUNT=0
+_BASHUNIT_COVERAGE_STATS_LOOKUP=""
 
 # Pre-compute stats for all tracked files (call once before reports)
 function bashunit::coverage::precompute_file_stats() {
@@ -206,14 +207,16 @@ function bashunit::coverage::precompute_file_stats() {
   _BASHUNIT_COVERAGE_STATS_PCT=()
   _BASHUNIT_COVERAGE_STATS_CLASS=()
   _BASHUNIT_COVERAGE_STATS_COUNT=0
+  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
 
   local file
   while IFS= read -r file; do
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
-    local executable hit pct class
-    executable=$(bashunit::coverage::get_executable_lines "$file")
-    hit=$(bashunit::coverage::get_hit_lines "$file")
+    local stats executable hit pct class
+    stats=$(bashunit::coverage::compute_file_coverage "$file")
+    executable="${stats%%:*}"
+    hit="${stats##*:}"
     pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
     class=$(bashunit::coverage::get_coverage_class "$pct")
 
@@ -224,20 +227,21 @@ function bashunit::coverage::precompute_file_stats() {
     _BASHUNIT_COVERAGE_STATS_PCT[idx]="$pct"
     _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$class"
     _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
+    _BASHUNIT_COVERAGE_STATS_LOOKUP="${_BASHUNIT_COVERAGE_STATS_LOOKUP}|${file}=${idx}|"
   done < <(bashunit::coverage::get_tracked_files)
 }
 
 # Look up cached stats for a file, returns "executable:hit:pct:class"
 function bashunit::coverage::get_cached_stats() {
   local file="$1"
-  local i
-  for ((i = 0; i < _BASHUNIT_COVERAGE_STATS_COUNT; i++)); do
-    if [ "${_BASHUNIT_COVERAGE_STATS_FILES[i]}" = "$file" ]; then
-      echo "${_BASHUNIT_COVERAGE_STATS_EXEC[i]}:${_BASHUNIT_COVERAGE_STATS_HIT[i]}:${_BASHUNIT_COVERAGE_STATS_PCT[i]}:${_BASHUNIT_COVERAGE_STATS_CLASS[i]}"
-      return 0
-    fi
-  done
-  # Fallback: compute if not cached
+  case "$_BASHUNIT_COVERAGE_STATS_LOOKUP" in
+  *"|${file}="*)
+    local idx="${_BASHUNIT_COVERAGE_STATS_LOOKUP#*"|${file}="}"
+    idx="${idx%%"|"*}"
+    echo "${_BASHUNIT_COVERAGE_STATS_EXEC[idx]}:${_BASHUNIT_COVERAGE_STATS_HIT[idx]}:${_BASHUNIT_COVERAGE_STATS_PCT[idx]}:${_BASHUNIT_COVERAGE_STATS_CLASS[idx]}"
+    return 0
+    ;;
+  esac
   bashunit::coverage::get_file_stats "$file"
 }
 
@@ -510,7 +514,27 @@ function bashunit::coverage::is_executable_line() {
   # Skip empty lines (line with only whitespace) — built-in, no subshell
   [ -z "${line// /}" ] && return 1
 
-  # Single combined grep covers every non-executable pattern
+  # Fast path: pure Bash checks for common non-executable patterns (no subshell)
+  local stripped="${line#"${line%%[![:space:]]*}"}"
+  local _trail="${stripped##*[![:space:]]}"
+  local trimmed="${stripped%"$_trail"}"
+
+  case "$trimmed" in
+  '#'*) return 1 ;;      # Comments (including shebang)
+  '{' | '}') return 1 ;; # Braces only
+  esac
+
+  local first="${trimmed%%[[:space:]]*}"
+  case "$first" in
+  'then' | 'else' | 'fi' | 'do' | 'done' | 'esac' | 'in' | ';;' | ';;&' | ';&' | ')')
+    local rest="${trimmed#"$first"}"
+    local _rl="${rest%%[![:space:]]*}"
+    rest="${rest#"$_rl"}"
+    case "$rest" in '' | '#'*) return 1 ;; esac
+    ;;
+  esac
+
+  # Fallback: grep for complex patterns (function declarations, case patterns, done+redirection)
   [ "$(printf '%s' "$line" | "$GREP" -cE "$_BASHUNIT_COVERAGE_NONEXEC_PATTERN" || true)" -gt 0 ] && return 1
 
   return 0
@@ -599,13 +623,20 @@ function bashunit::coverage::compute_file_coverage() {
   done < <(bashunit::coverage::get_all_line_hits "$file")
 
   local executable=0 hit=0 lineno=0 line line_hits
-  while IFS= read -r line || [ -n "$line" ]; do
+  local -a cv_lines=()
+  local _cli=0 _cl
+  while IFS= read -r _cl || [ -n "$_cl" ]; do
+    cv_lines[_cli]="$_cl"
+    ((++_cli))
+  done <"$file"
+
+  for line in "${cv_lines[@]}"; do
     ((++lineno))
     bashunit::coverage::is_executable_line "$line" "$lineno" || continue
     ((++executable))
     line_hits=${hits_by_line[lineno]:-0}
     [ "$line_hits" -gt 0 ] && ((++hit))
-  done <"$file"
+  done
 
   echo "${executable}:${hit}"
 }
@@ -753,9 +784,16 @@ function bashunit::coverage::get_function_coverage() {
   local hit=0
   local lineno=0
 
+  # Pre-load file lines into indexed array (avoids sed per line)
+  local -a fn_lines=()
+  local _fli=0 _fl
+  while IFS= read -r _fl || [ -n "$_fl" ]; do
+    fn_lines[_fli]="$_fl"
+    ((++_fli))
+  done <"$file"
+
   for ((lineno = fn_start; lineno <= fn_end; lineno++)); do
-    local line_content
-    line_content=$(sed -n "${lineno}p" "$file" 2>/dev/null) || continue
+    local line_content="${fn_lines[$((lineno - 1))]:-}"
 
     if bashunit::coverage::is_executable_line "$line_content" "$lineno"; then
       ((++executable))
@@ -903,15 +941,21 @@ function bashunit::coverage::report_lcov() {
       done < <(bashunit::coverage::get_all_line_hits "$file")
 
       local lineno=0 executable=0 hit=0 line line_hits
-      # shellcheck disable=SC2094
-      while IFS= read -r line || [ -n "$line" ]; do
+      local -a lcov_lines=()
+      local _lli=0 _ll
+      while IFS= read -r _ll || [ -n "$_ll" ]; do
+        lcov_lines[_lli]="$_ll"
+        ((++_lli))
+      done <"$file"
+
+      for line in "${lcov_lines[@]}"; do
         ((++lineno))
         bashunit::coverage::is_executable_line "$line" "$lineno" || continue
         ((++executable))
         local lh="${hits_by_line[$lineno]:-0}"
         [ "$lh" -gt 0 ] && ((++hit))
         echo "DA:${lineno},${lh}"
-      done <"$file"
+      done
 
       echo "LF:$executable"
       echo "LH:$hit"

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -511,7 +511,7 @@ function bashunit::coverage::is_executable_line() {
   [ -z "${line// /}" ] && return 1
 
   # Single combined grep covers every non-executable pattern
-  [ "$(echo "$line" | "$GREP" -cE "$_BASHUNIT_COVERAGE_NONEXEC_PATTERN" || true)" -gt 0 ] && return 1
+  [ "$(printf '%s' "$line" | "$GREP" -cE "$_BASHUNIT_COVERAGE_NONEXEC_PATTERN" || true)" -gt 0 ] && return 1
 
   return 0
 }
@@ -556,7 +556,7 @@ function bashunit::coverage::get_hit_lines() {
   local _idx=0 _fl
   while IFS= read -r _fl || [ -n "$_fl" ]; do
     file_lines[_idx]="$_fl"
-    _idx=$((_idx + 1))
+    ((++_idx))
   done <"$file"
 
   local count=0
@@ -565,7 +565,7 @@ function bashunit::coverage::get_hit_lines() {
     local line_content="${file_lines[$((line_num - 1))]:-}"
     [ -z "$line_content" ] && continue
     if bashunit::coverage::is_executable_line "$line_content" "$line_num"; then
-      count=$((count + 1))
+      ((++count))
     fi
   done
 
@@ -600,11 +600,11 @@ function bashunit::coverage::compute_file_coverage() {
 
   local executable=0 hit=0 lineno=0 line line_hits
   while IFS= read -r line || [ -n "$line" ]; do
-    lineno=$((lineno + 1))
+    ((++lineno))
     bashunit::coverage::is_executable_line "$line" "$lineno" || continue
-    executable=$((executable + 1))
+    ((++executable))
     line_hits=${hits_by_line[lineno]:-0}
-    [ "$line_hits" -gt 0 ] && hit=$((hit + 1))
+    [ "$line_hits" -gt 0 ] && ((++hit))
   done <"$file"
 
   echo "${executable}:${hit}"
@@ -664,16 +664,33 @@ function bashunit::coverage::extract_functions() {
     if [ "$in_function" -eq 0 ]; then
       local fn_name=""
 
-      # Match: name() with optional `function` keyword (parens form)
-      local _re='^[[:space:]]*(function[[:space:]]+)?([a-zA-Z_][a-zA-Z0-9_:]*)[[:space:]]*\(\)[[:space:]]*\{?[[:space:]]*(#.*)?$'
-      if [[ "$line" =~ $_re ]]; then
-        fn_name="${BASH_REMATCH[2]}"
-      else
-        # Match: function name { (keyword form, no parens)
-        _re='^[[:space:]]*(function[[:space:]]+)([a-zA-Z_][a-zA-Z0-9_:]*)[[:space:]]*\{[[:space:]]*(#.*)?$'
-        if [[ "$line" =~ $_re ]]; then
-          fn_name="${BASH_REMATCH[2]}"
-        fi
+      # Extract function name using pure Bash string operations (avoids sed subshell)
+      local stripped="${line#"${line%%[![:space:]]*}"}"
+
+      # Strip "function " prefix if present
+      case "$stripped" in
+      function[\ \	]*)
+        stripped="${stripped#function}"
+        stripped="${stripped#"${stripped%%[![:space:]]*}"}"
+        ;;
+      esac
+
+      # Extract first word as candidate function name
+      fn_name="${stripped%%[[:space:]\(\{]*}"
+
+      # Validate: must start with valid identifier char, and rest must have () or {
+      if [ -n "$fn_name" ]; then
+        case "$fn_name" in
+        [a-zA-Z_]*)
+          local after_name="${stripped#"$fn_name"}"
+          after_name="${after_name#"${after_name%%[![:space:]]*}"}"
+          case "$after_name" in
+          '()'* | '{'*) ;;
+          *) fn_name="" ;;
+          esac
+          ;;
+        *) fn_name="" ;;
+        esac
       fi
 
       if [ -n "$fn_name" ]; then
@@ -888,12 +905,12 @@ function bashunit::coverage::report_lcov() {
       local lineno=0 executable=0 hit=0 line line_hits
       # shellcheck disable=SC2094
       while IFS= read -r line || [ -n "$line" ]; do
-        lineno=$((lineno + 1))
+        ((++lineno))
         bashunit::coverage::is_executable_line "$line" "$lineno" || continue
-        executable=$((executable + 1))
-        line_hits=${hits_by_line[lineno]:-0}
-        [ "$line_hits" -gt 0 ] && hit=$((hit + 1))
-        echo "DA:${lineno},${line_hits}"
+        ((++executable))
+        local lh="${hits_by_line[$lineno]:-0}"
+        [ "$lh" -gt 0 ] && ((++hit))
+        echo "DA:${lineno},${lh}"
       done <"$file"
 
       echo "LF:$executable"
@@ -1400,7 +1417,7 @@ function bashunit::coverage::generate_file_html() {
   local _fli=0 _fl
   while IFS= read -r _fl || [ -n "$_fl" ]; do
     file_lines[_fli]="$_fl"
-    _fli=$((_fli + 1))
+    ((++_fli))
   done <"$file"
 
   # Pre-load test hits data into indexed array (for tooltips)
@@ -1671,7 +1688,7 @@ EOF
         local ln
         for ((ln = fn_start; ln <= fn_end; ln++)); do
           local ln_content
-          ln_content="${file_lines[$((ln - 1))]}"
+          ln_content="${file_lines[$((ln - 1))]:-}"
           if bashunit::coverage::is_executable_line "$ln_content" "$ln"; then
             ((++fn_executable))
             local ln_hits=${hits_by_line[$ln]:-0}
@@ -1727,7 +1744,7 @@ EOF
     local lineno=0
     local line
     for line in "${file_lines[@]}"; do
-      lineno=$((lineno + 1))
+      ((++lineno))
 
       local escaped_line
       escaped_line=$(bashunit::coverage::html_escape "$line")

--- a/src/main.sh
+++ b/src/main.sh
@@ -711,6 +711,8 @@ function bashunit::main::exec_tests() {
       bashunit::coverage::aggregate_parallel
     fi
 
+    bashunit::coverage::precompute_file_stats
+
     bashunit::coverage::report_text
 
     if [ -n "$BASHUNIT_COVERAGE_REPORT" ]; then

--- a/tests/unit/coverage_reporting_test.sh
+++ b/tests/unit/coverage_reporting_test.sh
@@ -322,3 +322,76 @@ EOF
 
   rm -f "$temp_file"
 }
+
+function test_coverage_precompute_file_stats_populates_cache() {
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "line 1"
+echo "line 2"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+
+  bashunit::coverage::precompute_file_stats
+
+  assert_equals "1" "$_BASHUNIT_COVERAGE_STATS_COUNT"
+  assert_equals "$temp_file" "${_BASHUNIT_COVERAGE_STATS_FILES[0]}"
+  assert_equals "2" "${_BASHUNIT_COVERAGE_STATS_EXEC[0]}"
+
+  rm -f "$temp_file"
+}
+
+function test_coverage_get_cached_stats_returns_same_as_get_file_stats() {
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "line 1"
+echo "line 2"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+
+  bashunit::coverage::precompute_file_stats
+
+  local cached direct
+  cached=$(bashunit::coverage::get_cached_stats "$temp_file")
+  direct=$(bashunit::coverage::get_file_stats "$temp_file")
+
+  assert_equals "$direct" "$cached"
+
+  rm -f "$temp_file"
+}
+
+function test_coverage_get_cached_stats_falls_back_when_not_cached() {
+  _BASHUNIT_COVERAGE_STATS_COUNT=0
+
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "line 1"
+echo "line 2"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+
+  local cached direct
+  cached=$(bashunit::coverage::get_cached_stats "$temp_file")
+  direct=$(bashunit::coverage::get_file_stats "$temp_file")
+
+  assert_equals "$direct" "$cached"
+
+  rm -f "$temp_file"
+}


### PR DESCRIPTION
## Background

Related #636

PRs #643 and #644 addressed the `is_executable_line` consolidation and `compute_file_coverage` single-pass. This PR adds further optimisations on top: eliminating remaining `sed`/`grep` subshells, pre-loading source files into arrays, caching stats across reports, and using pure Bash 3.0 string operations in `extract_functions` (replacing `[[ =~ ]]`).

## Changes

- **Eliminate `sed -n` per-line spawns** — read source files once into indexed arrays in `get_hit_lines` and `generate_file_html`, replacing per-line sed calls with array lookups
- **Cache file stats across reports** — `precompute_file_stats` computes executable/hit/pct once via `compute_file_coverage`, shared by `report_text`, `report_html`, and `get_percentage`; O(1) lookup with string-based cache
- **Bash 3.0 compatible `extract_functions`** — pure string operations replace `[[ =~ ]]` + `BASH_REMATCH`; `printf '%s'` replaces `echo` in `is_executable_line`; `((++var))` convention from #619
- **Pre-load file arrays in hot paths** — `compute_file_coverage`, `report_lcov`, and `get_function_coverage` now read files once and iterate with `for` instead of `while IFS= read`
- **Pure Bash fast-path in `is_executable_line`** — `case` statements handle comments, braces, control keywords, and standalone `)` without spawning grep; falls through to grep for complex patterns only
- Added tests for `precompute_file_stats` and `get_cached_stats`

### Per-Component Breakdown

> **Note:** BEFORE = original `main` before any optimisation PRs (#643, #644, and this PR). AFTER = this branch, which includes all three PRs' changes. The per-component and hyperfine numbers reflect the cumulative improvement.

Test workload: 15 source files, ~1200 hit entries, full report generation (text + lcov + html)

| Component                          | BEFORE         | AFTER         | Improvement  |
| ---------------------------------- | -------------- | ------------- | -------- |
| `is_executable_line` (8000 calls)  | 231,382 ms     | 30,556 ms     | 7.6x     |
| `extract_functions` (15 calls)     | 9,396 ms       | 93 ms         | 101.0x   |
| `report_text`                      | 74,480 ms      | 6,726 ms      | 11.1x    |
| `report_lcov`                      | 124,797 ms     | 6,334 ms      | 19.7x    |
| `report_html`                      | 213,923 ms     | 32,495 ms     | 6.6x     |
| **Full pipeline (text+lcov+html)** | **406,970 ms** | **44,797 ms** | **9.1x** |

### Hyperfine Statistical Benchmark

Measured with warmup run + 3 measured runs each, on a macOS machine:

```
Benchmark 1: BEFORE (main)
  Time (mean ± σ):     118.053 s ±  0.930 s
  Range (min … max):   117.169 s … 119.022 s    3 runs

Benchmark 2: AFTER (optimised)
  Time (mean ± σ):      8.782 s ±  0.209 s
  Range (min … max):    8.618 s … 9.018 s    3 runs

Summary
  AFTER ran 13.44 ± 0.34 times faster than BEFORE
```

**13.4x faster** confirmed by hyperfine. The original code took ~2 minutes to generate all three reports; after the optimisations it takes ~9 seconds.

### Caveats

- Numbers from macOS with moderate fork overhead. Cygwin environments have orders-of-magnitude higher fork costs, so subshell elimination gains would be amplified further.
- Per-component numbers use `EPOCHREALTIME` timestamps in a benchmark harness — directional rather than statistically rigorous. The hyperfine full-pipeline comparison is the headline number.
- Benchmark workload (15 files, ~1200 entries) is synthetic. Real-world speedup depends on repository size and hit density.

## Checklist

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes
