### PR TITLE
chore(skills): allow the pr skill to be model-invoked

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -3,7 +3,6 @@ name: pr
 description: Push branch and create a GitHub PR with concise, issue-linked description
 user-invocable: true
 argument-hint: "[#issue]"
-disable-model-invocation: true
 allowed-tools: Bash, Read, Grep, Glob
 ---
 


### PR DESCRIPTION
## 🤔 Background

The `pr` skill was marked `disable-model-invocation`, so Claude could only run it when a user explicitly typed `/pr`. Enabling model invocation lets the PR workflow run directly as the final step after implementing an issue.

## 💡 Changes

- Remove `disable-model-invocation: true` from the `pr` skill frontmatter so it can be invoked programmatically.
- Tooling/config only — no changes to `src/`, tests, or user-facing behavior (no CHANGELOG entry needed).