### PR TITLE
feat(release): publish floating major tag v0 for the GitHub Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - GitHub Action `args` input: when set, runs `bashunit <args>` after installing, so a workflow can install and run the suite in a single step
+- Floating major tag for the GitHub Action: the release process now force-moves `v0` to each release, so workflows can pin `TypedDevs/bashunit@v0` to track the latest release within a major (#700)
 
 ## [0.38.0](https://github.com/TypedDevs/bashunit/compare/0.37.0...0.38.0) - 2026-06-07
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -223,7 +223,8 @@ Downloading 'bashunit' to 'lib'...
 ## GitHub Actions
 
 The official `TypedDevs/bashunit` action installs the binary in one step.
-Pin it to a commit SHA for an immutable, supply-chain-safe install
+Pin it to the floating major tag `@v0` to track the latest release within a major,
+or to a commit SHA for an immutable, supply-chain-safe install
 (keeps static analyzers such as [zizmor](https://github.com/woodruffw/zizmor) happy):
 
 ::: code-group
@@ -236,8 +237,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # Pin to a commit SHA; the comment tracks the human-readable tag.
-      - uses: TypedDevs/bashunit@<commit-sha> # {{ pkg.version }}
+      # @v0 tracks the latest release within the v0 major.
+      # For an immutable pin use a commit SHA: TypedDevs/bashunit@<sha> # {{ pkg.version }}
+      - uses: TypedDevs/bashunit@v0
         with:
           version: '{{ pkg.version }}' # or "latest" (default)
           directory: lib               # optional, "lib" by default
@@ -257,7 +259,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # Install and run the suite in a single step via the `args` input.
-      - uses: TypedDevs/bashunit@<commit-sha> # {{ pkg.version }}
+      - uses: TypedDevs/bashunit@v0
         with:
           version: '{{ pkg.version }}'
           args: tests/ --strict

--- a/release.sh
+++ b/release.sh
@@ -536,6 +536,7 @@ function release::sandbox::run() {
   # Show what would happen with push/gh release
   release::log_sandbox "Would push: git push origin main"
   release::log_sandbox "Would push tag: git push origin $VERSION"
+  release::log_sandbox "Would move major tag: git push origin $(release::major_tag "$VERSION") --force"
   release::log_sandbox "Would create GitHub release with assets: bin/bashunit, bin/checksum"
   release::log_sandbox "Would update 'latest' branch"
 
@@ -558,6 +559,19 @@ function release::increment_minor() {
   local major minor
   IFS=. read -r major minor _ <<<"$version"
   echo "$major.$((minor + 1)).0"
+}
+
+##
+# Floating major tag for a version (e.g. "0.38.0" -> "v0").
+# Consumers of the GitHub Action can pin "@v0" to track the latest
+# release within a major without chasing exact patch tags.
+# Arguments: $1 - version (e.g. "0.38.0")
+##
+function release::major_tag() {
+  local version=$1
+  local major
+  IFS=. read -r major _ <<<"$version"
+  echo "v$major"
 }
 
 function release::validate_semver() {
@@ -850,12 +864,20 @@ function release::git_commit_and_tag() {
   git tag "$new_version"
   release::log_success "Created tag $new_version"
 
+  local major_tag
+  major_tag=$(release::major_tag "$new_version")
+  git tag -f "$major_tag" "$new_version"
+  release::log_success "Moved major tag $major_tag -> $new_version"
+
   if release::confirm_action "Do you want to push commit and tag to origin?"; then
     git push origin main
     git push origin "$new_version"
+    git push origin "$major_tag" --force
     release::log_success "Pushed to origin"
   else
-    release::log_warning "Skipping push (run manually: git push origin main && git push origin $new_version)"
+    release::log_warning "Skipping push. Run manually:"
+    release::log_warning "  git push origin main && git push origin $new_version"
+    release::log_warning "  git push origin $major_tag --force"
   fi
 }
 

--- a/tests/unit/release_utilities_test.sh
+++ b/tests/unit/release_utilities_test.sh
@@ -328,3 +328,15 @@ function test_build_project_dry_run_does_not_execute() {
   assert_contains "DRY-RUN" "$result"
   assert_contains "Would run" "$result"
 }
+
+##########################
+# Major tag test
+##########################
+
+function test_major_tag_returns_v_prefixed_major_for_zero() {
+  assert_same "v0" "$(release::major_tag "0.38.0")"
+}
+
+function test_major_tag_returns_v_prefixed_major_for_one() {
+  assert_same "v1" "$(release::major_tag "1.2.3")"
+}


### PR DESCRIPTION
## Summary

Lets consumers of the official action pin `TypedDevs/bashunit@v0` to track the latest release within a major, instead of chasing exact patch tags or a branch.

## Changes
- `release::major_tag` derives `vN` from a version (`0.38.0` → `v0`), unit-tested.
- The release push step force-moves the major tag (`git tag -f v0 <version>` + `git push origin v0 --force`); sandbox/dry-run output reflects it.
- Docs lead with `@v0`; SHA pinning kept as the immutable alternative.
- CHANGELOG updated.

## Activation
`@v0` becomes resolvable after the next release runs `release.sh`. To activate immediately for the current release, a maintainer can bootstrap it once:
```bash
git tag -f v0 0.38.0 && git push origin v0 --force
```

Closes #700