### PR TITLE
docs: polish all documentation pages to A+ quality

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -38,6 +38,7 @@ function mock_true() {
 function mock_false() {
   return 1
 }
+```
 :::
 
 ## assert_false
@@ -1503,3 +1504,10 @@ function test_failure() {
 }
 ```
 :::
+
+## Related
+
+- [Custom asserts](/custom-asserts) — build your own domain-specific assertions
+- [Test doubles](/test-doubles) — mocks and spies for isolated tests
+- [Data providers](/data-providers) — run the same assertions over many inputs
+- [Globals](/globals) — `bashunit::` helper functions

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -4,7 +4,7 @@ description: "Measure bash script execution time with bashunit benchmarks to fin
 
 # Benchmarks
 
-Measure execution time of your scripts with benchmark functions. Benchmarks help identify performance bottlenecks and ensure your code meets performance requirements.
+Benchmarks measure the execution time of your scripts with dedicated functions, helping you identify performance bottlenecks and ensure your code meets performance requirements.
 
 ## Quick Start
 
@@ -69,7 +69,7 @@ Run benchmarks using the `bench` command:
 ```
 :::
 
-If no file is provided, bashunit uses `BASHUNIT_DEFAULT_PATH` to locate all `*bench.sh` files.
+If no file is provided, bashunit uses [`BASHUNIT_DEFAULT_PATH`](/configuration) to locate all `*bench.sh` files.
 
 ## Output Formats
 
@@ -184,6 +184,12 @@ function bench_process_data() {
 ### Run Multiple Iterations
 
 Use `@its` >= 3 for more reliable averages, especially for operations with variable timing.
+
+## Related
+
+- [Command-Line](/command-line) — full reference for CLI flags and options
+- [Configuration](/configuration) — environment variables such as `BASHUNIT_DEFAULT_PATH`
+- [Coverage](/coverage) — measure which code paths your tests exercise
 
 <script setup>
 import pkg from '../package.json'

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -284,9 +284,8 @@ In parallel mode, both test files and individual test functions run concurrently
 for maximum performance.
 
 ::: warning
-Parallel mode is supported on **macOS**, **Ubuntu**, and **Windows**. On other
-systems (like Alpine Linux) the option is automatically disabled due to
-inconsistent results.
+Parallel mode is supported on **macOS**, **Ubuntu**, **Alpine**, and **Windows**.
+On other systems the option is automatically disabled due to inconsistent results.
 :::
 
 ::: tip Opt-out of test-level parallelism
@@ -796,6 +795,13 @@ bashunit bench --help
 bashunit watch --help
 bashunit doc --help
 ```
+
+## Related
+
+- [Configuration](/configuration) — set the same options via env vars and config files
+- [Test files](/test-files) — how bashunit discovers and names test files
+- [Coverage](/coverage) — code coverage tracking
+- [Benchmarks](/benchmarks) — performance benchmarks with `bashunit bench`
 
 <script setup>
 import pkg from '../package.json'

--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -503,7 +503,7 @@ function test_docker_called_with_correct_arguments() {
 
   deploy_image "myapp:v1.0.0"
 
-  assert_have_been_called_with "push myapp:v1.0.0" docker
+  assert_have_been_called_with docker "push myapp:v1.0.0"
 }
 
 function test_deploy_calls_docker_twice() {
@@ -875,3 +875,5 @@ function test_addition() {
 - Learn about [Data Providers](/data-providers) for parameterized testing
 - Check out [Snapshots](/snapshots) for testing complex output
 - Read about [Custom Asserts](/custom-asserts) for domain-specific testing
+- Browse the [Assertions](/assertions) reference for every available check
+- Use [Standalone](/standalone) assertions outside of test files

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,12 +4,12 @@ description: "Configure bashunit with environment variables and config files to 
 
 # Configuration
 
-Environment configuration to control **bashunit** behavior.
+Environment variables and config files control **bashunit** behavior across your project.
 
 It serves to configure the behavior of bashunit in your project.
 You need to create a `.env` file in the root directory,
 but you can give it another name if you pass it as an argument to the command with
-`--env` [option](/command-line#environment).
+`--env` [option](/command-line#environment-bootstrap).
 
 ## Config file (.bashunitrc)
 
@@ -41,7 +41,7 @@ environment variable or a `.env` entry always wins. `--skip-env-file` skips
 
 Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
 
-If a directory is specified, it will execute tests within files ending in `bench.sh`.
+If a directory is specified, it will execute tests within files ending in `test.sh`.
 When running benchmarks (`--bench`), the same path is used to search for files ending in `bench.sh`.
 
 If you use wildcards, **bashunit** will run any tests it finds.
@@ -67,7 +67,7 @@ Enables simplified output to the console. `false` by default.
 
 Verbose is the default output, but it can be overridden by the environment configuration.
 
-Similar as using `-s|--simple | -vvv|--detailed` option on the [command line](/command-line#output).
+Similar as using `-s|--simple | -vvv|--detailed` option on the [command line](/command-line#output-style).
 
 ::: code-group
 ```bash [Simple output]
@@ -98,8 +98,9 @@ BASHUNIT_SIMPLE_OUTPUT=false
 Runs the tests in child processes with randomized execution, which may improve overall testing speed, especially for larger test suites.
 
 ::: warning
-Parallel execution is supported only on **macOS** and **Ubuntu**. On other
-systems bashunit forces sequential execution to avoid inconsistent results.
+Parallel execution is supported on **macOS**, **Ubuntu**, **Alpine**, and
+**Windows**. On other systems bashunit forces sequential execution to avoid
+inconsistent results.
 :::
 
 Similar as using `-p|--parallel` option on the [command line](/command-line#parallel).
@@ -118,7 +119,7 @@ Similar as using `-j|--jobs` option on the [command line](/command-line#jobs).
 
 Force to stop the runner right after encountering one failing test. `false` by default.
 
-Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#stop-on-failure).
+Similar as using `-S|--stop-on-failure` option on the [command line](/command-line#test-options).
 
 ::: tip Assertion behavior
 By default, when an assertion fails within a test, subsequent assertions in the same test are skipped. Use `-R, --run-all` or set `BASHUNIT_STOP_ON_ASSERTION_FAILURE=false` to run all assertions even when one fails.
@@ -301,7 +302,7 @@ file and use `export -f function_name` to make them available in test subshells.
 This is the recommended pattern for sharing functions across tests.
 :::
 
-Similarly, you can use load an additional file via the [command line](/command-line#environment).
+Similarly, you can use load an additional file via the [command line](/command-line#environment-bootstrap).
 
 ::: code-group
 ```bash [Example]
@@ -337,7 +338,7 @@ export API_URL="https://${ENVIRONMENT}.api.example.com"
 ```
 :::
 
-You can also pass arguments inline via the [--env](/command-line#environment) option:
+You can also pass arguments inline via the [--env](/command-line#environment-bootstrap) option:
 
 ```bash
 bashunit --env "tests/bootstrap.sh staging verbose" tests/
@@ -347,7 +348,7 @@ bashunit --env "tests/bootstrap.sh staging verbose" tests/
 
 > `BASHUNIT_DEV_LOG=file`
 
-> See: [Globals > log](/globals#log)
+> See: [Globals > log](/globals#bashunit-log)
 
 ::: code-group
 ```bash [Setup]
@@ -376,7 +377,7 @@ quickly `tail -f` it while the tests run.
 
 Display internal details for each test.
 
-Similarly, you can use the command line option for this: [command line](/command-line#verbose).
+Similarly, you can use the command line option for this: [command line](/command-line#test-options).
 
 ::: code-group
 ```bash [Example]
@@ -390,7 +391,7 @@ BASHUNIT_VERBOSE=true
 
 Suppress all console output. Defaults to `false`.
 
-Similar as using `--no-output` option on the [command line](/command-line#no-output).
+Similar as using `--no-output` option on the [command line](/command-line#test-options).
 
 ::: code-group
 ```bash [Example]
@@ -441,7 +442,7 @@ Only show failures, suppressing passed, skipped, and incomplete tests. `false` b
 When enabled, progress output is suppressed and only failing tests are displayed.
 The final summary still shows all counts (passed/failed/skipped/incomplete).
 
-Similar as using `--failures-only` option on the [command line](/command-line#failures-only).
+Similar as using `--failures-only` option on the [command line](/command-line#test-options).
 
 ::: code-group
 ```bash [Example]
@@ -671,6 +672,13 @@ BASHUNIT_COVERAGE_THRESHOLD_LOW=60
 BASHUNIT_COVERAGE_THRESHOLD_HIGH=90
 ```
 :::
+
+## Related
+
+- [Command line](/command-line) — flags that mirror these settings
+- [Test files](/test-files) — how tests are discovered and named
+- [Coverage](/coverage) — measure how much code your tests exercise
+- [Globals](/globals) — helper functions available in tests
 
 <script setup>
 import pkg from '../package.json'

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -86,7 +86,7 @@ For most projects following standard naming conventions, you can simply run `bas
 
 ### Environment Variables
 
-You can also configure coverage via environment variables in your `.env` file:
+You can also configure coverage via [environment variables](/configuration) in your `.env` file:
 
 ```bash
 # Enable coverage
@@ -486,6 +486,12 @@ coverage:
 - `&&`/`||` short-circuit branches outside `if` and loop-entry decisions (`while`/`until`) are not tracked.
 
 See `adrs/adr-007-branch-coverage-mvp.md` for the design rationale and the rejected alternatives.
+
+## Related
+
+- [Command-Line](/command-line) — full reference for CLI flags and options
+- [Configuration](/configuration) — environment variables and config files
+- [Benchmarks](/benchmarks) — measure performance alongside coverage
 
 ## Limitations
 

--- a/docs/custom-asserts.md
+++ b/docs/custom-asserts.md
@@ -4,7 +4,7 @@ description: "Write custom assertions in bashunit to extend the testing framewor
 
 # Custom asserts
 
-**bashunit** enables you to extend the language by building your custom assertions. It is ideal for custom domain assertions, which don't need to be in the core library.
+Custom assertions let you extend **bashunit** with your own reusable checks, ideal for domain-specific assertions that don't need to live in the core library.
 
 :::tip
 Check the internal functional tests: `tests/functional/custom_asserts_test.sh` ([link](https://github.com/TypedDevs/bashunit/blob/main/tests/functional/custom_asserts_test.sh))
@@ -85,7 +85,7 @@ function test_api_returns_valid_json() {
 
 ### Composing with existing assertions
 
-Custom assertions can call other bashunit assertions internally:
+Custom assertions can call other [bashunit assertions](/assertions) internally:
 
 ```bash
 function assert_http_success() {
@@ -125,3 +125,9 @@ function assert_positive_number() {
 3. **Use descriptive names**: Name your custom assertions clearly, e.g., `assert_valid_email`, `assert_file_contains_header`.
 
 4. **Keep assertions focused**: Each custom assertion should test one specific condition.
+
+## Related
+
+- [Assertions](/assertions) — the built-in assertion reference
+- [Globals](/globals) — `bashunit::` helper functions
+- [Common patterns](/common-patterns) — real-world testing patterns

--- a/docs/data-providers.md
+++ b/docs/data-providers.md
@@ -45,7 +45,7 @@ function provider_function() {
 ```
 :::
 
-> **Note**: The previous variant of using `echo` to define data within a data provider
+> **Note**: The previous variant of using `echo` to define data within a data
 > provider is still supported but deprecated, as it does not support empty values or
 > values containing spaces. Prefer using the `bashunit::data_set` function going forward.
 
@@ -150,3 +150,9 @@ Running example_test.sh
 ✓ Passed: Directory exists ('outro', '/var')
 ```
 :::
+
+## Related
+
+- [Test files](/test-files) — `set_up` and `tear_down` lifecycle hooks
+- [Assertions](/assertions) — the built-in assertion reference
+- [Common patterns](/common-patterns) — real-world testing patterns

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -54,3 +54,10 @@ Sh:erpa is a tool for simplifying script creation. It integrates **bashunit** to
 ### [sqlh](https://gitlab.com/prodigal.knight/sqlite-history.sh)
 
 sqlh is a SQLite-backed shell history alternative with shared history features which works across multiple shells.
+
+## Related
+
+- [Quickstart](/quickstart) - write and run your first test
+- [Common patterns](/common-patterns) - real-world testing patterns
+- [Standalone](/standalone) - assertions outside test files
+- [Assertions](/assertions) - assertion reference

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -4,7 +4,7 @@ description: "Reference of bashunit global helper functions in the bashunit:: na
 
 # Globals
 
-You can use this list of global functions that exists to primarily to improve your developer experience.
+These global helper functions exist primarily to improve your developer experience.
 
 All helper functions use the `bashunit::` namespace prefix to prevent naming collisions with your own code.
 
@@ -100,3 +100,10 @@ See [Custom asserts](/custom-asserts) for full examples.
 
 The `bashunit::spy`, `bashunit::mock`, and `bashunit::unmock` helpers are
 documented in [Test doubles](/test-doubles).
+
+## Related
+
+- [Custom asserts](/custom-asserts) — build your own assertions with these helpers
+- [Assertions](/assertions) — the built-in assertion reference
+- [Test doubles](/test-doubles) — spies and mocks
+- [Configuration](/configuration) — configure the dev log used by `bashunit::log`

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -349,6 +349,13 @@ Dependabot bumps `github-actions` pins on the schedule you set.
 See bashunit's own pipeline for a real example: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::
 
+## Related
+
+- [Quickstart](/quickstart) - write and run your first test
+- [Command line](/command-line) - CLI flags and options
+- [Configuration](/configuration) - env vars and config files
+- [Project overview](/project-overview) - repo layout and contributor workflow
+
 <script setup>
 import pkg from '../package.json'
 </script>

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -52,3 +52,10 @@ Before submitting your pull request ensure that `npm run build` (run from `docs/
 ## Further reading
 
 For a step‑by‑step introduction check the [quickstart](/quickstart). Detailed usage of individual features is explained throughout the docs site.
+
+## Related
+
+- [Quickstart](/quickstart) - write and run your first test
+- [Installation](/installation) - install bashunit
+- [Command line](/command-line) - CLI flags and options
+- [Examples](/examples) - sample tests and real-world projects

--- a/docs/skipping-incomplete.md
+++ b/docs/skipping-incomplete.md
@@ -77,3 +77,9 @@ Assertions: 2 incomplete, 2 total
 Some tests incomplete
 ```
 :::
+
+## Related
+
+- [Assertions](/assertions) — the built-in assertion reference
+- [Test files](/test-files) — test discovery and lifecycle hooks
+- [Command line](/command-line) — CLI flags and options

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -87,3 +87,9 @@ echo 'Run at ::ignore::' > snapshots/example.snapshot
 # test
 assert_match_snapshot "Run at $(date)"
 ```
+
+## Related
+
+- [Assertions](/assertions) — the built-in assertion reference
+- [Configuration](/configuration) — env vars like `BASHUNIT_SNAPSHOT_PLACEHOLDER`
+- [Test doubles](/test-doubles) — mocks and spies for isolated tests

--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -203,3 +203,9 @@ All standard bashunit [assertions](/assertions) are available in standalone mode
 | `line_count` | Check number of lines |
 
 See the full [assertions reference](/assertions) for all available options.
+
+## Related
+
+- [Assertions](/assertions) — full assertion reference
+- [Command-Line](/command-line) — full reference for CLI flags and options
+- [Common Patterns](/common-patterns) — real-world testing recipes

--- a/docs/support.md
+++ b/docs/support.md
@@ -19,3 +19,9 @@ How to Get Support:
 
 We value our community's feedback and aim to address all concerns in a timely and effective manner.
 Your active participation and constructive feedback play a pivotal role in the continuous improvement of **bashunit**.
+
+## Related
+
+- [Quickstart](/quickstart) - write and run your first test
+- [Installation](/installation) - install bashunit
+- [Project overview](/project-overview) - repo layout and contributor workflow

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -4,7 +4,7 @@ description: "Create test doubles in bashunit: use mocks to override functions a
 
 # Test doubles
 
-When creating tests, you might need to override existing function to be able to write isolated tests from external behaviour. To accomplish this, you can use mocks. You can also check that a function was called with certain arguments or even a number of times with a spy.
+Test doubles let you override an existing function to write tests isolated from external behaviour: use mocks to replace a function's output, and spies to assert that a function was called, with which arguments, and how many times.
 
 Temporary files created by spies are isolated per test run, so they work reliably when executing tests in parallel.
 
@@ -256,3 +256,9 @@ function test_failure() {
 }
 ```
 :::
+
+## Related
+
+- [Assertions](/assertions) — the built-in assertion reference
+- [Custom asserts](/custom-asserts) — build your own domain-specific assertions
+- [Common patterns](/common-patterns) — real-world testing patterns

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -4,7 +4,7 @@ description: "Learn how bashunit discovers and names test files, plus tips for o
 
 # Test files
 
-**bashunit** offers a range of features for test files.
+**bashunit** discovers, names, and runs test files through a set of conventions and helpers.
 In this section, you'll find information about these features along with some helpful tips.
 
 ## Test file names
@@ -18,7 +18,7 @@ If you're using wildcards for scanning your tests, keep in mind that the initial
 To optimize this, we recommend adding a `test` prefix or suffix to your test file names, and include this identifier in your wildcard pattern too (e.g., `**/*test.sh` or `**/*test.bash`).
 This naming convention not only speeds up the scanning process but also helps you keep your test files organized.
 
-This is useful regardless of whether your test files are located near your production code or share directories with your mocks, stubs, or fixtures.
+This is useful regardless of whether your test files are located near your production code or share directories with your [mocks](/test-doubles), stubs, or fixtures.
 
 ## Test function names
 
@@ -153,3 +153,10 @@ Some tests failed
 
 This guarantees a broken test file always fails the suite, so it never
 passes by absence.
+
+## Related
+
+- [Command line](/command-line) — discover and run test files from the terminal
+- [Configuration](/configuration) — set the default test path and bootstrap file
+- [Assertions](/assertions) — assertions to use inside your test functions
+- [Common patterns](/common-patterns) — real-world testing patterns


### PR DESCRIPTION
Additive quality pass across all documentation pages.

## What changed
- **Cross-linking**: added a `## Related` section and contextual inline links to every page, improving navigation and SEO link graph.
- **Sharper intros**: tightened weak opening sentences to lead with the key term (prose only; no rewrites).
- **Factual fixes** (verified against `src/`):
  - Parallel execution platforms corrected to macOS, Ubuntu, Alpine, Windows (was wrong in `configuration.md` and `command-line.md`).
  - `BASHUNIT_DEFAULT_PATH` describes `test.sh` for normal runs (was `bench.sh`).
  - Fixed reversed `assert_have_been_called_with` argument order in `common-patterns.md`.
- **Broken anchors**: fixed 9 stale in-page `#anchor` links in `configuration.md` (build doesn't validate fragments; verified against generated IDs).
- **Markdown**: closed an unclosed code fence in `assertions.md`.

Headings untouched, code examples intact. Verified: docs build clean, site-wide anchor sweep clean, editorconfig OK.