### PR TITLE
docs(installation): Renovate/Dependabot config to auto-bump the Action SHA

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -301,6 +301,39 @@ jobs:
 asset (sha256) and fails the install on any mismatch. Set it to `false` only when
 pinning a release published before checksum assets existed.
 
+### Keep the SHA pin fresh automatically
+
+A commit-SHA pin is the most secure, but bumping it by hand is tedious. Let a bot do it
+and keep the `# {{ pkg.version }}` comment as the human-readable tracker.
+
+::: code-group
+```json [Renovate - renovate.json]
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["TypedDevs/bashunit"],
+      "pinDigests": true
+    }
+  ]
+}
+```
+
+```yaml [Dependabot - .github/dependabot.yml]
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+```
+:::
+
+Renovate updates the pinned SHA and refreshes the trailing `# tag` comment in the same PR.
+Dependabot bumps `github-actions` pins on the schedule you set.
+
 ::: tip
 See bashunit's own pipeline for a real example: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::


### PR DESCRIPTION
## Summary

Documents how to keep a commit-SHA pin of `TypedDevs/bashunit` fresh automatically, so users get the strongest supply-chain pin without manual bumps.

## Changes
- Add a "Keep the SHA pin fresh automatically" subsection to the GitHub Actions install docs.
- Renovate snippet (`pinDigests` + refreshes the `# tag` comment).
- Dependabot snippet (`github-actions` ecosystem).

Closes #701