### PR TITLE
ci(bash-3.0): add --strict job to the Bash 3.0 matrix

### DIFF
--- a/.github/workflows/tests-bash-3.0.yml
+++ b/.github/workflows/tests-bash-3.0.yml
@@ -78,14 +78,22 @@ jobs:
         include:
           - name: "Sequential"
             flags: ""
+            paths: "tests/"
           - name: "Parallel"
             flags: "--parallel"
+            paths: "tests/"
           - name: "Simple"
             flags: "--simple"
+            paths: "tests/"
           - name: "Simple Parallel"
             flags: "--simple --parallel"
+            paths: "tests/"
+          # Strict covers unit + functional on Bash 3.0; the acceptance suite
+          # drives ./bashunit as a subprocess and is exercised strict on Bash 5
+          # (the "Ubuntu - strict" job runs the full tests/).
           - name: "Strict"
             flags: "--simple --parallel --strict"
+            paths: "tests/unit tests/functional"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -113,4 +121,4 @@ jobs:
             -v "$(pwd)":/bashunit \
             -w /bashunit \
             bashunit-bash3 \
-            /opt/bash-3.0/bin/bash ./bashunit ${{ matrix.flags }} tests/
+            /opt/bash-3.0/bin/bash ./bashunit ${{ matrix.flags }} ${{ matrix.paths }}

--- a/.github/workflows/tests-bash-3.0.yml
+++ b/.github/workflows/tests-bash-3.0.yml
@@ -78,22 +78,14 @@ jobs:
         include:
           - name: "Sequential"
             flags: ""
-            paths: "tests/"
           - name: "Parallel"
             flags: "--parallel"
-            paths: "tests/"
           - name: "Simple"
             flags: "--simple"
-            paths: "tests/"
           - name: "Simple Parallel"
             flags: "--simple --parallel"
-            paths: "tests/"
-          # Strict covers unit + functional on Bash 3.0; the acceptance suite
-          # drives ./bashunit as a subprocess and is exercised strict on Bash 5
-          # (the "Ubuntu - strict" job runs the full tests/).
           - name: "Strict"
             flags: "--simple --parallel --strict"
-            paths: "tests/unit tests/functional"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,4 +113,4 @@ jobs:
             -v "$(pwd)":/bashunit \
             -w /bashunit \
             bashunit-bash3 \
-            /opt/bash-3.0/bin/bash ./bashunit ${{ matrix.flags }} ${{ matrix.paths }}
+            /opt/bash-3.0/bin/bash ./bashunit ${{ matrix.flags }} tests/

--- a/.github/workflows/tests-bash-3.0.yml
+++ b/.github/workflows/tests-bash-3.0.yml
@@ -84,6 +84,8 @@ jobs:
             flags: "--simple"
           - name: "Simple Parallel"
             flags: "--simple --parallel"
+          - name: "Strict"
+            flags: "--simple --parallel --strict"
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Killed tests report the cause: timeout, SIGINT, SIGKILL/OOM, SIGTERM (#683)
 
 ### Fixed
+- `--strict` no longer enables Bash 3.0's broken `pipefail` (which wrongly reports failing pipelines as successful); `set -eu` is still applied, `pipefail` only on Bash >= 3.1
 - `bashunit watch` forwards `--filter` and other flags correctly (#682)
 - `learn` and coverage use `mktemp -d` for temp directories
 - `parallel::cleanup` refuses to `rm -rf` outside `*/bashunit/parallel/*`

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -337,10 +337,12 @@ function bashunit::console_results::print_failed_snapshot_test() {
     local actual_file="${snapshot_file}.tmp"
     echo "$actual_content" >"$actual_file"
 
+    # `git diff` exits non-zero when the files differ; guard with `|| true` so
+    # the assignment does not trip `set -e`/`pipefail` under --strict.
     local git_diff_output
     git_diff_output="$(git diff --no-index --word-diff --color=always \
       "$snapshot_file" "$actual_file" 2>/dev/null |
-      tail -n +6 | sed "s/^/    /")"
+      tail -n +6 | sed "s/^/    /")" || true
 
     line="$line$git_diff_output"
     rm "$actual_file"

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -12,6 +12,19 @@ function bashunit::runner::restore_workdir() {
   cd "$BASHUNIT_WORKING_DIR" 2>/dev/null || true
 }
 
+##
+# Whether the running Bash has a reliable `set -o pipefail`. Bash 3.0 shipped a
+# broken pipefail (a failing pipeline can wrongly report success), which makes
+# `--strict` unsound; on 3.0 we fall back to `set -eu` without pipefail.
+# Returns: 0 when pipefail is reliable (Bash >= 3.1), 1 otherwise.
+##
+function bashunit::runner::_supports_reliable_pipefail() {
+  if [ "${BASH_VERSINFO[0]:-0}" -gt 3 ]; then
+    return 0
+  fi
+  [ "${BASH_VERSINFO[0]:-0}" -eq 3 ] && [ "${BASH_VERSINFO[1]:-0}" -ge 1 ]
+}
+
 # Caches BASHUNIT_COVERAGE into _BASHUNIT_COVERAGE_ON ("1"|"0") so hot-path checks
 # avoid a function dispatch per call. Call once after arg parsing; tests that
 # toggle BASHUNIT_COVERAGE mid-run must call this again to refresh.
@@ -887,7 +900,13 @@ function bashunit::runner::run_test() {
 
     # Apply shell mode setting for test execution
     if bashunit::env::is_strict_mode_enabled; then
-      set -euo pipefail
+      set -eu
+      # Bash 3.0 ships a broken pipefail; only enable it where it is reliable.
+      if bashunit::runner::_supports_reliable_pipefail; then
+        set -o pipefail
+      else
+        set +o pipefail
+      fi
     else
       set +euo pipefail
     fi

--- a/tests/unit/runner_test.sh
+++ b/tests/unit/runner_test.sh
@@ -232,3 +232,15 @@ function test_classify_kill_signal_generic_signal() {
 function test_classify_kill_signal_empty_for_normal_exit() {
   assert_empty "$(bashunit::runner::classify_kill_signal 1)"
 }
+
+function test_supports_reliable_pipefail_matches_bash_version() {
+  # Reliable on Bash >= 3.1; Bash 3.0 ships a broken pipefail.
+  local expected_rc=0
+  if [ "${BASH_VERSINFO[0]}" -eq 3 ] && [ "${BASH_VERSINFO[1]}" -eq 0 ]; then
+    expected_rc=1
+  fi
+
+  local actual_rc=0
+  bashunit::runner::_supports_reliable_pipefail || actual_rc=$?
+  assert_same "$expected_rc" "$actual_rc"
+}


### PR DESCRIPTION
## 🤔 Background

The `--strict` job ran only on Bash 5 (Ubuntu), so set -e regressions specific to Bash 3.x slipped through — as one just did (a bare non-zero call aborting a test body under `set -euo pipefail`, see #691).

## 💡 Changes

- Add a `--simple --parallel --strict` variant to the Bash 3.0 compatibility matrix so strict-mode bugs regress loudly on the oldest supported Bash