### PR TITLE
fix(runner): stop --test-timeout from flagging fast tests as timed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `--test-timeout` no longer intermittently reports a fast test as timed out. The watchdog's process-group kill could miss when `set -m` had not made the backgrounded subshell a group leader, leaving it to sleep the full timeout and fire against an already-finished test; it is now signalled by pid directly and skips marking a test that already completed
+
 ### Added
 - `--jobs auto` (and `-j auto`) caps parallel concurrency at the detected CPU core count, portable across Linux/macOS/BSD (`nproc`, then `sysctl`, then `getconf`, falling back to 4). The default stays unlimited (`--jobs 0`) (#766)
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -1020,6 +1020,10 @@ function bashunit::runner::run_with_timeout() {
   local test_pid=$!
   (
     sleep "$secs"
+    # Only a still-running test can have timed out. Without this guard a watchdog
+    # that outlived a missed teardown (see below) would mark an already-finished
+    # fast test as timed out.
+    kill -0 "$test_pid" 2>/dev/null || exit 0
     : >"$marker_file"
     kill -TERM -"$test_pid" 2>/dev/null
     sleep 0.3
@@ -1029,8 +1033,12 @@ function bashunit::runner::run_with_timeout() {
   set +m
 
   wait "$test_pid" 2>/dev/null
-  # Tear down the watchdog group (its `sleep` child included) so it cannot fire
-  # late or block the caller.
+  # Stop the watchdog by its pid AND its group. `set -m` does not reliably make a
+  # backgrounded subshell a group leader in a non-interactive shell, so the
+  # group-only kill intermittently misses, letting the watchdog sleep its full
+  # timeout and fire against a test that already passed. The direct-pid signal is
+  # always deliverable; the group signal also reaps the `sleep` child.
+  kill -TERM "$watchdog_pid" 2>/dev/null
   kill -TERM -"$watchdog_pid" 2>/dev/null
   wait "$watchdog_pid" 2>/dev/null
 


### PR DESCRIPTION
## Problem

`tests/acceptance/bashunit_timeout_test.sh::test_bashunit_does_not_time_out_a_fast_test` fails intermittently (~1 in 8 full-file runs):

```
✗ Failed: Bashunit does not time out a fast test
    Expected '1' to be exactly '0'
```

The inner `./bashunit --test-timeout 5 <fast-file>` exits `1` because a trivially fast test (`assert_empty ""`) is wrongly reported as `Test timed out after 5s`.

## Root cause

In `src/runner.sh` `run_with_timeout`, each test runs alongside a backgrounded watchdog subshell that is torn down after the test finishes via a process-group kill:

```sh
kill -TERM -"$watchdog_pid"
```

That relies on `set -m` having made the backgrounded subshell its own group leader, which is **not reliable in a non-interactive shell**. When the group kill misses, the watchdog is not stopped, sleeps its full timeout, and writes the timeout marker against a test that already passed, so `_BASHUNIT_RUNNER_TIMED_OUT` becomes `true` for a fast test.

Confirmed by instrumenting the watchdog: an instant `assert_greater_and_less_than` with `secs=5` was observed completing its full `sleep 5` and marking a timeout.

## Fix

Two complementary changes in `run_with_timeout`:

1. **Reliable teardown** — signal the watchdog by its **pid directly** (always deliverable to our own child) in addition to its group.
2. **Correctness guard** — before writing the marker the watchdog does `kill -0 "$test_pid" || exit 0`, so a watchdog that outlives teardown cannot mark an already-finished test. This makes the false positive impossible by construction.

Real timeouts still fire (the hanging-fixture cases still report `Test timed out after 1s` and fail).

## Verification

- 80/80 green runs of `bashunit_timeout_test.sh` (was ~1-in-8 flaky before).
- Full suite green: `./bashunit --parallel tests/` -> 1233 passed, 0 failed.
- `make sa`, `make lint` pass; `shfmt` clean.
- Bash 3.0+ compatible.