### PR TITLE
refactor(release): include docs/package.json in RELEASE_FILES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed
 - Split documentation into its own npm workspace under `docs/`: VitePress dependencies and `docs:*` scripts moved out of the root `package.json` so the published npm package stays slim. CI workflows, release script and contributing docs updated for the new `cd docs && npm ci` workflow; `make docs/{install,dev,build,preview}` shortcuts added
 - Guard root `package.json` against accidental regression of the docs-split: assert no `dependencies`/`devDependencies`/`peerDependencies`/`scripts` blocks ever return to the published manifest
+- `release.sh` now treats `docs/package.json` as a first-class `RELEASE_FILES` entry, so the release flow backs it up, restores it on rollback, and stages it without inline duplication. Backup/restore preserves nested directory paths
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ declare -r EXIT_EXECUTION_ERROR=2
 # Constants
 GITHUB_REPO_PATH="TypedDevs/bashunit"
 GITHUB_REPO_URL="https://github.com/${GITHUB_REPO_PATH}"
-RELEASE_FILES=("bashunit" "install.sh" "package.json" "CHANGELOG.md")
+RELEASE_FILES=("bashunit" "install.sh" "package.json" "docs/package.json" "CHANGELOG.md")
 
 # Helper function for regex matching (Bash 3.0+ compatible)
 function regex_match() {
@@ -287,7 +287,9 @@ function release::backup::init() {
 function release::backup::save_file() {
   local file=$1
   if [[ -f "$file" ]]; then
-    cp "$file" "$BACKUP_DIR/"
+    local dest="$BACKUP_DIR/$file"
+    mkdir -p "$(dirname "$dest")"
+    cp "$file" "$dest"
     release::log_verbose "Backed up: $file"
   fi
 }
@@ -313,14 +315,12 @@ function release::rollback::restore_files() {
   fi
 
   release::log_info "Restoring files from backup..."
-  for file in "$BACKUP_DIR"/*; do
-    if [[ -f "$file" ]]; then
-      local filename
-      filename=$(basename "$file")
-      cp "$file" "./$filename"
-      release::log_verbose "Restored: $filename"
-    fi
-  done
+  while IFS= read -r file; do
+    local rel="${file#"$BACKUP_DIR"/}"
+    mkdir -p "$(dirname "./$rel")"
+    cp "$file" "./$rel"
+    release::log_verbose "Restored: $rel"
+  done < <(find "$BACKUP_DIR" -type f)
   release::log_success "Files restored from backup"
 }
 
@@ -521,7 +521,7 @@ function release::sandbox::run() {
   release::blank_line
   # Commit changes (confirmations skipped in sandbox)
   release::log_info "Creating release commit..."
-  git add "${RELEASE_FILES[@]}" docs/package.json
+  git add "${RELEASE_FILES[@]}"
   git commit -m "release: $VERSION" -n
   release::log_success "Created commit"
   git tag "$VERSION"
@@ -843,7 +843,7 @@ function release::git_commit_and_tag() {
     return
   fi
 
-  git add "${RELEASE_FILES[@]}" docs/package.json
+  git add "${RELEASE_FILES[@]}"
   git commit -m "release: $new_version" -n
   release::log_success "Created commit"
 

--- a/tests/unit/release_utilities_test.sh
+++ b/tests/unit/release_utilities_test.sh
@@ -135,6 +135,47 @@ function test_rollback_restore_files_restores_backup() {
   rm -rf "$temp_dir"
 }
 
+function test_backup_save_file_preserves_subdirectory_path() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+
+  local result
+  result=$(
+    cd "$temp_dir" || return
+    mkdir -p docs
+    echo "docs content" >docs/package.json
+    release::backup::init
+    release::backup::save_file "docs/package.json"
+    cat "$BACKUP_DIR/docs/package.json"
+  )
+
+  assert_same "docs content" "$result"
+  rm -rf "$temp_dir"
+}
+
+function test_rollback_restore_files_restores_nested_paths() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+
+  local result
+  result=$(
+    cd "$temp_dir" || return
+    mkdir -p docs
+    echo "original docs" >docs/package.json
+    echo "original root" >root.txt
+    release::backup::init
+    release::backup::save_file "docs/package.json"
+    release::backup::save_file "root.txt"
+    echo "modified docs" >docs/package.json
+    echo "modified root" >root.txt
+    release::rollback::restore_files 2>/dev/null
+    printf '%s|%s' "$(cat docs/package.json)" "$(cat root.txt)"
+  )
+
+  assert_same "original docs|original root" "$result"
+  rm -rf "$temp_dir"
+}
+
 ##########################
 # Pre-flight check tests
 ##########################


### PR DESCRIPTION
## 🤔 Background

After #649 the docs `package.json` exists alongside the root one, but `release.sh` referenced it inline (two `git add ... docs/package.json` duplications) while leaving it out of the `RELEASE_FILES` array. That meant backup/rollback never covered it, and adding it naïvely would have collided with the root file because the backup helper flattened paths.

## 💡 Changes

- Promote `docs/package.json` to a first-class `RELEASE_FILES` entry so preflight, backup, rollback and commit-staging all handle it uniformly
- Drop the two inline `git add ... docs/package.json` duplications
- Update `release::backup::save_file` and `release::rollback::restore_files` to preserve nested directory structure
- New tests covering subdirectory backup + nested-path rollback