### PR TITLE
test(package): guard root package.json against dependency regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 - Split documentation into its own npm workspace under `docs/`: VitePress dependencies and `docs:*` scripts moved out of the root `package.json` so the published npm package stays slim. CI workflows, release script and contributing docs updated for the new `cd docs && npm ci` workflow; `make docs/{install,dev,build,preview}` shortcuts added
+- Guard root `package.json` against accidental regression of the docs-split: assert no `dependencies`/`devDependencies`/`peerDependencies`/`scripts` blocks ever return to the published manifest
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/tests/unit/package_json_test.sh
+++ b/tests/unit/package_json_test.sh
@@ -81,6 +81,20 @@ function test_package_json_excludes_docs_dependencies() {
   assert_not_contains '"vue"' "$pkg"
 }
 
+function test_package_json_declares_no_dependencies_block() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_not_matches '"dependencies"[[:space:]]*:' "$pkg"
+  assert_not_matches '"devDependencies"[[:space:]]*:' "$pkg"
+  assert_not_matches '"peerDependencies"[[:space:]]*:' "$pkg"
+}
+
+function test_package_json_declares_no_scripts_block() {
+  local pkg
+  pkg=$(cat "$PKG_FILE")
+  assert_not_matches '"scripts"[[:space:]]*:' "$pkg"
+}
+
 function test_docs_package_json_marked_private() {
   local pkg
   pkg=$(cat "$DOCS_PKG_FILE")


### PR DESCRIPTION
## 🤔 Background

Follow-up to #649. The split moved VitePress out of root `package.json`, but nothing prevents a future contributor from re-adding `dependencies`, `devDependencies`, `peerDependencies` or `scripts` to the published manifest by accident.

## 💡 Changes

- Add structural assertions to `tests/unit/package_json_test.sh` ensuring the root manifest carries none of the dependency or scripts blocks
- Document the guard in CHANGELOG `Unreleased`