### PR TITLE
perf(state): skip base64 forks for empty subshell-context fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Faster test execution: each test file's data-provider annotations are scanned once and cached, replacing a per-test `grep`+`sed` probe with a pure-bash lookup (no behaviour change) (#763)
+- Faster test execution: skip the base64 encode fork for a test's empty title, hook message and output (the common case), and short-circuit decoding of empty fields (no behaviour change) (#762)
 
 ## [0.41.0](https://github.com/TypedDevs/bashunit/compare/0.40.0...0.41.0) - 2026-07-11
 

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -149,8 +149,8 @@ function bashunit::helper::encode_base64() {
 function bashunit::helper::decode_base64() {
   local value="$1"
 
-  # Handle empty string marker
-  if [ "$value" = "_BASHUNIT_EMPTY_" ]; then
+  # Empty input decodes to empty; short-circuit to skip the base64 fork (#762).
+  if [ -z "$value" ] || [ "$value" = "_BASHUNIT_EMPTY_" ]; then
     printf ''
     return
   fi

--- a/src/state.sh
+++ b/src/state.sh
@@ -228,23 +228,36 @@ function bashunit::state::initialize_assertions_count() {
   _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
 }
 
+# base64-encodes a field, writing the result into _BASHUNIT_STATE_ENCODED_OUT.
+# Empty values (the common case for title/hook message, and output on a passing
+# test) encode to an empty field with no base64 fork (#762). base64 of "" is ""
+# anyway, so this stays wire-compatible.
+_BASHUNIT_STATE_ENCODED_OUT=""
+function bashunit::state::encode_field() {
+  local value=$1
+  if [ -z "$value" ]; then
+    _BASHUNIT_STATE_ENCODED_OUT=""
+    return
+  fi
+  if [ "$_BASHUNIT_BASE64_WRAP_FLAG" = true ]; then
+    # Alpine requires the -w 0 option to avoid wrapping
+    _BASHUNIT_STATE_ENCODED_OUT=$(echo -n "$value" | base64 -w 0)
+  else
+    _BASHUNIT_STATE_ENCODED_OUT=$(echo -n "$value" | base64)
+  fi
+}
+
 function bashunit::state::export_subshell_context() {
   local encoded_test_output
   local encoded_test_title
-
   local encoded_test_hook_message
 
-  if [ "$_BASHUNIT_BASE64_WRAP_FLAG" = true ]; then
-    # Alpine requires the -w 0 option to avoid wrapping
-    encoded_test_output=$(echo -n "$_BASHUNIT_TEST_OUTPUT" | base64 -w 0)
-    encoded_test_title=$(echo -n "$_BASHUNIT_TEST_TITLE" | base64 -w 0)
-    encoded_test_hook_message=$(echo -n "$_BASHUNIT_TEST_HOOK_MESSAGE" | base64 -w 0)
-  else
-    # macOS and others: default base64 without wrapping
-    encoded_test_output=$(echo -n "$_BASHUNIT_TEST_OUTPUT" | base64)
-    encoded_test_title=$(echo -n "$_BASHUNIT_TEST_TITLE" | base64)
-    encoded_test_hook_message=$(echo -n "$_BASHUNIT_TEST_HOOK_MESSAGE" | base64)
-  fi
+  bashunit::state::encode_field "$_BASHUNIT_TEST_OUTPUT"
+  encoded_test_output=$_BASHUNIT_STATE_ENCODED_OUT
+  bashunit::state::encode_field "$_BASHUNIT_TEST_TITLE"
+  encoded_test_title=$_BASHUNIT_STATE_ENCODED_OUT
+  bashunit::state::encode_field "$_BASHUNIT_TEST_HOOK_MESSAGE"
+  encoded_test_hook_message=$_BASHUNIT_STATE_ENCODED_OUT
 
   cat <<EOF
 ##ASSERTIONS_FAILED=$_BASHUNIT_ASSERTIONS_FAILED\

--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -292,6 +292,34 @@ function test_export_assertions_count() {
     "$export_assertions_count"
 }
 
+function test_encode_field_returns_empty_for_empty_value() {
+  bashunit::state::encode_field ""
+  assert_same "" "$_BASHUNIT_STATE_ENCODED_OUT"
+}
+
+function test_encode_field_round_trips_a_plain_value() {
+  bashunit::state::encode_field "hello world"
+  assert_same "hello world" "$(bashunit::helper::decode_base64 "$_BASHUNIT_STATE_ENCODED_OUT")"
+}
+
+function test_encode_field_round_trips_a_multiline_value() {
+  local value
+  value="$(printf 'line one\nline two')"
+  bashunit::state::encode_field "$value"
+  assert_same "$value" "$(bashunit::helper::decode_base64 "$_BASHUNIT_STATE_ENCODED_OUT")"
+}
+
+function test_encode_field_round_trips_a_value_with_ansi_codes() {
+  local value
+  value="$(printf '\033[31mred\033[0m')"
+  bashunit::state::encode_field "$value"
+  assert_same "$value" "$(bashunit::helper::decode_base64 "$_BASHUNIT_STATE_ENCODED_OUT")"
+}
+
+function test_decode_base64_returns_empty_for_empty_value() {
+  assert_same "" "$(bashunit::helper::decode_base64 "")"
+}
+
 function test_calculate_total_assertions() {
   local input="##ASSERTIONS_FAILED=1\
   ##ASSERTIONS_PASSED=2\


### PR DESCRIPTION
## 🤔 Background

Related #762

Every test base64-encoded its title, hook message and output when exporting subshell context, forking `base64` three times even though a passing test leaves all three empty.

## 💡 Changes

- Extract `encode_field`, which returns an empty field for empty input with no fork; `base64` of `""` is `""`, so the wire format is byte-identical. Also short-circuit `decode_base64` on empty input.
- Fork census on a 100-test file: `base64` 101 -> 1 (three encodes + the output decode removed per test). Platform-independent win.
- Behaviour preserved: existing `export_subshell_context` characterization tests (empty and non-empty fields) plus new round-trip tests (empty, plain, multiline, ANSI) pass; full suite green sequential and `--parallel`.