### PR TITLE
refactor(runner): extract runtime error pattern scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `release.sh` now treats `docs/package.json` as a first-class `RELEASE_FILES` entry, so the release flow backs it up, restores it on rollback, and stages it without inline duplication. Backup/restore preserves nested directory paths
 - Extract `bashunit::runner::source_login_shell_profiles` and `bashunit::runner::print_verbose_test_summary` from the 320-line `run_test` body so the hot path reads top-down without inline `~/.profile` sourcing or printf scaffolding
 - Further trim `bashunit::runner::run_test`: extract `export_test_identity` (test ID + coverage env exports) and `apply_interpolated_title` (data-provider title interpolation) so the function opens with five named one-liners instead of an inline export/branch block
+- Extract `bashunit::runner::detect_runtime_error` so the 23-pattern runtime-error scan in `run_test` becomes a single named call
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -46,6 +46,29 @@ function bashunit::runner::apply_interpolated_title() {
   printf '%s' "$interpolated"
 }
 
+function bashunit::runner::detect_runtime_error() {
+  local runtime_output=$1
+  local error
+  for error in "command not found" "unbound variable" "permission denied" \
+    "no such file or directory" "syntax error" "bad substitution" \
+    "division by 0" "cannot allocate memory" "bad file descriptor" \
+    "segmentation fault" "illegal option" "argument list too long" \
+    "readonly variable" "missing keyword" "killed" \
+    "cannot execute binary file" "invalid arithmetic operator" \
+    "ambiguous redirect" "integer expression expected" \
+    "too many arguments" "value too great" \
+    "not a valid identifier" "unexpected EOF"; do
+    case "$runtime_output" in
+    *"$error"*)
+      local runtime_error="${runtime_output#*: }"
+      printf '%s' "${runtime_error//$'\n'/}"
+      return 0
+      ;;
+    esac
+  done
+  printf ''
+}
+
 function bashunit::runner::print_verbose_test_summary() {
   local test_file=$1
   local fn_name=$2
@@ -735,25 +758,8 @@ function bashunit::runner::run_test() {
 
   local runtime_output="${test_execution_result%%##ASSERTIONS_*}"
 
-  local runtime_error=""
-  local error=""
-  for error in "command not found" "unbound variable" "permission denied" \
-    "no such file or directory" "syntax error" "bad substitution" \
-    "division by 0" "cannot allocate memory" "bad file descriptor" \
-    "segmentation fault" "illegal option" "argument list too long" \
-    "readonly variable" "missing keyword" "killed" \
-    "cannot execute binary file" "invalid arithmetic operator" \
-    "ambiguous redirect" "integer expression expected" \
-    "too many arguments" "value too great" \
-    "not a valid identifier" "unexpected EOF"; do
-    case "$runtime_output" in
-    *"$error"*)
-      runtime_error="${runtime_output#*: }"  # Remove everything up to and including ": "
-      runtime_error=${runtime_error//$'\n'/} # Remove all newlines using parameter expansion
-      break
-      ;;
-    esac
-  done
+  local runtime_error
+  runtime_error=$(bashunit::runner::detect_runtime_error "$runtime_output")
 
   bashunit::runner::parse_result "$fn_name" "$test_execution_result" "$@"
 


### PR DESCRIPTION
## 🤔 Background

Iter 2 of the `run_test` slim-down. The function still inlined a 23-pattern `case` loop that scanned the captured runtime output for known shell errors.

## 💡 Changes

- Extract `bashunit::runner::detect_runtime_error <runtime_output>` — returns the cleaned error string (or empty) so the call site is a single line
- Pure extraction; the existing acceptance suite (`bashunit_execution_error_test.sh`, `bashunit_syntax_error_test.sh`) covers the path