### PR TITLE
fix(coverage): count backslash line-continuation lines as covered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Coverage report now counts backslash line-continuation lines as covered: a multi-line statement's hit is propagated forward across its continuation chain, so the lines after a trailing `\` are no longer reported as uncovered (#722)
+
 ### Changed
 - Documentation and project URLs now point to the new primary domain `bashunit.com` (old `bashunit.typeddevs.com` continues to work as a redirect)
 - The docs site now deploys to GitHub Pages on the `bashunit.com` custom domain (`deploy-gh-pages.yml`); the installer is copied into the site root from the repo's canonical `install.sh`

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -647,8 +647,27 @@ function bashunit::coverage::compute_file_coverage() {
   echo "${executable}:${hit}"
 }
 
+# Detect whether a source line ends with a Bash line-continuation, i.e. an
+# odd number of unescaped trailing backslashes with no trailing whitespace.
+# Comment lines never continue. Used to propagate coverage hits from a
+# statement's starting line to its continuation lines (see #722).
+function bashunit::coverage::_ends_with_continuation() {
+  local line="$1"
+  local lead="${line#"${line%%[![:space:]]*}"}"
+  case "$lead" in '#'*) return 1 ;; esac
+  local trailing="${line##*[!\\]}"
+  case "$line" in *[!\\]*) : ;; *) trailing="$line" ;; esac
+  [ $(( ${#trailing} % 2 )) -eq 1 ]
+}
+
 # Get all line hits for a file in one pass (performance optimization)
 # Output format: one "lineno:count" per line
+#
+# Bash's DEBUG trap attributes a multi-line statement's execution to the line
+# where the statement starts; backslash continuation lines never receive their
+# own hit. To match the report's expectation that continuation lines are
+# covered, the start line's count is propagated forward across the
+# continuation chain (see #722).
 function bashunit::coverage::get_all_line_hits() {
   local file="$1"
 
@@ -656,13 +675,51 @@ function bashunit::coverage::get_all_line_hits() {
     return
   fi
 
-  # Extract all lines for this file, count occurrences of each line number
-  local count lineno
-  grep "^${file}:" "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null |
-    cut -d: -f2 | sort | uniq -c |
-    while read -r count lineno; do
-      echo "${lineno}:${count}"
-    done
+  # Extract all lines for this file, count occurrences of each line number.
+  local -a counts=()
+  local count lineno maxln=0
+  while read -r count lineno; do
+    if [ -n "$lineno" ]; then
+      counts[lineno]=$count
+      [ "$lineno" -gt "$maxln" ] && maxln=$lineno
+    fi
+  done < <(grep "^${file}:" "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null |
+    cut -d: -f2 | sort | uniq -c)
+
+  if [ "$maxln" -eq 0 ]; then
+    return
+  fi
+
+  # Read the source so continuation lines can be detected.
+  local -a src=()
+  local _i=0 _l
+  while IFS= read -r _l || [ -n "$_l" ]; do
+    src[_i]="$_l"
+    ((++_i))
+  done <"$file"
+
+  local total=$_i
+  [ "$maxln" -gt "$total" ] && total=$maxln
+
+  # Propagate each start line's count forward across its continuation chain.
+  local carry=0 idx h
+  for ((idx = 1; idx <= total; idx++)); do
+    h=${counts[idx]:-0}
+    if [ "$carry" -gt 0 ] && [ "$h" -lt "$carry" ]; then
+      h=$carry
+      counts[idx]=$h
+    fi
+    if [ "$h" -gt 0 ] && bashunit::coverage::_ends_with_continuation "${src[idx - 1]:-}"; then
+      carry=$h
+    else
+      carry=0
+    fi
+  done
+
+  local ln
+  for ((ln = 1; ln <= total; ln++)); do
+    [ "${counts[ln]:-0}" -gt 0 ] && echo "${ln}:${counts[ln]}"
+  done
 }
 
 # Get all test hits for a file in one pass (performance optimization)

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -657,7 +657,7 @@ function bashunit::coverage::_ends_with_continuation() {
   case "$lead" in '#'*) return 1 ;; esac
   local trailing="${line##*[!\\]}"
   case "$line" in *[!\\]*) : ;; *) trailing="$line" ;; esac
-  [ $(( ${#trailing} % 2 )) -eq 1 ]
+  [ $((${#trailing} % 2)) -eq 1 ]
 }
 
 # Get all line hits for a file in one pass (performance optimization)
@@ -720,6 +720,11 @@ function bashunit::coverage::get_all_line_hits() {
   for ((ln = 1; ln <= total; ln++)); do
     [ "${counts[ln]:-0}" -gt 0 ] && echo "${ln}:${counts[ln]}"
   done
+
+  # The for loop's exit status leaks the last `[ -gt ]` test, which is 1 when the
+  # final line has no hits; return 0 explicitly so callers under `set -e` (strict
+  # mode) don't treat a successful run as a failure (see #722).
+  return 0
 }
 
 # Get all test hits for a file in one pass (performance optimization)

--- a/tests/unit/coverage_executable_test.sh
+++ b/tests/unit/coverage_executable_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2317
+# shellcheck disable=SC1003 # intentional literal trailing backslashes in test inputs
 
 # Save original coverage state to restore after tests
 _ORIG_COVERAGE_DATA_FILE=""
@@ -282,4 +283,98 @@ function test_coverage_is_executable_line_returns_false_for_done_with_append_red
   local result
   result=$(bashunit::coverage::is_executable_line '  done >> /tmp/out.log' 2 && echo "yes" || echo "no")
   assert_equals "no" "$result"
+}
+
+# --- _ends_with_continuation (#722) -----------------------------------------
+
+function test_coverage_ends_with_continuation_true_for_single_trailing_backslash() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation 'echo foo \' && echo "yes" || echo "no")
+  assert_equals "yes" "$result"
+}
+
+function test_coverage_ends_with_continuation_true_for_indented_continuation() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation '  some_command --flag \' && echo "yes" || echo "no")
+  assert_equals "yes" "$result"
+}
+
+function test_coverage_ends_with_continuation_false_for_no_backslash() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation 'echo foo' && echo "yes" || echo "no")
+  assert_equals "no" "$result"
+}
+
+function test_coverage_ends_with_continuation_false_for_escaped_backslash() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation 'echo foo \\' && echo "yes" || echo "no")
+  assert_equals "no" "$result"
+}
+
+function test_coverage_ends_with_continuation_true_for_three_backslashes() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation 'echo foo \\\' && echo "yes" || echo "no")
+  assert_equals "yes" "$result"
+}
+
+function test_coverage_ends_with_continuation_false_for_trailing_whitespace_after_backslash() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation 'echo foo \ ' && echo "yes" || echo "no")
+  assert_equals "no" "$result"
+}
+
+function test_coverage_ends_with_continuation_false_for_comment_line() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation '# a trailing slash in a comment \' && echo "yes" || echo "no")
+  assert_equals "no" "$result"
+}
+
+function test_coverage_ends_with_continuation_false_for_empty_line() {
+  local result
+  result=$(bashunit::coverage::_ends_with_continuation '' && echo "yes" || echo "no")
+  assert_equals "no" "$result"
+}
+
+# --- get_all_line_hits continuation propagation (#722) ----------------------
+
+function test_coverage_get_all_line_hits_propagates_across_continuation_chain() {
+  local dir
+  dir=$(mktemp -d)
+  _BASHUNIT_COVERAGE_DATA_FILE="${dir}/coverage.data"
+
+  local src="${dir}/script.sh"
+  printf '%s\n' 'echo start \' '  middle \' '  end' 'echo other' >"$src"
+
+  # Start line (1) hit twice, standalone line (4) hit once.
+  printf '%s\n' "${src}:1" "${src}:1" "${src}:4" >"$_BASHUNIT_COVERAGE_DATA_FILE"
+
+  local result
+  result=$(bashunit::coverage::get_all_line_hits "$src")
+
+  local expected
+  expected=$(printf '%s\n' "1:2" "2:2" "3:2" "4:1")
+
+  rm -rf "$dir" 2>/dev/null || true
+  _BASHUNIT_COVERAGE_DATA_FILE=""
+
+  assert_equals "$expected" "$result"
+}
+
+function test_coverage_get_all_line_hits_does_not_propagate_without_continuation() {
+  local dir
+  dir=$(mktemp -d)
+  _BASHUNIT_COVERAGE_DATA_FILE="${dir}/coverage.data"
+
+  local src="${dir}/script.sh"
+  printf '%s\n' 'echo one' 'echo two' >"$src"
+
+  printf '%s\n' "${src}:1" >"$_BASHUNIT_COVERAGE_DATA_FILE"
+
+  local result
+  result=$(bashunit::coverage::get_all_line_hits "$src")
+
+  rm -rf "$dir" 2>/dev/null || true
+  _BASHUNIT_COVERAGE_DATA_FILE=""
+
+  assert_equals "1:1" "$result"
 }


### PR DESCRIPTION
## Background

Related #722

Bash's DEBUG trap attributes a multi-line statement's execution to the line where the statement starts, so the lines after a trailing `\` never receive their own hit and are reported as uncovered. The issue's example shows the line with the backslash counted, but the following line missed.

## Changes

- Propagate each start line's hit count forward across its continuation chain in `get_all_line_hits`. This is the single function feeding the percentage, lcov, html and uncovered-line reports, so the fix lands everywhere at once.
- Add `bashunit::coverage::_ends_with_continuation`, which detects a trailing unescaped backslash (odd number of trailing backslashes, no trailing whitespace, not a comment line).
- Unit tests for `_ends_with_continuation` (single/odd/even backslashes, trailing whitespace, comments, empty line) and for the forward propagation in `get_all_line_hits`.

Reproducing the issue's snippet under a real coverage run, before vs after:

```
# before
src/calc.sh    2/3 lines ( 66%)
# after
src/calc.sh    3/3 lines (100%)
```

`make test` (868 passed, 3 pre-existing skips), `shellcheck -xC` clean on both changed files. Bash 3.0 compatible (indexed arrays only).

## Checklist

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes