### PR TITLE
docs: polish footer with linked license and brand

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -199,11 +199,15 @@ export default defineConfig({
     },
 
     footer: {
-      message: 'Released under the MIT License.',
+      message:
+        'Released under the ' +
+        '<a href="https://github.com/TypedDevs/bashunit/blob/main/LICENSE"' +
+        ' target="_blank">MIT License</a>.',
       copyright:
-        'Copyright © 2023-present bashunit. ' +
-        '<a href="https://github.com/TypedDevs/bashunit"' +
-        ' target="_blank">Source · GitHub</a>'
+        'Copyright © 2023-present ' +
+        '<a href="https://bashunit.com">bashunit</a>' +
+        ' · <a href="https://github.com/TypedDevs/bashunit"' +
+        ' target="_blank">GitHub</a>'
     }
   },
 


### PR DESCRIPTION
Improve the docs footer for a more professional yet simple look:

- Link `MIT License` text to the actual LICENSE file (verifiable)
- Link the `bashunit` brand to the homepage
- Simplify the source link to `GitHub`

Renders as:
> Released under the **MIT License**.
> Copyright © 2023-present **bashunit** · **GitHub**