### PR TITLE
fix(runner): bundle src/watch.sh into build so watch subcommand works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `watch` subcommand failed with `bashunit::watch::run: command not found` in the released binary because `src/watch.sh` was missing from the build; it is now bundled (#735)
+
 ### Changed
 - Faster test execution by removing subprocess forks from hot paths (no behaviour change)
 

--- a/build.sh
+++ b/build.sh
@@ -107,6 +107,7 @@ function build::dependencies() {
     "src/helpers.sh"
     "src/test_title.sh"
     "src/upgrade.sh"
+    "src/watch.sh"
     "src/assertions.sh"
     "src/reports.sh"
     "src/runner.sh"

--- a/tests/unit/build_test.sh
+++ b/tests/unit/build_test.sh
@@ -6,32 +6,31 @@ function set_up_before_script() {
   ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 }
 
-# Every src file the dev entrypoint sources (except dev-only helpers) must also be
-# listed in build::dependencies, otherwise its functions are missing from the
-# distributable single-file binary (regressions: bench #0.31.0, watch #735).
-function test_build_dependencies_cover_every_sourced_src_file() {
-  local entry_sources build_deps missing=""
-  entry_sources=$(grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/bashunit" | grep -v '^src/dev/')
-  build_deps=$(grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/build.sh")
+function src_files_sourced_by_entrypoint() {
+  # Dev-only helpers under src/dev/ are intentionally excluded from the build.
+  grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/bashunit" | grep -v '^src/dev/' | sort -u
+}
 
-  local file
-  for file in $entry_sources; do
-    if ! echo "$build_deps" | grep -qx "$file"; then
-      missing="$missing $file"
-    fi
-  done
+function src_files_in_build() {
+  grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/build.sh" | sort -u
+}
+
+# Every src file the dev entrypoint sources (except dev-only helpers) must also be
+# bundled by build.sh, otherwise its functions are missing from the distributable
+# single-file binary (regressions: bench #0.31.0, watch #735).
+function test_build_bundles_every_src_file_sourced_by_entrypoint() {
+  local missing
+  missing=$(comm -23 <(src_files_sourced_by_entrypoint) <(src_files_in_build))
 
   assert_empty "$missing"
 }
 
 function test_built_binary_defines_watch_run() {
-  local out_dir
-  out_dir="$(mktemp -d)"
+  local build_dir
+  build_dir=$(bashunit::temp_dir)
 
-  bash "$ROOT_DIR/build.sh" "$out_dir" >/dev/null 2>&1
+  (cd "$ROOT_DIR" && bash build.sh "$build_dir") >/dev/null 2>&1
 
-  assert_file_exists "$out_dir/bashunit"
-  assert_equals "1" "$(grep -c 'function bashunit::watch::run()' "$out_dir/bashunit")"
-
-  rm -rf "$out_dir"
+  assert_file_exists "$build_dir/bashunit"
+  assert_equals "1" "$(grep -c 'function bashunit::watch::run()' "$build_dir/bashunit")"
 }

--- a/tests/unit/build_test.sh
+++ b/tests/unit/build_test.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+ROOT_DIR=""
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+}
+
+# Every src file the dev entrypoint sources (except dev-only helpers) must also be
+# listed in build::dependencies, otherwise its functions are missing from the
+# distributable single-file binary (regressions: bench #0.31.0, watch #735).
+function test_build_dependencies_cover_every_sourced_src_file() {
+  local entry_sources build_deps missing=""
+  entry_sources=$(grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/bashunit" | grep -v '^src/dev/')
+  build_deps=$(grep -oE 'src/[a-zA-Z0-9_/]+\.sh' "$ROOT_DIR/build.sh")
+
+  local file
+  for file in $entry_sources; do
+    if ! echo "$build_deps" | grep -qx "$file"; then
+      missing="$missing $file"
+    fi
+  done
+
+  assert_empty "$missing"
+}
+
+function test_built_binary_defines_watch_run() {
+  local out_dir
+  out_dir="$(mktemp -d)"
+
+  bash "$ROOT_DIR/build.sh" "$out_dir" >/dev/null 2>&1
+
+  assert_file_exists "$out_dir/bashunit"
+  assert_equals "1" "$(grep -c 'function bashunit::watch::run()' "$out_dir/bashunit")"
+
+  rm -rf "$out_dir"
+}


### PR DESCRIPTION
## 🤔 Background

Related #735

The distributable single-file `bashunit` referenced `bashunit::watch::run` but never defined it, so `bashunit watch` failed with `command not found` in every release since 0.34.0. Same class as the 0.31.0 `bench` bug: `src/watch.sh` was sourced by the dev entrypoint but omitted from the build dependency list.

## 💡 Changes

- Add `src/watch.sh` to `build::dependencies` so the watch functions are bundled into the built binary.
- Add a guard test asserting every src file sourced by the dev entrypoint is present in the build, preventing this whole class of regression.
- Add a smoke test confirming the built binary defines `bashunit::watch::run`.