### PR TITLE
fix(test): make _supports_wait_n test set -e safe

### DIFF
--- a/tests/unit/parallel_test.sh
+++ b/tests/unit/parallel_test.sh
@@ -63,8 +63,9 @@ function test_supports_wait_n_matches_running_bash_version() {
     expected_rc=0
   fi
 
-  bashunit::runner::_supports_wait_n
-  assert_same "$expected_rc" "$?"
+  local actual_rc=0
+  bashunit::runner::_supports_wait_n || actual_rc=$?
+  assert_same "$expected_rc" "$actual_rc"
 }
 
 function test_wait_for_job_slot_releases_when_background_job_finishes() {


### PR DESCRIPTION
## 🤔 Background

Running `./bashunit -s -p --strict` on Bash 3.x reported a failure: 21 of 23 tests in `parallel_test.sh` errored.

## 💡 Changes

- `test_supports_wait_n_matches_running_bash_version` called `bashunit::runner::_supports_wait_n` as a bare statement; on Bash < 4.3 it returns 1, so under `set -euo pipefail` the test body aborted and cascaded into the rest of the file
- Capture the return code with `|| actual_rc=$?` so `--strict` no longer aborts
- Only surfaced on Bash 3.x; CI runs the strict job on Bash 5 where the function returns 0