### PR TITLE
fix(cli): ignore floating major tags when resolving latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `bashunit upgrade` resolved the floating `v0` Action tag as the latest version, breaking upgrades; it now only considers exact-version tags
+
 ## [0.39.0](https://github.com/TypedDevs/bashunit/compare/0.38.0...0.39.0) - 2026-06-09
 
 ### Added

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -322,10 +322,12 @@ function bashunit::helper::get_latest_tag() {
     return 1
   fi
 
+  # Floating major tags (e.g. v0) are not releases and must not win
   git ls-remote --tags "$BASHUNIT_GIT_REPO" |
     awk '{print $2}' |
     sed 's|^refs/tags/||' |
     grep -v '\^{}' |
+    grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' |
     sort -Vr |
     head -n 1
 }

--- a/tests/unit/helpers_test.sh
+++ b/tests/unit/helpers_test.sh
@@ -292,6 +292,17 @@ EOF
   unset -f git # remove the mock
 }
 
+function test_get_latest_tag_ignores_floating_major_tags() {
+  bashunit::mock git <<EOF
+fc9aac40eb8e5ad4483f08d79eb678a3650dcf78        refs/tags/0.38.0
+3977be123b0b73cfdf4b4eff46b909f37aa83b3c        refs/tags/0.39.0
+9bb3726a1bf83fb09ca548a398762ab89baaa9b6        refs/tags/v0
+b546c693198870dd75d1a102b94f4ddad6f4f3ea        refs/tags/v0^{}
+EOF
+  assert_same "0.39.0" "$(bashunit::helper::get_latest_tag)"
+  unset -f git # remove the mock
+}
+
 function test_to_run_with_filter_matching_string_in_function_name() {
   local functions
   functions=("test_my_awesome_function" "test_your_awesome_function" "test_so_lala_function")


### PR DESCRIPTION
## Summary

The 0.39.0 release published the floating `v0` tag for the GitHub Action (#700). `bashunit::helper::get_latest_tag` sorts all remote tags with `sort -Vr`, and `v0` sorts above every exact version, so `bashunit upgrade` resolved `v0` as the latest version and tried to download a release asset that does not exist.

This broke two CI jobs on `main` (Bash 3.0 Compatibility and Tests/Alpine) via `tests/acceptance/bashunit_upgrade_test.sh`, and breaks `bashunit upgrade` at runtime.

## Fix

Restrict latest-tag candidates to exact-version tags (`^[0-9]+\.[0-9]+(\.[0-9]+)?$`) before sorting.

## Verification

- New unit test `test_get_latest_tag_ignores_floating_major_tags` (RED: returned `v0`; GREEN: returns `0.39.0`)
- `tests/acceptance/bashunit_upgrade_test.sh` passes against the real repo (downloads the 0.39.0 asset)
- Full suite: 1110 passed (sequential and `--parallel`)
- Bash 3.2 (`/bin/bash`): helpers + upgrade tests green
- `make sa`, `make lint`, `shfmt` clean