### PR TITLE
docs(blog): highlight Dependabot auto-update benefit of the GitHub Action

### DIFF
--- a/docs/blog/2026-06-07-release-0-38.md
+++ b/docs/blog/2026-06-07-release-0-38.md
@@ -29,6 +29,8 @@ Installing bashunit in CI no longer means hand-rolling a `curl | bash` step. The
 
 It exposes `path` and `version` outputs so later steps can reference the exact install.
 
+The biggest day-to-day win for consumers: once the action is pinned, [Dependabot or Renovate](/installation#keep-the-sha-pin-fresh-automatically) bumps it on a schedule — so bashunit updates land as routine pull requests instead of someone remembering to re-run a `curl | bash` step by hand.
+
 ### Installer checksum verification
 
 `install.sh` can now validate the downloaded binary against the release `checksum` asset. Set `BASHUNIT_VERIFY_CHECKSUM=true` to turn it on ([#695](https://github.com/TypedDevs/bashunit/issues/695)):

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -345,6 +345,9 @@ updates:
 Renovate updates the pinned SHA and refreshes the trailing `# tag` comment in the same PR.
 Dependabot bumps `github-actions` pins on the schedule you set.
 
+Either way you get bashunit updates as routine pull requests — no manual re-pinning or
+`curl | bash` bumps to remember. Review the PR, let CI run, merge.
+
 ::: tip
 See bashunit's own pipeline for a real example: https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/tests.yml
 :::


### PR DESCRIPTION
## 🤔 Background

Follow-up to #730. In review, @staabm noted that the GitHub Action's main benefit for consumers is automatic bashunit updates via Dependabot — no more manual bumps — which the blog post didn't surface and the docs only framed as supply-chain hygiene.

## 💡 Changes

- 0.38 release blog post now calls out that, once the action is pinned, Dependabot/Renovate bumps it on a schedule so bashunit updates arrive as routine PRs.
- Sharpened the installation docs' "Keep the SHA pin fresh automatically" section to make the consumer benefit explicit (review PR, let CI run, merge — no manual re-pinning).
- Blog post links to that docs section using the site-relative anchor; verified the docs build and anchor resolve.