### PR TITLE
docs: drop license line from footer

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -199,10 +199,6 @@ export default defineConfig({
     },
 
     footer: {
-      message:
-        'Released under the ' +
-        '<a href="https://github.com/TypedDevs/bashunit/blob/main/LICENSE"' +
-        ' target="_blank">MIT License</a>.',
       copyright:
         'Copyright © 2023-present ' +
         '<a href="https://bashunit.com">bashunit</a>' +


### PR DESCRIPTION
Remove the 'Released under the MIT License' line from the docs footer, keeping only the copyright/brand/source line.