### PR TITLE
fix(cli): skip non-assert headings in 'bashunit doc' output

### DIFF
--- a/src/doc.sh
+++ b/src/doc.sh
@@ -18,6 +18,12 @@ function bashunit::doc::print_asserts() {
   local line
   while IFS='' read -r line || [ -n "$line" ]; do
     fn=$(echo "$line" | sed -n 's/^## \([A-Za-z0-9_]*\).*/\1/p')
+    # Only treat assertion headings as doc entries; skip prose sections
+    # like "## Related" that are part of the documentation page but not asserts.
+    case "$fn" in
+    assert* | bashunit*) ;;
+    *) fn="" ;;
+    esac
     if [ -n "$fn" ]; then
       local _match=0
       if [ -z "$filter" ]; then


### PR DESCRIPTION
## Problem

The docs polish (#716) added a `## Related` navigation section to `docs/assertions.md`. The `bashunit doc` parser treated **any** `## Word` heading as an assertion entry, printing a dangling `## Related` line.

This broke the `should display all assert docs` snapshot test, failing both the **Tests** and **Bash 3.0 Compatibility** CI jobs on `main`.

## Fix

Restrict doc parsing to assertion headings (`assert*` / `bashunit*`) via a portable `case` filter. Avoids BSD-sed alternation incompatibility (`\|` not supported in macOS sed).

## Verification

- `./bashunit doc` output matches snapshot again
- Full suite green: 1110 passed, 0 failed
- `make sa`, `make lint`, `shfmt` all pass
- Bash 3.0+ compatible (portable `case`)