### PR TITLE
feat(cli): scaffold a CI workflow in 'bashunit init'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - GitHub Action `args` input: when set, runs `bashunit <args>` after installing, so a workflow can install and run the suite in a single step
 - Floating major tag for the GitHub Action: the release process now force-moves `v0` to each release, so workflows can pin `TypedDevs/bashunit@v0` to track the latest release within a major (#700)
+- `bashunit init` now scaffolds a `.github/workflows/tests.yml` CI workflow using the official action (existing files are left untouched) (#702)
 
 ## [0.38.0](https://github.com/TypedDevs/bashunit/compare/0.37.0...0.38.0) - 2026-06-07
 

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -209,6 +209,7 @@ Arguments:
 Creates:
   - bootstrap.sh              Setup file for test configuration
   - example_test.sh           Sample test file to get started
+  - .github/workflows/tests.yml  CI workflow using the official action
 
 Examples:
   bashunit init               Create tests/ directory

--- a/src/init.sh
+++ b/src/init.sh
@@ -28,6 +28,25 @@ SH
     echo "> Created $example_test"
   fi
 
+  local workflow_dir=".github/workflows"
+  local workflow_file="$workflow_dir/tests.yml"
+  if [ ! -f "$workflow_file" ]; then
+    mkdir -p "$workflow_dir"
+    cat >"$workflow_file" <<SH
+name: Tests
+on: [pull_request, push]
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: TypedDevs/bashunit@v0
+        with:
+          args: $tests_dir
+SH
+    echo "> Created $workflow_file"
+  fi
+
   local env_file=".env"
   local env_line="BASHUNIT_BOOTSTRAP=$bootstrap_file"
   if [ -f "$env_file" ]; then

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -33,6 +33,23 @@ function test_bashunit_init_custom_directory() {
   popd >/dev/null
 }
 
+function test_bashunit_init_creates_github_workflow() {
+  pushd "$TMP_DIR" >/dev/null
+  "$BASHUNIT_PATH" init >/tmp/init.log
+  assert_file_exists ".github/workflows/tests.yml"
+  assert_file_contains ".github/workflows/tests.yml" "TypedDevs/bashunit@"
+  popd >/dev/null
+}
+
+function test_bashunit_init_does_not_overwrite_existing_workflow() {
+  pushd "$TMP_DIR" >/dev/null
+  mkdir -p ".github/workflows"
+  echo "custom-workflow" >".github/workflows/tests.yml"
+  "$BASHUNIT_PATH" init >/tmp/init.log
+  assert_file_contains ".github/workflows/tests.yml" "custom-workflow"
+  popd >/dev/null
+}
+
 function test_bashunit_init_updates_env() {
   bashunit::skip "flaky" && return
 


### PR DESCRIPTION
## Summary

`bashunit init` now scaffolds a ready-to-use CI workflow so a fresh project gets working CI in one command.

## Changes
- `bashunit init` creates `.github/workflows/tests.yml` using `TypedDevs/bashunit@v0` with `args: <tests-dir>`.
- Overwrite guard: an existing workflow file is left untouched (same pattern as the other init files).
- Updated `init --help` and CHANGELOG.

## Tests
- `test_bashunit_init_creates_github_workflow` — file exists + references the action.
- `test_bashunit_init_does_not_overwrite_existing_workflow` — preserves user content.

Closes #702