### PR TITLE
chore(shellcheck): silence intentional SC2016 in coverage tests

### DIFF
--- a/tests/unit/coverage_executable_test.sh
+++ b/tests/unit/coverage_executable_test.sh
@@ -241,6 +241,7 @@ function test_coverage_is_executable_line_returns_false_for_done_with_file_redir
 
 function test_coverage_is_executable_line_returns_false_for_done_with_herestring() {
   local result
+  # shellcheck disable=SC2016
   result=$(bashunit::coverage::is_executable_line '  done <<<"$var"' 2 && echo "yes" || echo "no")
   assert_equals "no" "$result"
 }
@@ -253,6 +254,7 @@ function test_coverage_is_executable_line_returns_false_for_done_with_process_su
 
 function test_coverage_is_executable_line_returns_false_for_done_with_redirect_and_comment() {
   local result
+  # shellcheck disable=SC2016
   result=$(bashunit::coverage::is_executable_line '  done < "$file" # read input' 2 && echo "yes" || echo "no")
   assert_equals "no" "$result"
 }


### PR DESCRIPTION
## 🤔 Background

`make sa` prints two SC2016 hints on every run because two coverage tests deliberately pass literal `$var`/`$file` strings as fixtures to `is_executable_line`. The warnings are noise — the strings are meant to look like raw shell snippets.

## 💡 Changes

- Add per-line `# shellcheck disable=SC2016` directives next to the two intentional fixtures so `make sa` runs noise-free