### PR TITLE
refactor(package): split docs workspace from root package.json

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,10 +54,11 @@ make test && make sa && make lint
 
 ### Documentation Setup (Optional)
 
-For documentation changes:
+Docs live in their own workspace under `docs/` with an isolated `package.json`.
 
 ```bash
 nvm use  # Uses .nvmrc version
+cd docs
 npm ci
 npm run docs:dev
 ```
@@ -197,12 +198,13 @@ Then create the PR on GitHub, fill out the template, and link related issues.
 
 ## Documentation
 
-Documentation is built with [VitePress](https://vitepress.dev/).
+Documentation is built with [VitePress](https://vitepress.dev/) and lives in `docs/` as its own npm workspace.
 
 ```bash
 nvm use
+cd docs
 npm ci
-npm run docs:dev  # Start dev server
+npm run docs:dev    # Start dev server
 npm run docs:build  # Build and test
 ```
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -60,7 +60,7 @@ Docs live in their own workspace under `docs/` with an isolated `package.json`.
 nvm use  # Uses .nvmrc version
 cd docs
 npm ci
-npm run docs:dev
+npm run dev
 ```
 
 ## Making Changes
@@ -204,8 +204,8 @@ Documentation is built with [VitePress](https://vitepress.dev/) and lives in `do
 nvm use
 cd docs
 npm ci
-npm run docs:dev    # Start dev server
-npm run docs:build  # Build and test
+npm run dev    # Start dev server
+npm run build  # Build and test
 ```
 
 **Guidelines:** Keep it simple, include examples, test all code examples.

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -5,7 +5,7 @@ This is a guide to knowing the steps to create a new release.
 1. Update the version in [BASHUNIT_VERSION](../bashunit)
 1. Update the version in [LATEST_BASHUNIT_VERSION](../install.sh)
 1. Update the version in [CHANGELOG.md](../CHANGELOG.md)
-1. Update the version in [package.json](../package.json)
+1. Update the version in [package.json](../package.json) and [docs/package.json](../docs/package.json)
 1. Build the project `./build.sh bin`
     1. This will generate `bin/bashunit` and `bin/checksum`
 1. Update the checksum(sha256) in [package.json](../package.json)

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -26,9 +26,12 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
+        working-directory: docs
         run: npm ci
 
       - name: Build with VitePress
+        working-directory: docs
         run: npm run docs:build

--- a/.github/workflows/check-docs.yml
+++ b/.github/workflows/check-docs.yml
@@ -34,4 +34,4 @@ jobs:
 
       - name: Build with VitePress
         working-directory: docs
-        run: npm run docs:build
+        run: npm run build

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build with VitePress
         working-directory: docs
-        run: npm run docs:build
+        run: npm run build
 
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -28,11 +28,14 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: docs/package-lock.json
 
       - name: Install dependencies
+        working-directory: docs
         run: npm ci
 
       - name: Build with VitePress
+        working-directory: docs
         run: npm run docs:build
 
       - name: Publish to Cloudflare Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Publish bashunit to the npm registry: `npm install -g bashunit` ships the prebuilt single-file binary; new `npm-publish.yml` workflow publishes on release (#244)
 
 ### Changed
+- Split documentation into its own npm workspace under `docs/`: VitePress dependencies and `docs:*` scripts moved out of the root `package.json` so the published npm package stays slim. CI workflows, release script and contributing docs updated for the new `cd docs && npm ci` workflow; `make docs/{install,dev,build,preview}` shortcuts added
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ docs/install:
 	@cd docs && npm ci
 
 docs/dev:
-	@cd docs && npm run docs:dev
+	@cd docs && npm run dev
 
 docs/build:
-	@cd docs && npm run docs:build
+	@cd docs && npm run build
 
 docs/preview:
-	@cd docs && npm run docs:preview
+	@cd docs && npm run preview

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,10 @@ help:
 	@echo "  pre_commit/run           Function that will be called when the pre-commit hook runs"
 	@echo "  sa                       Run shellcheck static analysis tool"
 	@echo "  lint                     Run editorconfig linter tool"
+	@echo "  docs/install             Install docs npm dependencies (in docs/)"
+	@echo "  docs/dev                 Start the VitePress dev server"
+	@echo "  docs/build               Build the documentation site"
+	@echo "  docs/preview             Preview the built documentation"
 
 SRC_SCRIPTS_DIR=src
 TEST_SCRIPTS_DIR=tests
@@ -98,3 +102,15 @@ ifndef LINTER_CHECKER
 else
 	@editorconfig-checker && printf "\e[1m\e[32m%s\e[0m\n" "editorconfig-check: OK!"
 endif
+
+docs/install:
+	@cd docs && npm ci
+
+docs/dev:
+	@cd docs && npm run docs:dev
+
+docs/build:
+	@cd docs && npm run docs:build
+
+docs/preview:
+	@cd docs && npm run docs:preview

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bashunit-docs",
-  "version": "0.20.0",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bashunit-docs",
-      "version": "0.20.0",
+      "version": "0.35.0",
       "license": "MIT",
       "dependencies": {
         "chart.js": "^4.4.9",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bashunit-docs",
+  "version": "0.35.0",
+  "description": "Docs for bashunit a simple testing library for bash scripts",
+  "private": true,
+  "repository": "git@github.com:TypedDevs/bashunit.git",
+  "author": "TypedDevs <team@typeddevs.com>",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
+  },
+  "dependencies": {
+    "chart.js": "^4.4.9",
+    "vanilla-tilt": "^1.8.1"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3",
+    "vue": "^3.5.16"
+  }
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,9 +8,9 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "docs:dev": "vitepress dev .",
-    "docs:build": "vitepress build .",
-    "docs:preview": "vitepress preview ."
+    "dev": "vitepress dev .",
+    "build": "vitepress build .",
+    "preview": "vitepress preview ."
   },
   "dependencies": {
     "chart.js": "^4.4.9",

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -40,10 +40,10 @@ For documentation changes you can preview locally with:
 ```bash
 cd docs
 npm ci
-npm run docs:dev
+npm run dev
 ```
 
-Before submitting your pull request ensure that `npm run docs:build` (run from `docs/`) succeeds and that the test suite passes.
+Before submitting your pull request ensure that `npm run build` (run from `docs/`) succeeds and that the test suite passes.
 
 ## Further reading
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -38,11 +38,12 @@ Pull requests are welcome! Please read the [contribution guide](https://github.c
 For documentation changes you can preview locally with:
 
 ```bash
+cd docs
 npm ci
 npm run docs:dev
 ```
 
-Before submitting your pull request ensure that `npm run docs:build` succeeds and that the test suite passes.
+Before submitting your pull request ensure that `npm run docs:build` (run from `docs/`) succeeds and that the test suite passes.
 
 ## Further reading
 

--- a/package.json
+++ b/package.json
@@ -35,18 +35,5 @@
     "bashunit",
     "tdd",
     "assertions"
-  ],
-  "scripts": {
-    "docs:dev": "vitepress dev docs",
-    "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
-  },
-  "dependencies": {
-    "chart.js": "^4.4.9",
-    "vanilla-tilt": "^1.8.1"
-  },
-  "devDependencies": {
-    "vitepress": "^1.6.3",
-    "vue": "^3.5.16"
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "bugs": {
     "url": "https://github.com/TypedDevs/bashunit/issues"
   },
-  "author": "TypedDevs <team@typeddevs.com>",
+  "author": "Chemaclass <chemaclass@outlook.es>",
   "license": "MIT",
   "type": "module",
   "bin": {

--- a/release.sh
+++ b/release.sh
@@ -521,7 +521,7 @@ function release::sandbox::run() {
   release::blank_line
   # Commit changes (confirmations skipped in sandbox)
   release::log_info "Creating release commit..."
-  git add "${RELEASE_FILES[@]}"
+  git add "${RELEASE_FILES[@]}" docs/package.json
   git commit -m "release: $VERSION" -n
   release::log_success "Created commit"
   git tag "$VERSION"
@@ -624,6 +624,13 @@ function release::update_package_json_version() {
     "\"version\": \"[^\"]*\"" \
     "\"version\": \"$new_version\"" \
     "version"
+  if [ -f "docs/package.json" ]; then
+    release::update_file_pattern \
+      "docs/package.json" \
+      "\"version\": \"[^\"]*\"" \
+      "\"version\": \"$new_version\"" \
+      "version"
+  fi
 }
 
 function release::update_changelog() {
@@ -836,7 +843,7 @@ function release::git_commit_and_tag() {
     return
   fi
 
-  git add "${RELEASE_FILES[@]}"
+  git add "${RELEASE_FILES[@]}" docs/package.json
   git commit -m "release: $new_version" -n
   release::log_success "Created commit"
 

--- a/tests/unit/package_json_test.sh
+++ b/tests/unit/package_json_test.sh
@@ -2,10 +2,12 @@
 
 ROOT_DIR=""
 PKG_FILE=""
+DOCS_PKG_FILE=""
 
 function set_up_before_script() {
   ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
   PKG_FILE="$ROOT_DIR/package.json"
+  DOCS_PKG_FILE="$ROOT_DIR/docs/package.json"
 }
 
 function test_package_json_name_is_bashunit() {
@@ -50,9 +52,44 @@ function test_package_json_keeps_checksum_field() {
   assert_matches '"checksum"[[:space:]]*:' "$pkg"
 }
 
-function test_package_json_keeps_docs_scripts() {
+function test_package_json_excludes_docs_scripts() {
   local pkg
   pkg=$(cat "$PKG_FILE")
+  assert_not_contains 'docs:dev' "$pkg"
+  assert_not_contains 'docs:build' "$pkg"
+}
+
+function test_docs_package_json_keeps_docs_scripts() {
+  local pkg
+  pkg=$(cat "$DOCS_PKG_FILE")
   assert_contains 'docs:dev' "$pkg"
   assert_contains 'docs:build' "$pkg"
+}
+
+function test_docs_package_json_name_is_bashunit_docs() {
+  local pkg
+  pkg=$(cat "$DOCS_PKG_FILE")
+  assert_matches '"name"[[:space:]]*:[[:space:]]*"bashunit-docs"' "$pkg"
+}
+
+function test_package_json_excludes_docs_dependencies() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_not_contains 'vitepress' "$pkg"
+  assert_not_contains 'chart.js' "$pkg"
+  assert_not_contains 'vanilla-tilt' "$pkg"
+  assert_not_contains '"vue"' "$pkg"
+}
+
+function test_docs_package_json_marked_private() {
+  local pkg
+  pkg=$(cat "$DOCS_PKG_FILE")
+  assert_matches '"private"[[:space:]]*:[[:space:]]*true' "$pkg"
+}
+
+function test_docs_package_json_declares_vitepress_devdep() {
+  local pkg
+  pkg=$(cat "$DOCS_PKG_FILE")
+  assert_matches '"devDependencies"[[:space:]]*:' "$pkg"
+  assert_contains 'vitepress' "$pkg"
 }

--- a/tests/unit/package_json_test.sh
+++ b/tests/unit/package_json_test.sh
@@ -55,15 +55,15 @@ function test_package_json_keeps_checksum_field() {
 function test_package_json_excludes_docs_scripts() {
   local pkg
   pkg=$(cat "$PKG_FILE")
-  assert_not_contains 'docs:dev' "$pkg"
-  assert_not_contains 'docs:build' "$pkg"
+  assert_not_contains 'vitepress' "$pkg"
 }
 
-function test_docs_package_json_keeps_docs_scripts() {
+function test_docs_package_json_declares_vitepress_scripts() {
   local pkg
   pkg=$(cat "$DOCS_PKG_FILE")
-  assert_contains 'docs:dev' "$pkg"
-  assert_contains 'docs:build' "$pkg"
+  assert_contains '"dev": "vitepress dev' "$pkg"
+  assert_contains '"build": "vitepress build' "$pkg"
+  assert_contains '"preview": "vitepress preview' "$pkg"
 }
 
 function test_docs_package_json_name_is_bashunit_docs() {

--- a/tests/unit/release_update_test.sh
+++ b/tests/unit/release_update_test.sh
@@ -122,6 +122,43 @@ function test_update_package_json_version_changes_version_string() {
   rm -rf "$temp_dir"
 }
 
+function test_update_package_json_version_also_updates_docs_package_json() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+
+  cp "$FIXTURES_DIR/mock_package.json" "$temp_dir/package.json"
+  mkdir -p "$temp_dir/docs"
+  cp "$FIXTURES_DIR/mock_package.json" "$temp_dir/docs/package.json"
+
+  DRY_RUN=false
+  (
+    cd "$temp_dir" || return
+    release::update_package_json_version "0.31.0" 2>/dev/null
+  )
+
+  assert_contains '"version": "0.31.0"' "$(cat "$temp_dir/package.json")"
+  assert_contains '"version": "0.31.0"' "$(cat "$temp_dir/docs/package.json")"
+
+  rm -rf "$temp_dir"
+}
+
+function test_update_package_json_version_skips_docs_when_missing() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+
+  cp "$FIXTURES_DIR/mock_package.json" "$temp_dir/package.json"
+
+  DRY_RUN=false
+  (
+    cd "$temp_dir" || return
+    release::update_package_json_version "0.31.0" 2>/dev/null
+  )
+
+  assert_file_not_exists "$temp_dir/docs/package.json"
+
+  rm -rf "$temp_dir"
+}
+
 function test_update_changelog_adds_new_unreleased_section() {
   local temp_dir
   temp_dir=$(mktemp -d)


### PR DESCRIPTION
## 🤔 Background

Publishing bashunit to npm (#244) shipped VitePress and the docs site as runtime dependencies of the package. This bloats `npm install bashunit` for end users and conflates two unrelated workspaces.

## 💡 Changes

- Move VitePress deps and `docs:*` scripts into a dedicated `docs/package.json` (private workspace) so the published npm package stays slim
- Update `publish-docs` and `check-docs` workflows to run from `docs/` and cache its lockfile
- Teach `release.sh` and `.github/RELEASE.md` to bump `docs/package.json` version alongside the root one
- Refresh contributing docs and add `make docs/{install,dev,build,preview}` shortcuts for the new `cd docs && npm ci` workflow