### PR TITLE
ci(npm): switch to OIDC trusted publishing (tokenless)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,6 +24,11 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org/
 
+      # OIDC trusted publishing (tokenless) requires npm >= 11.5.1.
+      # Node 22 (lts/jod) ships npm 10, so upgrade explicitly.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Build bashunit single-file binary
         shell: bash
         run: ./build.sh bin
@@ -33,7 +38,8 @@ jobs:
         run: |
           test -x bin/bashunit || { echo "bin/bashunit missing or not executable"; exit 1; }
 
+      # No token: npm authenticates via GitHub OIDC (Trusted Publishing).
+      # Configure the trusted publisher once at npmjs.com -> bashunit -> Settings.
+      # Provenance is generated automatically.
       - name: Publish to npm
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public


### PR DESCRIPTION
## Why

The `Publish to npm` job keeps failing with `401 Unauthorized` / `404 PUT` because the `NPM_TOKEN` secret keeps expiring or being rejected (confirmed via `npm whoami` → 401). Manual token rotation is the root problem — npm tokens expire and need re-issuing every time.

## Fix: OIDC Trusted Publishing (no token, ever)

npm supports tokenless publishing from GitHub Actions via OIDC. This removes the secret entirely — nothing to expire, nothing to rotate.

- Drop `NODE_AUTH_TOKEN`; rely on the existing `permissions: id-token: write`.
- Upgrade npm to `>= 11.5.1` (Node 22 / `lts/jod` ships npm 10; OIDC needs 11.5.1+).
- Provenance is generated automatically — dropped the now-redundant `--provenance` flag.

## One-time manual setup (required before this works)

On **npmjs.com → `bashunit` package → Settings → Trusted Publisher → GitHub Actions**:
- Organization: `TypedDevs`
- Repository: `bashunit`
- Workflow filename: `npm-publish.yml`
- Environment: *(leave blank)*

After that, every release publishes automatically with zero secrets. The old `NPM_TOKEN` secret can be deleted.

## Note

This publishes going forward (0.38.0 onward). The skipped 0.37.0 npm version can be backfilled separately or left as a gap (npm `latest` jumps 0.36.0 → 0.38.0).
