### PR TITLE
refactor(runner): extract subshell output type and formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Extract `bashunit::runner::source_login_shell_profiles` and `bashunit::runner::print_verbose_test_summary` from the 320-line `run_test` body so the hot path reads top-down without inline `~/.profile` sourcing or printf scaffolding
 - Further trim `bashunit::runner::run_test`: extract `export_test_identity` (test ID + coverage env exports) and `apply_interpolated_title` (data-provider title interpolation) so the function opens with five named one-liners instead of an inline export/branch block
 - Extract `bashunit::runner::detect_runtime_error` so the 23-pattern runtime-error scan in `run_test` becomes a single named call
+- Extract `bashunit::runner::extract_subshell_type` and `bashunit::runner::format_subshell_output` so the encoded-output decode block in `run_test` is two pure transforms (the `print_line` side effect stays at the call site)
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -46,6 +46,21 @@ function bashunit::runner::apply_interpolated_title() {
   printf '%s' "$interpolated"
 }
 
+function bashunit::runner::extract_subshell_type() {
+  local subshell_output=$1
+  local type="${subshell_output%%]*}"
+  printf '%s' "${type#[}"
+}
+
+function bashunit::runner::format_subshell_output() {
+  local subshell_output=$1
+  local line="${subshell_output#*]}"
+  line=${line//\[failed\]/$'\n'}
+  line=${line//\[skipped\]/$'\n'}
+  line=${line//\[incomplete\]/$'\n'}
+  printf '%s' "$line"
+}
+
 function bashunit::runner::detect_runtime_error() {
   local runtime_output=$1
   local error
@@ -739,21 +754,12 @@ function bashunit::runner::run_test() {
   local subshell_output=$(bashunit::runner::decode_subshell_output "$test_execution_result")
 
   if [ -n "$subshell_output" ]; then
-    # Formatted as "[type]line" @see `bashunit::state::print_line()`
-    local type="${subshell_output%%]*}" # Remove everything after "]"
-    type="${type#[}"                    # Remove the leading "["
-    local line="${subshell_output#*]}"  # Remove everything before and including "]"
-
-    # Replace [type] with a newline to split the messages
-    line=${line//\[failed\]/$'\n'}     # Replace [failed] with newline
-    line=${line//\[skipped\]/$'\n'}    # Replace [skipped] with newline
-    line=${line//\[incomplete\]/$'\n'} # Replace [incomplete] with newline
-
+    local type
+    type=$(bashunit::runner::extract_subshell_type "$subshell_output")
+    subshell_output=$(bashunit::runner::format_subshell_output "$subshell_output")
     if ! bashunit::env::is_failures_only_enabled; then
-      bashunit::state::print_line "$type" "$line"
+      bashunit::state::print_line "$type" "$subshell_output"
     fi
-
-    subshell_output=$line
   fi
 
   local runtime_output="${test_execution_result%%##ASSERTIONS_*}"


### PR DESCRIPTION
## 🤔 Background

Iter 3 of the `run_test` slim-down. The `[type]line` decode block was inline: parse the encoded type, replace `[failed]/[skipped]/[incomplete]` markers with newlines, then call `print_line` and reassign the local.

## 💡 Changes

- Extract `bashunit::runner::extract_subshell_type` — pulls the `[type]` prefix
- Extract `bashunit::runner::format_subshell_output` — strips markers and returns the cleaned line
- Keep the `bashunit::state::print_line` side effect at the call site so command substitution does not capture user-facing output (regression caught locally during the parallel test run; fix preserved)
- Bash 3.0+ compatible