### PR TITLE
feat(cli): add --report-junit as an alias of --log-junit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - GitHub Action `args` input: when set, runs `bashunit <args>` after installing, so a workflow can install and run the suite in a single step
 - Floating major tag for the GitHub Action: the release process now force-moves `v0` to each release, so workflows can pin `TypedDevs/bashunit@v0` to track the latest release within a major (#700)
 - `bashunit init` now scaffolds a `.github/workflows/tests.yml` CI workflow using the official action (existing files are left untouched) (#702)
+- `--report-junit <file>` flag as an alias of `--log-junit`, for naming parity with `--report-html` (#705)
 
 ### Changed
 - `install.sh` now verifies the release checksum by default (set `BASHUNIT_VERIFY_CHECKSUM=false` to opt out); it soft-skips with a warning when a checksum asset is unavailable unless verification was explicitly requested (#703)

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -61,7 +61,7 @@ bashunit test tests/ --parallel --simple
 | `--exclude-tag <name>`         | Skip tests with matching `@tag` (repeatable)     |
 | `--output <format>`            | Output format (`tap` for TAP version 13)         |
 | `-w, --watch`                  | Watch files and re-run tests on change           |
-| `--log-junit <file>`           | Write JUnit XML report                           |
+| `--log-junit, --report-junit <file>` | Write JUnit XML report                     |
 | `--log-gha <file>`             | Write GitHub Actions workflow-commands log       |
 | `-j, --jobs <N>`               | Run tests in parallel with max N concurrent jobs |
 | `-p, --parallel`               | Run tests in parallel                            |

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -108,7 +108,7 @@ Options:
   -f, --filter <name>         Only run tests matching the name
   --tag <name>                Only run tests with matching @tag (repeatable, OR logic)
   --exclude-tag <name>        Skip tests with matching @tag (repeatable, exclude wins)
-  --log-junit <file>          Write JUnit XML report
+  --log-junit, --report-junit <file>  Write JUnit XML report
   -j, --jobs <N>              Run tests in parallel with max N concurrent jobs
   -p, --parallel              Run tests in parallel (unlimited concurrency)
   --no-parallel               Run tests sequentially

--- a/src/main.sh
+++ b/src/main.sh
@@ -92,7 +92,7 @@ function bashunit::main::cmd_test() {
       set +o allexport
       shift
       ;;
-    --log-junit)
+    --log-junit | --report-junit)
       export BASHUNIT_LOG_JUNIT="$2"
       shift
       ;;

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -23,11 +23,12 @@ function test_bashunit_when_log_junit_env() {
 
 function test_bashunit_report_junit_is_alias_of_log_junit() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+  local report=report-junit-alias.xml
 
   # The fixture contains failing tests by design, so the run exits non-zero;
   # swallow it (we only care that --report-junit produced the file).
-  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --report-junit report-junit-alias.xml "$test_file" >/dev/null 2>&1 || true
-  assert_file_exists report-junit-alias.xml
-  assert_file_contains report-junit-alias.xml "<testsuite"
-  rm report-junit-alias.xml
+  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --report-junit "$report" "$test_file" >/dev/null 2>&1 || true
+  assert_file_exists "$report"
+  assert_file_contains "$report" "<testsuite"
+  rm "$report"
 }

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -20,3 +20,14 @@ function test_bashunit_when_log_junit_env() {
   assert_file_exists log-junit.xml
   rm log-junit.xml
 }
+
+function test_bashunit_report_junit_is_alias_of_log_junit() {
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
+
+  # The fixture contains failing tests by design, so the run exits non-zero;
+  # swallow it (we only care that --report-junit produced the file).
+  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --report-junit report-junit-alias.xml "$test_file" >/dev/null 2>&1 || true
+  assert_file_exists report-junit-alias.xml
+  assert_file_contains report-junit-alias.xml "<testsuite"
+  rm report-junit-alias.xml
+}


### PR DESCRIPTION
## Summary

Adds `--report-junit <file>` as an alias of `--log-junit`, giving naming parity with the existing `--report-html`. Both flags set `BASHUNIT_LOG_JUNIT` and emit the same JUnit XML.

## Changes
- `--report-junit` parsed alongside `--log-junit` in `src/main.sh`.
- Help text + `command-line.md` table updated.
- Acceptance test asserts the alias writes a valid JUnit report.
- CHANGELOG.

## On SARIF (the issue's other half)
Deferred deliberately. SARIF is a format for **static-analysis / security findings** consumed by GitHub code scanning, not for test results. Test reporting is already well served by JUnit XML and the GitHub Actions annotations (`--log-gha`, #704). Emitting test failures as SARIF would misuse the format. If there's a concrete code-scanning use case we can revisit it as its own issue.

Closes #705