### PR TITLE
feat(runner): include test name + file:line in failure output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - `--profile` reports the slowest tests after a run (count via `BASHUNIT_PROFILE_COUNT`, default 10); works in sequential and parallel mode (#678)
 - Snapshot mismatches show a readable line diff even when `git` is unavailable (expected lines prefixed `-`, actual `+`) (#679)
+- Failure output now includes the originating test `file:line` (`at <file>:<line>`) (#680)
 
 ### Fixed
 - `bashunit learn` and coverage now create temp directories via `mktemp -d` (no predictable PID-based paths under `/tmp`)

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -267,6 +267,20 @@ function bashunit::console_results::print_successful_test() {
   bashunit::state::print_line "successful" "$full_line"
 }
 
+##
+# Returns a faint "    at <file>:<line>" suffix (preceded by a newline) pointing
+# at the currently running test function, or an empty string when the location
+# is unknown. Used to append source context to failure output.
+##
+function bashunit::console_results::test_location_suffix() {
+  local location=${_BASHUNIT_TEST_LOCATION:-}
+  if [ -z "$location" ]; then
+    return 0
+  fi
+
+  printf "\n    ${_BASHUNIT_COLOR_FAINT}at %s${_BASHUNIT_COLOR_DEFAULT}" "$location"
+}
+
 function bashunit::console_results::print_failure_message() {
   local test_name=$1
   local failure_message=$2
@@ -277,6 +291,8 @@ ${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT}: %s
     ${_BASHUNIT_COLOR_FAINT}Message:${_BASHUNIT_COLOR_DEFAULT} \
 ${_BASHUNIT_COLOR_BOLD}'%s'${_BASHUNIT_COLOR_DEFAULT}\n" \
     "${test_name}" "${failure_message}")"
+
+  line="$line$(bashunit::console_results::test_location_suffix)"
 
   bashunit::state::print_line "failure" "$line"
 }
@@ -302,6 +318,8 @@ ${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT}: %s
     ${_BASHUNIT_COLOR_FAINT}%s${_BASHUNIT_COLOR_DEFAULT} ${_BASHUNIT_COLOR_BOLD}'%s'${_BASHUNIT_COLOR_DEFAULT}\n" \
       "${extra_key}" "${extra_value}")"
   fi
+
+  line="$line$(bashunit::console_results::test_location_suffix)"
 
   bashunit::state::print_line "failed" "$line"
 }
@@ -476,6 +494,8 @@ function bashunit::console_results::print_error_test() {
       line="$line$(printf "      %s\n" "$output_line")"
     done <<<"$raw_output"
   fi
+
+  line="$line$(bashunit::console_results::test_location_suffix)"
 
   bashunit::state::print_line "error" "$line"
 }

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -38,9 +38,41 @@ function bashunit::runner::export_test_identity() {
   local test_file=$1
   local fn_name=$2
   export BASHUNIT_CURRENT_TEST_ID="$(bashunit::helper::generate_id "$fn_name")"
+  bashunit::runner::resolve_test_location "$test_file" "$fn_name"
+  export _BASHUNIT_TEST_LOCATION
   if [ "${_BASHUNIT_COVERAGE_ON:-0}" = 1 ]; then
     export _BASHUNIT_COVERAGE_CURRENT_TEST_FILE="$test_file"
     export _BASHUNIT_COVERAGE_CURRENT_TEST_FN="$fn_name"
+  fi
+}
+
+##
+# Resolves "<test_file>:<line>" for a test function and writes it into the
+# global _BASHUNIT_TEST_LOCATION, using `declare -F` under `extdebug` to read
+# the definition line. Falls back to just the file path when the line cannot be
+# determined. Bash 3.0+ compatible. Writes a global slot (no extra subshell).
+# Arguments: $1 test file, $2 function name
+##
+function bashunit::runner::resolve_test_location() {
+  local test_file=$1
+  local fn_name=$2
+
+  # Enable extdebug only inside the command-substitution subshell so it never
+  # leaks into the parent shell — globally toggling extdebug interferes with
+  # `set -e`/DEBUG-trap behavior under --strict.
+  local def line=""
+  def="$(shopt -s extdebug; declare -F "$fn_name" 2>/dev/null)" || true
+
+  # `declare -F` (with extdebug) prints "<name> <line> <file>".
+  if [ -n "$def" ]; then
+    line=${def#* }
+    line=${line%% *}
+  fi
+
+  if [ -n "$line" ]; then
+    _BASHUNIT_TEST_LOCATION="${test_file}:${line}"
+  else
+    _BASHUNIT_TEST_LOCATION="$test_file"
   fi
 }
 

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_advanced_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_advanced_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,4 @@
 [31m✗ Failed[0m: assert same
     [90mExpected[0m [1m'foo'[0m
     [90mbut got [0m [1m'bar'[0m
+    [90mat tests/acceptance/bashunit_direct_fn_call_advanced_test.sh:12[0m

--- a/tests/acceptance/snapshots/bashunit_exit_code_test_sh.test_bashunit_when_a_test_returns_non_zero.snapshot
+++ b/tests/acceptance/snapshots/bashunit_exit_code_test_sh.test_bashunit_when_a_test_returns_non_zero.snapshot
@@ -1,6 +1,7 @@
 [1mRunning tests/acceptance/fixtures/test_bashunit_when_a_test_returns_non_zero.sh[0m
 [31m✗ Error[0m: Returns non zero
     [90m[0m
+    [90mat tests/acceptance/fixtures/test_bashunit_when_a_test_returns_non_zero.sh:3[0m
 
 [1mThere was 1 failure:[0m
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_env.snapshot
@@ -6,6 +6,7 @@
 |[31m✗ Failed[0m: Assert failing
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 |    [90mSource:[0m
 |    [90m13:[0m assert_same 1 0
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_simple_output_option.snapshot
@@ -6,6 +6,7 @@
 |[31m✗ Failed[0m: Assert failing
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 |    [90mSource:[0m
 |    [90m13:[0m assert_same 1 0
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_env.snapshot
@@ -4,6 +4,7 @@
 [31m✗ Failed[0m: Assert failing
     [90mExpected[0m [1m'1'[0m
     [90mbut got [0m [1m'0'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
@@ -13,6 +14,7 @@
 |[31m✗ Failed[0m: Assert failing
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 |    [90mSource:[0m
 |    [90m13:[0m assert_same 1 0
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_when_a_test_fail_verbose_output_option.snapshot
@@ -4,6 +4,7 @@
 [31m✗ Failed[0m: Assert failing
     [90mExpected[0m [1m'1'[0m
     [90mbut got [0m [1m'0'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 [32m✓ Passed[0m: Assert greater and less than
 [32m✓ Passed[0m: Assert empty
 
@@ -13,6 +14,7 @@
 |[31m✗ Failed[0m: Assert failing
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
 |    [90mSource:[0m
 |    [90m13:[0m assert_same 1 0
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_a_test_fail_and_exit_immediately.snapshot
@@ -1,6 +1,7 @@
 [1mRunning ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh[0m
 [31m✗ Error[0m: Error
     [90m[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_exit_immediately_after_execution_error.sh:3[0m
 
 [1mThere was 1 failure:[0m
 

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_bashunit_with_multiple_failing_tests.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: Assert failing
     [90mExpected[0m [1m'1'[0m
     [90mbut got [0m [1m'2'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh:7[0m
 [36m✒ Incomplete[0m: Assert todo and skip[90m    foo[0m
 [33m↷ Skipped[0m: Assert todo and skip[90m    bar[0m
 [33m↷ Skipped[0m: Assert skip and todo[90m    baz[0m
@@ -14,6 +15,7 @@
 |[31m✗ Failed[0m: Assert failing
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_with_multiple_failing_tests.sh:7[0m
 |    [90mSource:[0m
 |    [90m8:[0m assert_same 1 2
 |    [90m9:[0m assert_same 3 4

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_env.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: Failure
     [90mExpected[0m [1m'2'[0m
     [90mbut got [0m [1m'3'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7[0m
 
 [1mThere was 1 failure:[0m
 
@@ -10,6 +11,7 @@
 |[31m✗ Failed[0m: Failure
 |    [90mExpected[0m [1m'2'[0m
 |    [90mbut got [0m [1m'3'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7[0m
 |    [90mSource:[0m
 |    [90m8:[0m assert_same 2 3
 

--- a/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_log_junit_test_sh.test_bashunit_when_log_junit_option.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: Failure
     [90mExpected[0m [1m'2'[0m
     [90mbut got [0m [1m'3'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7[0m
 
 [1mThere was 1 failure:[0m
 
@@ -10,6 +11,7 @@
 |[31m✗ Failed[0m: Failure
 |    [90mExpected[0m [1m'2'[0m
 |    [90mbut got [0m [1m'3'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh:7[0m
 |    [90mSource:[0m
 |    [90m8:[0m assert_same 2 3
 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_env.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: Fail
     [90mExpected[0m [1m'to be empty'[0m
     [90mbut got [0m [1m'non empty'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7[0m
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
@@ -12,6 +13,7 @@
 |[31m✗ Failed[0m: Fail
 |    [90mExpected[0m [1m'to be empty'[0m
 |    [90mbut got [0m [1m'non empty'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7[0m
 |    [90mSource:[0m
 |    [90m8:[0m assert_empty "non empty"
 

--- a/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_report_html_test_sh.test_bashunit_when_report_html_option.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: Fail
     [90mExpected[0m [1m'to be empty'[0m
     [90mbut got [0m [1m'non empty'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7[0m
 [33m↷ Skipped[0m: Skipped
 [36m✒ Incomplete[0m: Todo
 
@@ -12,6 +13,7 @@
 |[31m✗ Failed[0m: Fail
 |    [90mExpected[0m [1m'to be empty'[0m
 |    [90mbut got [0m [1m'non empty'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_report_html.sh:7[0m
 |    [90mSource:[0m
 |    [90m8:[0m assert_empty "non empty"
 

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: B error
     [90mExpected[0m [1m'1'[0m
     [90mbut got [0m [1m'2'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
 
 [33mStop on failure enabled...[0m
 [1mThere was 1 failure:[0m
@@ -11,6 +12,7 @@
 |[31m✗ Failed[0m: B error
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
 |    [90mSource:[0m
 |    [90m7:[0m assert_same 1 1
 |    [90m8:[0m assert_same 1 2 # error

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env_simple_output.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_env_simple_output.snapshot
@@ -8,6 +8,7 @@
 |[31m✗ Failed[0m: B error
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
 |    [90mSource:[0m
 |    [90m7:[0m assert_same 1 1
 |    [90m8:[0m assert_same 1 2 # error

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_bashunit_when_stop_on_failure_option.snapshot
@@ -3,6 +3,7 @@
 [31m✗ Failed[0m: B error
     [90mExpected[0m [1m'1'[0m
     [90mbut got [0m [1m'2'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
 
 [33mStop on failure enabled...[0m
 [1mThere was 1 failure:[0m
@@ -11,6 +12,7 @@
 |[31m✗ Failed[0m: B error
 |    [90mExpected[0m [1m'1'[0m
 |    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
 |    [90mSource:[0m
 |    [90m7:[0m assert_same 1 1
 |    [90m8:[0m assert_same 1 2 # error

--- a/tests/acceptance/snapshots/bashunit_tap_output_test_sh.test_tap_output_failing_tests_matches_snapshot.snapshot
+++ b/tests/acceptance/snapshots/bashunit_tap_output_test_sh.test_tap_output_failing_tests_matches_snapshot.snapshot
@@ -6,6 +6,7 @@ not ok 3 - Assert failing
   ---
   Expected '1'
   but got  '0'
+  at tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
   ...
 ok 4 - Assert greater and less than
 ok 5 - Assert empty

--- a/tests/unit/console_results_test.sh
+++ b/tests/unit/console_results_test.sh
@@ -748,3 +748,27 @@ function test_snapshot_line_diff_handles_extra_actual_lines() {
 
   assert_contains "+ extra" "$output"
 }
+
+function test_test_location_suffix_when_set() {
+  local original=${_BASHUNIT_TEST_LOCATION:-}
+  export _BASHUNIT_TEST_LOCATION="tests/foo_test.sh:42"
+
+  local output
+  output="$(bashunit::console_results::test_location_suffix)"
+
+  assert_contains "tests/foo_test.sh:42" "$output"
+
+  export _BASHUNIT_TEST_LOCATION="$original"
+}
+
+function test_test_location_suffix_empty_when_unset() {
+  local original=${_BASHUNIT_TEST_LOCATION:-}
+  unset _BASHUNIT_TEST_LOCATION
+
+  local output
+  output="$(bashunit::console_results::test_location_suffix)"
+
+  assert_empty "$output"
+
+  export _BASHUNIT_TEST_LOCATION="$original"
+}


### PR DESCRIPTION
## 🤔 Background

Related #680

When a test fails, the inline output showed only the assertion message; the originating `file:line` was easy to lose once the run scrolled.

## 💡 Changes

- Append `at <file>:<line>` to failed / failure-message / error output, pointing at the running test function
- Resolve the location once per test via `declare -F` under `extdebug`, isolated in a subshell so it can't affect `--strict` mode
- Regenerate snapshots that capture failure output to include the new line