### PR TITLE
feat(watch): pass --filter through to watch loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Project config file `.bashunitrc` (`KEY=value` lines); precedence is CLI flag > env var / `.env` > `.bashunitrc` > default; honors `--skip-env-file` (#681)
 
 ### Fixed
+- `bashunit watch` now forwards `--filter` (and other flags) to each run regardless of position, and no longer mangles forwarded arguments (#682)
 - `bashunit learn` and coverage now create temp directories via `mktemp -d` (no predictable PID-based paths under `/tmp`)
 - `bashunit::parallel::cleanup` refuses to `rm -rf` a `TEMP_DIR_PARALLEL_TEST_SUITE` whose path is not under `*/bashunit/parallel/*`, preventing accidental wipes from env overrides
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -453,18 +453,40 @@ function bashunit::main::cmd_learn() {
 # Subcommand: watch
 #############################
 function bashunit::main::cmd_watch() {
-  case "${1:-}" in
-  -h | --help)
-    bashunit::console_header::print_watch_help
-    exit 0
-    ;;
-  esac
+  local path=""
+  local -a extra_args=()
 
-  local path="${1:-.}"
-  shift || true
-  local -a extra_args=("$@")
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    -h | --help)
+      bashunit::console_header::print_watch_help
+      exit 0
+      ;;
+    -f | --filter)
+      # Forward the filter flag and its value to the underlying test run
+      extra_args[${#extra_args[@]}]="$1"
+      shift || true
+      if [ $# -gt 0 ]; then
+        extra_args[${#extra_args[@]}]="$1"
+      fi
+      ;;
+    -*)
+      extra_args[${#extra_args[@]}]="$1"
+      ;;
+    *)
+      if [ -z "$path" ]; then
+        path="$1"
+      else
+        extra_args[${#extra_args[@]}]="$1"
+      fi
+      ;;
+    esac
+    shift || true
+  done
 
-  bashunit::watch::run "$path" "${extra_args[@]+\"${extra_args[@]}\"}"
+  [ -z "$path" ] && path="."
+
+  bashunit::watch::run "$path" "${extra_args[@]+"${extra_args[@]}"}"
 }
 
 #############################

--- a/tests/unit/watch_test.sh
+++ b/tests/unit/watch_test.sh
@@ -90,3 +90,35 @@ function test_wait_for_change_does_nothing_for_unknown_tool() {
   assert_not_called inotifywait
   assert_not_called fswatch
 }
+
+# bashunit::main::cmd_watch — filter passthrough
+
+function test_cmd_watch_forwards_filter_after_path() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "tests/" "--filter" "my_test")
+
+  assert_contains "tests/" "$output"
+  assert_contains "--filter my_test" "$output"
+}
+
+function test_cmd_watch_extracts_path_when_filter_first() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "--filter" "my_test" "tests/")
+
+  assert_contains "tests/" "$output"
+  assert_contains "--filter my_test" "$output"
+}
+
+function test_cmd_watch_defaults_path_to_dot() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "--filter" "my_test")
+
+  assert_contains "." "$output"
+  assert_contains "--filter my_test" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #682

`bashunit watch` re-ran everything on each change and mishandled forwarded flags, so `--filter` could not be used to narrow the watch loop.

## 💡 Changes

- Parse `watch` arguments so the path can appear in any position
- Forward `-f/--filter` (and its value) plus other flags to each underlying test run
- Fix a quoting bug that passed extra args with literal escaped quotes