### PR TITLE
feat(cli): pin GitHub Action version default to the released version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `--report-junit <file>` flag as an alias of `--log-junit`, for naming parity with `--report-html` (#705)
 
 ### Changed
+- The GitHub Action's `version` input now defaults to the concrete version pinned at the action ref (bumped by the release process) instead of `latest`, so the installed bashunit version is visible at the call site and pinning the action by SHA pins the version; pass `version: latest` to opt into the build-time tag explicitly
 - `install.sh` now verifies the release checksum by default (set `BASHUNIT_VERIFY_CHECKSUM=false` to opt out); it soft-skips with a warning when a checksum asset is unavailable unless verification was explicitly requested (#703)
 - `--log-gha` annotations now include the failing test's `line` (`::error file=…,line=…`), so they pin to the exact line in a pull request's "Files changed" tab (#704)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - `--report-junit <file>` flag as an alias of `--log-junit`, for naming parity with `--report-html` (#705)
 
 ### Changed
-- The GitHub Action's `version` input now defaults to the concrete version pinned at the action ref (bumped by the release process) instead of `latest`, so the installed bashunit version is visible at the call site and pinning the action by SHA pins the version; pass `version: latest` to opt into the build-time tag explicitly
+- The GitHub Action's `version` input now defaults to the version pinned at the action ref instead of `latest`, so pinning the action by SHA pins a visible bashunit version
 - `install.sh` now verifies the release checksum by default (set `BASHUNIT_VERIFY_CHECKSUM=false` to opt out); it soft-skips with a warning when a checksum asset is unavailable unless verification was explicitly requested (#703)
 - `--log-gha` annotations now include the failing test's `line` (`::error file=…,line=…`), so they pin to the exact line in a pull request's "Files changed" tab (#704)
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ branding:
 
 inputs:
   version:
-    description: 'bashunit version to install (e.g. "0.37.0") or "latest".'
+    description: 'bashunit version to install (e.g. "0.37.0"). Defaults to the version pinned at this action ref. Pass "latest" to override.'
     required: false
-    default: latest
+    default: '0.38.0'
   directory:
     description: 'Directory, relative to the workspace, where the bashunit binary is installed.'
     required: false

--- a/release.sh
+++ b/release.sh
@@ -13,7 +13,7 @@ declare -r EXIT_EXECUTION_ERROR=2
 # Constants
 GITHUB_REPO_PATH="TypedDevs/bashunit"
 GITHUB_REPO_URL="https://github.com/${GITHUB_REPO_PATH}"
-RELEASE_FILES=("bashunit" "install.sh" "package.json" "docs/package.json" "CHANGELOG.md")
+RELEASE_FILES=("bashunit" "install.sh" "action.yml" "package.json" "docs/package.json" "CHANGELOG.md")
 
 # Helper function for regex matching (Bash 3.0+ compatible)
 function regex_match() {
@@ -509,6 +509,7 @@ function release::sandbox::run() {
   # Run release steps in sandbox (cd already done in setup_git)
   release::update_bashunit_version "$VERSION"
   release::update_install_version "$VERSION"
+  release::update_action_version "$VERSION"
   release::update_package_json_version "$VERSION"
   release::update_changelog "$VERSION" "$CURRENT_VERSION"
 
@@ -629,6 +630,15 @@ function release::update_install_version() {
     "LATEST_BASHUNIT_VERSION=\"[^\"]*\"" \
     "LATEST_BASHUNIT_VERSION=\"$new_version\"" \
     "LATEST_BASHUNIT_VERSION"
+}
+
+function release::update_action_version() {
+  local new_version=$1
+  release::update_file_pattern \
+    "action.yml" \
+    "default: '[0-9][^']*'" \
+    "default: '$new_version'" \
+    "action.yml default version"
 }
 
 function release::update_package_json_version() {
@@ -1032,6 +1042,9 @@ function release::main() {
 
   release::update_install_version "$VERSION"
   release::state::record_step "update_install_version"
+
+  release::update_action_version "$VERSION"
+  release::state::record_step "update_action_version"
 
   release::update_package_json_version "$VERSION"
   release::state::record_step "update_package_json_version"

--- a/tests/unit/fixtures/release/mock_action.yml
+++ b/tests/unit/fixtures/release/mock_action.yml
@@ -1,0 +1,12 @@
+name: Install bashunit
+inputs:
+  version:
+    description: 'bashunit version to install.'
+    required: false
+    default: '0.30.0'
+  directory:
+    required: false
+    default: lib
+  add-to-path:
+    required: false
+    default: 'true'

--- a/tests/unit/release_update_test.sh
+++ b/tests/unit/release_update_test.sh
@@ -103,6 +103,30 @@ function test_update_install_version_changes_version_string() {
   rm -rf "$temp_dir"
 }
 
+function test_update_action_version_changes_only_numeric_default() {
+  local temp_dir
+  temp_dir=$(mktemp -d)
+
+  cp "$FIXTURES_DIR/mock_action.yml" "$temp_dir/action.yml"
+
+  DRY_RUN=false
+  (
+    cd "$temp_dir" || return
+    release::update_action_version "0.31.0" 2>/dev/null
+  )
+
+  local result
+  result=$(cat "$temp_dir/action.yml")
+  # The version default is bumped...
+  assert_contains "default: '0.31.0'" "$result"
+  # ...but non-numeric defaults are left untouched.
+  assert_contains "default: lib" "$result"
+  assert_contains "default: 'true'" "$result"
+  assert_not_contains "default: '0.30.0'" "$result"
+
+  rm -rf "$temp_dir"
+}
+
 function test_update_package_json_version_changes_version_string() {
   local temp_dir
   temp_dir=$(mktemp -d)


### PR DESCRIPTION
## What

The action's `version` input defaulted to `latest`, which reads like a rolling tag even though `install.sh` already ships a baked, release-bumped `LATEST_BASHUNIT_VERSION` and never makes a runtime "newest release" lookup. So pinning the action by SHA already pinned the version — the default just hid that.

This makes the default a **concrete version string** in `action.yml`, bumped by the release process, so the pinned version is visible right at the call site. Pinning the action by SHA pins a visible bashunit version with no ambiguity.

## Changes

- `action.yml`: `version` default `latest` → `'0.38.0'`; clearer description
- `release.sh`: new `release::update_action_version`, added `action.yml` to `RELEASE_FILES`, wired into both the sandbox and real release steps (with state recording)
- regression test + `mock_action.yml` fixture: bumps only the numeric default, leaves `lib`/`'true'` untouched
- `CHANGELOG.md` entry

## Notes

No behavior change for callers passing `version: latest` explicitly — that still installs the build-time pinned tag. Context: [phpstan-src#5826 review](https://github.com/phpstan/phpstan-src/pull/5826#issuecomment-4661707150).

## Checks

- `make sa`, `make lint` pass
- `./bashunit tests/` and `./bashunit --parallel tests/` green
