### PR TITLE
feat(cli): publish bashunit to the npm registry

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,39 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Publish bashunit to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build bashunit single-file binary
+        shell: bash
+        run: ./build.sh bin
+
+      - name: Verify build artifact exists
+        shell: bash
+        run: |
+          test -x bin/bashunit || { echo "bin/bashunit missing or not executable"; exit 1; }
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Display captured test output on assertion failures when `--show-output` is enabled (#637)
 - `bashunit::env::supports_color` helper exposing a capability probe (`TERM=dumb` / `tput colors < 8`) for future auto-detection use; `bashunit::io::clear_screen` helper that prefers `tput clear` and falls back to the raw ANSI sequence (#247)
+- Publish bashunit to the npm registry: `npm install -g bashunit` ships the prebuilt single-file binary; new `npm-publish.yml` workflow publishes on release (#244)
 
 ### Changed
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,6 +157,116 @@ On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.
 sudo port install bashunit
 ```
 
+## npm
+
+If your project already uses Node.js tooling (e.g. a JavaScript or TypeScript repo), you can install **bashunit** directly from the [npm registry](https://www.npmjs.com/package/bashunit).
+
+The npm package ships only the prebuilt single-file binary plus `LICENSE` and `README.md`; it does not include the source tree.
+
+### Per-project (recommended)
+
+Install **bashunit** as a `devDependency` so the version is pinned in your `package.json` and reproducible across machines and CI:
+
+```bash
+npm install --save-dev bashunit
+```
+
+Add a script to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "test:sh": "bashunit tests/"
+  },
+  "devDependencies": {
+    "bashunit": "^{{ pkg.version }}"
+  }
+}
+```
+
+Then run:
+
+```bash
+npm run test:sh
+# or invoke directly via npx
+npx bashunit tests/
+```
+
+### Global
+
+Install **bashunit** system-wide so the `bashunit` command is available on your `PATH`:
+
+```bash
+npm install -g bashunit
+bashunit --version
+bashunit tests/
+```
+
+### One-shot, no install
+
+`npx` can download and run the latest release on demand, useful for quick tries or ephemeral CI jobs:
+
+```bash
+npx bashunit@latest tests/
+```
+
+### Example consumer project
+
+```
+my-app/
+├── package.json          # has "bashunit" in devDependencies
+├── src/
+│   └── deploy.sh
+└── tests/
+    └── deploy_test.sh
+```
+
+```bash [tests/deploy_test.sh]
+#!/usr/bin/env bash
+
+source "$(dirname "$0")/../src/deploy.sh"
+
+function test_deploy_returns_url() {
+  assert_equals "https://example.com" "$(get_deploy_url)"
+}
+```
+
+Run from the project root:
+
+```bash
+npx bashunit tests/
+```
+
+### GitHub Actions with npm
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx bashunit tests/
+```
+
+::: tip
+The npm package is restricted to `darwin` and `linux`; on Windows use [WSL](https://learn.microsoft.com/windows/wsl/install). bashunit still requires **Bash 3.0 or newer** at runtime - npm does not enforce this, the `bashunit` script does.
+:::
+
+::: warning
+Because only the prebuilt single-file binary is shipped, you cannot `source` bashunit internals from inside `node_modules/bashunit/`. Use the `bashunit` command directly. If you need to extend or vendor the framework, install via [install.sh](#install-sh) or clone the repository.
+:::
+
 ## GitHub Actions
 
 ```yaml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,13 +1,10 @@
 # Installation
 
-Although there's no Bash script dependency manager like npm for JavaScript, Maven for Java, pip for Python, or composer for PHP;
-you can add **bashunit** as a dependency in your repository according to your preferences.
-
-Here, we provide different options that you can use to install **bashunit** in your application.
+**bashunit** ships as a single-file executable. Pick the option that fits your project: `install.sh` (universal), [npm](#npm) (Node.js projects), [Brew](#brew) (macOS/Linux global), [MacPorts](#macports), or [bashdep](#bashdep).
 
 ## Requirements
 
-bashunit requires **Bash 3.0** or newer.
+bashunit requires **Bash 3.0** or newer. On Windows use [WSL](https://learn.microsoft.com/windows/wsl/install).
 
 ## install.sh
 
@@ -81,6 +78,60 @@ We try to keep it stable, but there is no promise that we won't change functions
 Committing (or not) this file to your project it's up to you. In the end, it is a dev dependency.
 :::
 
+## npm
+
+[bashunit on npm](https://www.npmjs.com/package/bashunit) is the recommended option for Node.js projects.
+
+::: code-group
+```bash [Per-project (recommended)]
+npm install --save-dev bashunit
+npx bashunit tests/
+```
+
+```bash [Global]
+npm install -g bashunit
+bashunit tests/
+```
+
+```bash [One-shot]
+# No install, runs the latest release
+npx bashunit@latest tests/
+```
+:::
+
+Add a script to your `package.json` so contributors and CI run the same command:
+
+```json
+{
+  "scripts": {
+    "test:sh": "bashunit tests/"
+  },
+  "devDependencies": {
+    "bashunit": "^{{ pkg.version }}"
+  }
+}
+```
+
+::: warning
+The npm package only ships the prebuilt single-file binary (no `src/` tree), and is restricted to `darwin` and `linux`. You cannot `source` internals from `node_modules/bashunit/` - use the `bashunit` command. To vendor or extend the framework, use [install.sh](#install-sh) or clone the repository.
+:::
+
+## Brew
+
+You can install **bashunit** globally on macOS or Linux using brew.
+
+```bash
+brew install bashunit
+```
+
+## MacPorts
+
+On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
+
+```bash
+sudo port install bashunit
+```
+
 ## bashdep
 
 You can manage your dependencies using [bashdep](https://github.com/Chemaclass/bashdep),
@@ -141,164 +192,40 @@ Downloading 'bashunit' to 'lib'...
 ```
 :::
 
-## Brew
+## GitHub Actions
 
-You can install **bashunit** globally on macOS or Linux using brew.
-
-```bash
-brew install bashunit
-```
-
-## MacPorts
-
-On macOS, you can also install **bashunit** via [MacPorts](https://www.macports.org):
-
-```bash
-sudo port install bashunit
-```
-
-## npm
-
-If your project already uses Node.js tooling (e.g. a JavaScript or TypeScript repo), you can install **bashunit** directly from the [npm registry](https://www.npmjs.com/package/bashunit).
-
-The npm package ships only the prebuilt single-file binary plus `LICENSE` and `README.md`; it does not include the source tree.
-
-### Per-project (recommended)
-
-Install **bashunit** as a `devDependency` so the version is pinned in your `package.json` and reproducible across machines and CI:
-
-```bash
-npm install --save-dev bashunit
-```
-
-Add a script to your `package.json`:
-
-```json
-{
-  "scripts": {
-    "test:sh": "bashunit tests/"
-  },
-  "devDependencies": {
-    "bashunit": "^{{ pkg.version }}"
-  }
-}
-```
-
-Then run:
-
-```bash
-npm run test:sh
-# or invoke directly via npx
-npx bashunit tests/
-```
-
-### Global
-
-Install **bashunit** system-wide so the `bashunit` command is available on your `PATH`:
-
-```bash
-npm install -g bashunit
-bashunit --version
-bashunit tests/
-```
-
-### One-shot, no install
-
-`npx` can download and run the latest release on demand, useful for quick tries or ephemeral CI jobs:
-
-```bash
-npx bashunit@latest tests/
-```
-
-### Example consumer project
-
-```
-my-app/
-├── package.json          # has "bashunit" in devDependencies
-├── src/
-│   └── deploy.sh
-└── tests/
-    └── deploy_test.sh
-```
-
-```bash [tests/deploy_test.sh]
-#!/usr/bin/env bash
-
-source "$(dirname "$0")/../src/deploy.sh"
-
-function test_deploy_returns_url() {
-  assert_equals "https://example.com" "$(get_deploy_url)"
-}
-```
-
-Run from the project root:
-
-```bash
-npx bashunit tests/
-```
-
-### GitHub Actions with npm
-
-```yaml
+::: code-group
+```yaml [via install.sh]
+# .github/workflows/bashunit-tests.yml
 name: Tests
+on: [pull_request, push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: curl -s https://bashunit.typeddevs.com/install.sh | bash
+      - run: ./lib/bashunit tests
+```
 
-on:
-  pull_request:
-  push:
-    branches: [main]
-
+```yaml [via npm]
+# .github/workflows/bashunit-tests.yml
+name: Tests
+on: [pull_request, push]
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with:
-          node-version: 20
+        with: { node-version: 20 }
       - run: npm ci
       - run: npx bashunit tests/
 ```
-
-::: tip
-The npm package is restricted to `darwin` and `linux`; on Windows use [WSL](https://learn.microsoft.com/windows/wsl/install). bashunit still requires **Bash 3.0 or newer** at runtime - npm does not enforce this, the `bashunit` script does.
 :::
 
-::: warning
-Because only the prebuilt single-file binary is shipped, you cannot `source` bashunit internals from inside `node_modules/bashunit/`. Use the `bashunit` command directly. If you need to extend or vendor the framework, install via [install.sh](#install-sh) or clone the repository.
-:::
-
-## GitHub Actions
-
-```yaml
-# example: .github/workflows/bashunit-tests.yml
-name: Tests
-
-on:
-  pull_request:
-  push:
-    branches:
-      - main
-
-jobs:
-  tests:
-    name: "Run tests"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: "Install bashunit"
-        run: |
-          curl -s https://bashunit.typeddevs.com/install.sh > install.sh
-          chmod +x install.sh
-          ./install.sh
-
-      - name: "Test"
-        run: "./lib/bashunit tests"
-```
-
 ::: tip
-Get inspiration from the pipelines running on the bashunit-project itself: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
+See bashunit's own pipeline for a real example: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::
 
 <script setup>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,11 +8,22 @@ Thanks to **bashunit**, verifying and validating your Bash code has never been s
 
 ## Installation
 
-There is a tool that will generate an executable with the whole library in a single file:
+Pick whichever fits your project. See [installation](/installation) for the complete list (Brew, MacPorts, bashdep, GitHub Actions, etc.).
 
 ::: code-group
-```bash [Linux/Mac]
+```bash [install.sh]
+# Generates lib/bashunit (single-file executable)
 curl -s https://bashunit.typeddevs.com/install.sh | bash
+```
+
+```bash [npm]
+# Per-project: pinned in package.json, run via npx
+npm install --save-dev bashunit
+npx bashunit tests/
+
+# Or global
+npm install -g bashunit
+bashunit tests/
 ```
 
 ```bash [Windows]
@@ -28,9 +39,7 @@ curl -s https://bashunit.typeddevs.com/install.sh | bash
 ```
 :::
 
-This will create a file inside a lib folder, such as `lib/bashunit`.
-
-See more about [installation](/installation).
+The `install.sh` route creates `lib/bashunit`; the npm route exposes `bashunit` via `npx` or your global `PATH`.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,41 @@
 {
-  "name": "bashunit-docs",
+  "name": "bashunit",
   "version": "0.35.0",
   "checksum": "bfe9f69bda77034234a38f26182cc34e1f7648d846dab57a513a14cf91977544",
-  "description": "Docs for bashunit a simple testing library for bash scripts",
-  "main": "index.js",
-  "repository": "git@github.com:TypedDevs/bashunit.git",
+  "description": "A simple testing library for bash scripts.",
+  "homepage": "https://bashunit.typeddevs.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TypedDevs/bashunit.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TypedDevs/bashunit/issues"
+  },
   "author": "TypedDevs <team@typeddevs.com>",
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "bashunit": "./bin/bashunit"
+  },
+  "files": [
+    "bin/bashunit",
+    "LICENSE",
+    "README.md"
+  ],
+  "os": [
+    "darwin",
+    "linux"
+  ],
+  "keywords": [
+    "bash",
+    "shell",
+    "testing",
+    "test",
+    "unit-testing",
+    "bashunit",
+    "tdd",
+    "assertions"
+  ],
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",

--- a/tests/unit/package_json_test.sh
+++ b/tests/unit/package_json_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=""
+PKG_FILE=""
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  PKG_FILE="$ROOT_DIR/package.json"
+}
+
+function test_package_json_name_is_bashunit() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"name"[[:space:]]*:[[:space:]]*"bashunit"' "$pkg"
+}
+
+function test_package_json_declares_bin_entry() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"bin"[[:space:]]*:' "$pkg"
+  assert_matches '"bashunit"[[:space:]]*:[[:space:]]*"\./bin/bashunit"' "$pkg"
+}
+
+function test_package_json_whitelists_publish_files() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"files"[[:space:]]*:' "$pkg"
+  assert_contains 'bin/bashunit' "$pkg"
+  assert_contains 'LICENSE' "$pkg"
+  assert_contains 'README.md' "$pkg"
+}
+
+function test_package_json_restricts_os_to_unix() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"os"[[:space:]]*:' "$pkg"
+  assert_contains '"darwin"' "$pkg"
+  assert_contains '"linux"' "$pkg"
+}
+
+function test_package_json_keeps_version_field() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"version"[[:space:]]*:[[:space:]]*"[0-9]+\.[0-9]+\.[0-9]+"' "$pkg"
+}
+
+function test_package_json_keeps_checksum_field() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_matches '"checksum"[[:space:]]*:' "$pkg"
+}
+
+function test_package_json_keeps_docs_scripts() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_contains 'docs:dev' "$pkg"
+  assert_contains 'docs:build' "$pkg"
+}


### PR DESCRIPTION
## 🤔 Background

Closes #244

To make `bashunit` consumable from JS/TS projects without `curl | bash`, publish the framework to the npm registry. Distribution becomes a one-liner (`npm install --save-dev bashunit` or `npx bashunit`).

## 💡 Changes

- Convert root `package.json` into a publishable npm package (name, bin, files whitelist, os, repo metadata) while keeping vitepress docs scripts and version/checksum sync intact.
- Add `npm-publish.yml` workflow: on release published, build the single-file binary and publish with provenance.
- Document npm install (per-project, global, npx) with a consumer example and a GitHub Actions snippet.
- Add unit test validating the publishable `package.json` shape.

<img width="1297" height="895" alt="Screenshot 2026-05-01 at 17 13 04" src="https://github.com/user-attachments/assets/9316fcaf-a5cd-44da-8dd4-90d3cbcc03c9" />

