### PR TITLE
fix(security): harden temp-dir handling against symlink/env-override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- `bashunit learn` and coverage now create temp directories via `mktemp -d` (no predictable PID-based paths under `/tmp`)
+- `bashunit::parallel::cleanup` refuses to `rm -rf` a `TEMP_DIR_PARALLEL_TEST_SUITE` whose path is not under `*/bashunit/parallel/*`, preventing accidental wipes from env overrides
+
 ### Internal
 - Codify global-slot return pattern for hot-path helpers; namespace mock/spy state under `_BASHUNIT_SPY_*` (#674)
 

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -75,11 +75,10 @@ function bashunit::coverage::init() {
     return 0
   fi
 
-  # Create coverage data directory with unique name
-  # Use $$ (PID) + $RANDOM to avoid conflicts when tests call coverage::init
+  # Create coverage data directory with unique name via mktemp -d
+  # (avoids $$-$RANDOM collisions and symlink races in shared temp dirs)
   local coverage_dir
-  coverage_dir="${BASHUNIT_TEMP_DIR:-/tmp}/bashunit-coverage-$$-$RANDOM"
-  mkdir -p "$coverage_dir"
+  coverage_dir=$("${MKTEMP:-mktemp}" -d "${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}/bashunit-coverage.XXXXXXXX")
 
   _BASHUNIT_COVERAGE_DATA_FILE="${coverage_dir}/hits.dat"
   _BASHUNIT_COVERAGE_TRACKED_FILES="${coverage_dir}/files.dat"

--- a/src/learn.sh
+++ b/src/learn.sh
@@ -6,14 +6,14 @@
 # Provides guided tutorials and exercises to learn bashunit
 ##
 
-declare -r LEARN_TEMP_DIR="/tmp/bashunit_learn_$$"
+LEARN_TEMP_DIR=""
 declare -r LEARN_PROGRESS_FILE="$HOME/.bashunit_learn_progress"
 
 ##
 # Initialize learning environment
 ##
 function bashunit::learn::init() {
-  mkdir -p "$LEARN_TEMP_DIR"
+  LEARN_TEMP_DIR=$("${MKTEMP:-mktemp}" -d "${TMPDIR:-/tmp}/bashunit_learn.XXXXXXXX")
   mkdir -p tests
 }
 
@@ -21,7 +21,9 @@ function bashunit::learn::init() {
 # Cleanup learning environment
 ##
 function bashunit::learn::cleanup() {
-  rm -rf "$LEARN_TEMP_DIR"
+  if [ -n "${LEARN_TEMP_DIR:-}" ] && [ -d "$LEARN_TEMP_DIR" ]; then
+    rm -rf "$LEARN_TEMP_DIR"
+  fi
 }
 
 ##

--- a/src/parallel.sh
+++ b/src/parallel.sh
@@ -126,7 +126,16 @@ function bashunit::parallel::must_stop_on_failure() {
 
 function bashunit::parallel::cleanup() {
   # shellcheck disable=SC2153
-  rm -rf "$TEMP_DIR_PARALLEL_TEST_SUITE"
+  local target="$TEMP_DIR_PARALLEL_TEST_SUITE"
+  case "$target" in
+  */bashunit/parallel/*)
+    rm -rf "$target"
+    ;;
+  *)
+    bashunit::internal_log "parallel::cleanup" "refused unsafe path:$target"
+    return 1
+    ;;
+  esac
 }
 
 function bashunit::parallel::init() {

--- a/tests/unit/parallel_test.sh
+++ b/tests/unit/parallel_test.sh
@@ -20,7 +20,7 @@ function set_up() {
   _ORIGINAL_TEMP_DIR_PARALLEL="${TEMP_DIR_PARALLEL_TEST_SUITE:-}"
   _ORIGINAL_TEMP_FILE_STOP="${TEMP_FILE_PARALLEL_STOP_ON_FAILURE:-}"
 
-  export TEMP_DIR_PARALLEL_TEST_SUITE="$_TEST_TEMP_DIR/parallel_suite"
+  export TEMP_DIR_PARALLEL_TEST_SUITE="$_TEST_TEMP_DIR/bashunit/parallel/suite"
   export TEMP_FILE_PARALLEL_STOP_ON_FAILURE="$_TEST_TEMP_DIR/stop_on_failure"
 }
 
@@ -145,6 +145,16 @@ function test_cleanup_removes_temp_directory() {
   bashunit::parallel::cleanup
 
   assert_directory_not_exists "$TEMP_DIR_PARALLEL_TEST_SUITE"
+}
+
+function test_cleanup_refuses_path_outside_bashunit_parallel() {
+  local unsafe_dir="$_TEST_TEMP_DIR/not_bashunit"
+  mkdir -p "$unsafe_dir"
+  export TEMP_DIR_PARALLEL_TEST_SUITE="$unsafe_dir"
+
+  bashunit::parallel::cleanup
+
+  assert_directory_exists "$unsafe_dir"
 }
 
 # === stop_on_failure tests ===

--- a/tests/unit/parallel_test.sh
+++ b/tests/unit/parallel_test.sh
@@ -152,8 +152,10 @@ function test_cleanup_refuses_path_outside_bashunit_parallel() {
   mkdir -p "$unsafe_dir"
   export TEMP_DIR_PARALLEL_TEST_SUITE="$unsafe_dir"
 
-  bashunit::parallel::cleanup
+  local rc=0
+  bashunit::parallel::cleanup || rc=$?
 
+  assert_same "1" "$rc"
   assert_directory_exists "$unsafe_dir"
 }
 


### PR DESCRIPTION
## Summary
- `src/learn.sh`: replace predictable `/tmp/bashunit_learn_$$` with `mktemp -d`, eliminating PID-based symlink races in shared `/tmp`
- `src/coverage.sh`: replace `$$-$RANDOM` directory naming with `mktemp -d` for the same reason and to drop the (low but real) collision risk
- `src/parallel.sh`: `bashunit::parallel::cleanup` now refuses to `rm -rf` a `TEMP_DIR_PARALLEL_TEST_SUITE` whose path is not under `*/bashunit/parallel/*` — guards against accidental wipes when the env var is overridden

## Background
Came out of a security/bug audit of `src/`. Eval-based findings (`assert_duration`, `bashunit assert "<cmd>"`, `--debug FILE`) were verified as intentional CLI APIs, not vulnerabilities — only the temp-dir issues were real. No public API changes.
