### PR TITLE
refactor(runner): extract encoded field decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Extract `bashunit::runner::detect_runtime_error` so the 23-pattern runtime-error scan in `run_test` becomes a single named call
 - Extract `bashunit::runner::extract_subshell_type` and `bashunit::runner::format_subshell_output` so the encoded-output decode block in `run_test` is two pure transforms (the `print_line` side effect stays at the call site)
 - Extract `bashunit::runner::compute_total_assertions` so the five `_te_*` parameter-expansion lines collapse into a single named call
+- Extract `bashunit::runner::extract_encoded_field` so the three `TEST_TITLE`/`TEST_HOOK_FAILURE`/`TEST_HOOK_MESSAGE` decode blocks share a single key-aware helper instead of three near-duplicates
 - Centralize all ANSI escape emission through the existing `_BASHUNIT_COLOR_*` constants. `src/coverage.sh` and the `--watch` screen-clear in `src/main.sh` no longer hardcode escape sequences (#247)
 - Speed up coverage report generation by collapsing the per-line non-executable pattern checks in `bashunit::coverage::is_executable_line` into a single combined `grep` invocation (#636)
 - Speed up coverage report generation further by combining executable + hit counting into a single source-file pass (`bashunit::coverage::compute_file_coverage`) shared across text/lcov/html reporters, removing per-line `get_line_hits` scans of the coverage data file (#636)

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -46,6 +46,19 @@ function bashunit::runner::apply_interpolated_title() {
   printf '%s' "$interpolated"
 }
 
+function bashunit::runner::extract_encoded_field() {
+  local test_execution_result=$1
+  local key=$2
+  local marker="##${key}="
+  case "$test_execution_result" in
+  *"$marker"*)
+    local rest="${test_execution_result#*"$marker"}"
+    printf '%s' "${rest%%##*}"
+    ;;
+  *) printf '' ;;
+  esac
+}
+
 function bashunit::runner::compute_total_assertions() {
   local test_execution_result=$1
   local failed passed skipped incomplete snapshot
@@ -790,27 +803,15 @@ function bashunit::runner::run_test() {
   local total_assertions
   total_assertions=$(bashunit::runner::compute_total_assertions "$test_execution_result")
 
-  local encoded_test_title
-  encoded_test_title="${test_execution_result##*##TEST_TITLE=}"
-  encoded_test_title="${encoded_test_title%%##*}"
+  local encoded_test_title hook_failure encoded_hook_message
+  encoded_test_title=$(bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_TITLE")
+  hook_failure=$(bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_FAILURE")
+  encoded_hook_message=$(bashunit::runner::extract_encoded_field "$test_execution_result" "TEST_HOOK_MESSAGE")
+
   local test_title=""
   [ -n "$encoded_test_title" ] && test_title="$(bashunit::helper::decode_base64 "$encoded_test_title")"
-
-  local encoded_hook_failure
-  encoded_hook_failure="${test_execution_result##*##TEST_HOOK_FAILURE=}"
-  encoded_hook_failure="${encoded_hook_failure%%##*}"
-  local hook_failure=""
-  if [ "$encoded_hook_failure" != "$test_execution_result" ]; then
-    hook_failure="$encoded_hook_failure"
-  fi
-
-  local encoded_hook_message
-  encoded_hook_message="${test_execution_result##*##TEST_HOOK_MESSAGE=}"
-  encoded_hook_message="${encoded_hook_message%%##*}"
   local hook_message=""
-  if [ -n "$encoded_hook_message" ]; then
-    hook_message="$(bashunit::helper::decode_base64 "$encoded_hook_message")"
-  fi
+  [ -n "$encoded_hook_message" ] && hook_message="$(bashunit::helper::decode_base64 "$encoded_hook_message")"
 
   bashunit::set_test_title "$test_title"
   local label


### PR DESCRIPTION
## 🤔 Background

Final iter of the `run_test` slim-down. Three encoded fields (`TEST_TITLE`, `TEST_HOOK_FAILURE`, `TEST_HOOK_MESSAGE`) were each decoded with a near-identical pair of parameter expansions, and `TEST_HOOK_FAILURE` had to compare against the full result to detect "no key present".

## 💡 Changes

- Add `bashunit::runner::extract_encoded_field <result> <key>` — uses a `case` match so the absent-key case returns an empty string explicitly
- Collapse the three decode blocks into three calls
- Bash 3.0+ compatible (`case`/`esac`, no `[[ ]]`, no associative arrays)