### PR TITLE
fix(release): keep git tag stdout out of create_tags return value

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -594,8 +594,11 @@ function release::create_tags() {
   local major_tag
   major_tag=$(release::major_tag "$new_version")
 
-  git tag -a -m "$new_version" "$new_version"
-  git tag -f -a -m "$major_tag" "$major_tag" "${new_version}^{}"
+  # Silence git's own stdout ("Updated tag 'v0' (was ...)" when -f replaces an
+  # existing tag) so it cannot leak into this function's stdout, which the
+  # caller captures as the major tag name. Errors still surface on stderr.
+  git tag -a -m "$new_version" "$new_version" >/dev/null
+  git tag -f -a -m "$major_tag" "$major_tag" "${new_version}^{}" >/dev/null
 
   echo "$major_tag"
 }

--- a/tests/unit/release_utilities_test.sh
+++ b/tests/unit/release_utilities_test.sh
@@ -405,3 +405,21 @@ function test_create_tags_returns_major_tag_name() {
   cd "$origin" || return 1
   rm -rf "$repo"
 }
+
+# Regression: when the major tag already exists, `git tag -f` prints
+# "Updated tag 'v0' (was ...)" to stdout. That must not leak into the
+# returned major tag name (it previously did, producing an invalid push
+# refspec during a real release).
+function test_create_tags_returns_clean_name_when_major_tag_already_exists() {
+  local repo origin result
+  repo="$(_create_tags_setup_repo)"
+  origin="$(pwd)"
+
+  cd "$repo" || return 1
+  git tag v0 # pre-existing major tag -> -f takes the update path
+  result="$(release::create_tags '0.40.0')"
+  assert_same "v0" "$result" # exactly "v0", no "Updated tag ..." noise
+
+  cd "$origin" || return 1
+  rm -rf "$repo"
+}


### PR DESCRIPTION
## Summary

Follow-up to #727. During the 0.40.0 release, `release::create_tags` returned a polluted value: when the floating major tag (`v0`) already exists, `git tag -f` writes `Updated tag 'v0' (was <sha>)` to **stdout**, and `major_tag=$(release::create_tags ...)` captured it. The push step then got `git push origin "Updated tag 'v0' (was ...)\nv0" --force` and failed with `fatal: invalid refspec`.

The 0.40.0 release was completed manually (tag/v0/GitHub release/latest all published correctly); this PR fixes the script so the next release runs clean end-to-end.

## Changes

- Redirect both `git tag` commands' stdout to `/dev/null` in `release::create_tags` so only the major tag name reaches stdout. Errors still surface on stderr (and `set -e` still aborts on failure).
- Add `test_create_tags_returns_clean_name_when_major_tag_already_exists`, which pre-creates `v0` to exercise the `git tag -f` *update* path. The original tests only covered first-time creation (which prints nothing), so they missed this. Verified the new test fails on the pre-fix code and passes with the fix.

## Test plan

- `./bashunit tests/unit/release_*.sh` — all green
- `make sa && make lint && shfmt` — clean