### PR TITLE
docs(blog): add release posts for 0.38, 0.39 and 0.40

### DIFF
--- a/docs/blog/2026-06-07-release-0-38.md
+++ b/docs/blog/2026-06-07-release-0-38.md
@@ -1,0 +1,47 @@
+---
+date: '2026-06-07'
+title: 'Release 0.38.0'
+description: 'An official GitHub Action to install bashunit, pinnable by commit SHA, plus opt-in checksum verification and a hardened installer.'
+coverAlt: 'Official GitHub Action, SHA-pinnable installs, installer checksum verification and hardening'
+
+aside: false
+---
+
+# {{ $frontmatter.title }}
+
+<time>{{ $formatDate($frontmatter.date) }}</time>
+
+## New features
+
+### Official GitHub Action
+
+Installing bashunit in CI no longer means hand-rolling a `curl | bash` step. The new `TypedDevs/bashunit` composite action installs bashunit for you and can be pinned by commit SHA for immutable, reproducible builds ([#695](https://github.com/TypedDevs/bashunit/issues/695)):
+
+```yaml
+- uses: TypedDevs/bashunit@<commit-sha>
+  with:
+    version: '0.38.0'      # optional, defaults to the version pinned at the ref
+    directory: 'lib'       # where to install
+    add-to-path: 'true'    # expose `bashunit` on PATH
+    verify-checksum: 'true'
+- run: bashunit tests/
+```
+
+It exposes `path` and `version` outputs so later steps can reference the exact install.
+
+### Installer checksum verification
+
+`install.sh` can now validate the downloaded binary against the release `checksum` asset. Set `BASHUNIT_VERIFY_CHECKSUM=true` to turn it on ([#695](https://github.com/TypedDevs/bashunit/issues/695)):
+
+```bash
+BASHUNIT_VERIFY_CHECKSUM=true bash <(curl -s https://bashunit.com/install.sh)
+```
+
+## Bug fixes
+
+- `install.sh` now fails loudly — non-zero exit, no stub binary — when a download fails, and retries transient failures instead of silently reporting success ([#695](https://github.com/TypedDevs/bashunit/issues/695)).
+- `install.sh` creates nested target directories with `mkdir -p` ([#695](https://github.com/TypedDevs/bashunit/issues/695)).
+
+---
+
+See the full changelog for [0.38.0](https://github.com/TypedDevs/bashunit/releases/tag/0.38.0) on GitHub.

--- a/docs/blog/2026-06-09-release-0-39.md
+++ b/docs/blog/2026-06-09-release-0-39.md
@@ -1,0 +1,50 @@
+---
+date: '2026-06-09'
+title: 'Release 0.39.0'
+description: 'Run the suite straight from the GitHub Action, pin it by major with v0, scaffold a CI workflow on init, a --report-junit alias, default checksum verification and line-accurate GHA annotations.'
+coverAlt: 'Action args input, v0 major tag, init CI scaffold, report-junit alias, default checksum, GHA line annotations'
+
+aside: false
+---
+
+# {{ $frontmatter.title }}
+
+<time>{{ $formatDate($frontmatter.date) }}</time>
+
+## New features
+
+### Install and run in one Action step
+
+The GitHub Action gained an `args` input: when set, it runs `bashunit <args>` right after installing, so a single step both installs the framework and runs your suite:
+
+```yaml
+- uses: TypedDevs/bashunit@v0
+  with:
+    args: 'tests/ --parallel'
+```
+
+### Pin the Action by major with `v0`
+
+The release process now force-moves a floating `v0` tag to each release, so workflows can pin `TypedDevs/bashunit@v0` and automatically track the latest release within the major ([#700](https://github.com/TypedDevs/bashunit/issues/700)).
+
+### Scaffold a CI workflow on `init`
+
+`bashunit init` now scaffolds a `.github/workflows/tests.yml` that uses the official action, giving new projects working CI out of the box. Existing files are left untouched ([#702](https://github.com/TypedDevs/bashunit/issues/702)).
+
+### `--report-junit` alias
+
+`--report-junit <file>` is now an alias of `--log-junit`, for naming parity with `--report-html` ([#705](https://github.com/TypedDevs/bashunit/issues/705)).
+
+## Changes
+
+- The Action's `version` input now defaults to the version pinned at the action ref instead of `latest`, so pinning the action by SHA also pins a visible bashunit version.
+- `install.sh` now verifies the release checksum by default. Set `BASHUNIT_VERIFY_CHECKSUM=false` to opt out; it soft-skips with a warning when a checksum asset is unavailable unless verification was explicitly requested ([#703](https://github.com/TypedDevs/bashunit/issues/703)).
+- `--log-gha` annotations now include the failing test's `line` (`::error file=…,line=…`), so they pin to the exact line in a pull request's "Files changed" tab ([#704](https://github.com/TypedDevs/bashunit/issues/704)).
+
+## Patch 0.39.1
+
+A follow-up fix: `bashunit upgrade` was resolving the floating `v0` Action tag as the latest version, which broke upgrades. It now only considers exact-version tags. See the [0.39.1](https://github.com/TypedDevs/bashunit/releases/tag/0.39.1) changelog.
+
+---
+
+See the full changelog for [0.39.0](https://github.com/TypedDevs/bashunit/releases/tag/0.39.0) on GitHub.

--- a/docs/blog/2026-06-16-release-0-40.md
+++ b/docs/blog/2026-06-16-release-0-40.md
@@ -1,0 +1,43 @@
+---
+date: '2026-06-16'
+title: 'Release 0.40.0'
+description: 'Abort hanging tests with a per-test timeout, plus coverage fixes for line continuations and printf spies, a leaked exit-code fix, and the move to bashunit.com.'
+coverAlt: 'Per-test timeout, coverage continuation and printf-spy fixes, exit-code fix, bashunit.com domain'
+
+aside: false
+---
+
+# {{ $frontmatter.title }}
+
+<time>{{ $formatDate($frontmatter.date) }}</time>
+
+## New features
+
+### Abort hanging tests with `--test-timeout`
+
+A single hanging test could stall an entire run. The new `--test-timeout <seconds>` flag (or `BASHUNIT_TEST_TIMEOUT`) aborts any test that runs longer than the given number of seconds, marks it failed, and keeps running the rest. It is disabled by default (`0`), needs no external `timeout` command, and works on Bash 3.2+ ([#721](https://github.com/TypedDevs/bashunit/issues/721)):
+
+```bash
+bashunit --test-timeout 5 tests/
+# or
+BASHUNIT_TEST_TIMEOUT=5 bashunit tests/
+```
+
+## Bug fixes
+
+- A test that exited non-zero no longer poisons the exit code of later tests in the same file; the per-test exit code is now reset between tests.
+- Coverage now counts backslash line-continuation lines as covered: a multi-line statement's hit is propagated across its continuation chain, so the lines after a trailing `\` are no longer reported as uncovered ([#722](https://github.com/TypedDevs/bashunit/issues/722)).
+- Spying or mocking the `printf` builtin no longer breaks coverage collection. The coverage buffer is now flushed with `builtin printf`, so a test double can no longer shadow the write and silently drop coverage data for that test ([#724](https://github.com/TypedDevs/bashunit/issues/724)).
+
+## Changes
+
+- URLs and project links now point to the new primary domain [bashunit.com](https://bashunit.com). The old `bashunit.typeddevs.com` continues to work as a redirect.
+- The docs site now deploys to GitHub Pages on the `bashunit.com` custom domain.
+
+## Removed
+
+- The weekly-downloads chart on the docs homepage, whose data source was not portable. It may be revisited later.
+
+---
+
+See the full changelog for [0.40.0](https://github.com/TypedDevs/bashunit/releases/tag/0.40.0) on GitHub.


### PR DESCRIPTION
## Summary

Backfills the blog with release write-ups for the three releases since 0.37, matching the existing post format (frontmatter + `New features` / `Changes` / `Bug fixes` sections, issue links, closing changelog link). Posts are auto-listed via the blog content glob (`posts.data.ts`).

- **0.38.0** — official `TypedDevs/bashunit` GitHub Action (SHA-pinnable), opt-in installer checksum verification, hardened `install.sh`.
- **0.39.0** — Action `args` to install+run in one step, `v0` floating major tag, `bashunit init` CI scaffold, `--report-junit` alias, default checksum verification, line-accurate GHA annotations. Includes a note on the 0.39.1 patch.
- **0.40.0** — `--test-timeout`, coverage fixes (#722, #724), leaked exit-code fix, move to bashunit.com.

## Pagination

Kept blog pagination at `perPage = 10` (unchanged). With ~20 release posts that's a few pages with short scroll per page — 15 would only trade a page for a longer page. 10 is the conventional, faster-rendering default already in place.

## Test plan

- `cd docs && npm run build` — builds clean with all three new posts
- `make lint` — editorconfig OK
- All referenced issue/PR numbers verified to exist