### PR TITLE
feat(ci): publish coverage badge from dogfooded --coverage run

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,80 @@
+name: Coverage
+
+# Dogfoods bashunit's own --coverage engine. On every push to main it measures
+# how much of src/ the unit suite exercises, uploads the LCOV report as a build
+# artifact, and publishes a shields.io endpoint badge to the orphan `badges`
+# branch (which the README badge reads). It runs only on main / manual dispatch,
+# so a failure here never gates pull-request checks.
+#
+# The coverage engine's own meta-tests (tests/unit/coverage_*_test.sh) are
+# excluded from the measured run: executing them under --coverage double-
+# instruments src/coverage.sh and corrupts their assertions.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: "Measure and publish coverage"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup Config
+        run: cp .env.example .env
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run coverage on the unit suite
+        run: |
+          files=$(ls tests/unit/*_test.sh | grep -v '/coverage_')
+          # shellcheck disable=SC2086
+          ./bashunit --coverage --coverage-report coverage/lcov.info --coverage-paths src $files
+
+      - name: Upload LCOV report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: coverage/lcov.info
+          if-no-files-found: error
+
+      - name: Publish coverage badge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pct=$(bash tools/coverage_percent.sh coverage/lcov.info)
+          color=red
+          if   [ "$pct" -ge 90 ]; then color=brightgreen
+          elif [ "$pct" -ge 75 ]; then color=green
+          elif [ "$pct" -ge 60 ]; then color=yellowgreen
+          elif [ "$pct" -ge 40 ]; then color=yellow
+          elif [ "$pct" -ge 20 ]; then color=orange
+          fi
+          echo "Coverage: ${pct}% (${color})"
+          mkdir -p badge
+          printf '{"schemaVersion":1,"label":"coverage","message":"%s%%","color":"%s"}\n' \
+            "$pct" "$color" > badge/coverage.json
+          cat badge/coverage.json
+          cd badge
+          git init -q
+          git checkout -q -b badges
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add coverage.json
+          git commit -q -m "chore(coverage): update badge to ${pct}%"
+          git push -f "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--test-timeout` no longer intermittently reports a fast test as timed out. The watchdog's process-group kill could miss when `set -m` had not made the backgrounded subshell a group leader, leaving it to sleep the full timeout and fire against an already-finished test; it is now signalled by pid directly and skips marking a test that already completed
 
 ### Added
+- Coverage badge: a `coverage.yml` CI workflow dogfoods `--coverage` on every push to `main`, uploads `coverage/lcov.info` as an artifact, and publishes a shields.io endpoint badge (now shown in the README) to an orphan `badges` branch — no third-party coverage service. The engine's own meta-tests are excluded from the measured run to avoid double-instrumenting `src/coverage.sh` (#754)
 - `--jobs auto` (and `-j auto`) caps parallel concurrency at the detected CPU core count, portable across Linux/macOS/BSD (`nproc`, then `sysctl`, then `getconf`, falling back to 4). The default stays unlimited (`--jobs 0`) (#766)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     <a href="https://github.com/TypedDevs/bashunit/actions/workflows/linter.yml">
         <img src="https://github.com/TypedDevs/bashunit/actions/workflows/linter.yml/badge.svg" alt="Editorconfig checker">
     </a>
+    <a href="https://github.com/TypedDevs/bashunit/actions/workflows/coverage.yml">
+        <img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/TypedDevs/bashunit/badges/coverage.json" alt="Coverage">
+    </a>
     <a href="https://github.com/TypedDevs/bashunit/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT Software License">
     </a>

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -487,6 +487,20 @@ coverage:
 
 See `adrs/adr-007-branch-coverage-mvp.md` for the design rationale and the rejected alternatives.
 
+## This repo's own coverage
+
+bashunit dogfoods its own coverage engine. On every push to `main`, the
+[`coverage.yml`](https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/coverage.yml)
+workflow runs `--coverage` over the unit suite, uploads the `coverage/lcov.info`
+report as a build artifact, and publishes the total percentage as a
+[shields.io endpoint](https://shields.io/badges/endpoint-badge) badge (shown in the
+README). It is a real-world example of wiring the coverage engine into CI without a
+third-party coverage service.
+
+Note the workflow excludes the engine's own meta-tests (`tests/unit/coverage_*_test.sh`)
+from the measured run: executing them under `--coverage` double-instruments
+`src/coverage.sh` and corrupts their assertions.
+
 ## Related
 
 - [Command-Line](/command-line) — full reference for CLI flags and options

--- a/tests/unit/coverage_percent_test.sh
+++ b/tests/unit/coverage_percent_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Tests for tools/coverage_percent.sh: extract a single rounded coverage
+# percentage from an LCOV report by summing the per-section LH/LF records.
+
+COVERAGE_PERCENT_SCRIPT="${BASHUNIT_ROOT_DIR:-.}/tools/coverage_percent.sh"
+
+function test_coverage_percent_sums_lh_over_lf() {
+  local lcov
+  lcov=$(mktemp)
+  cat >"$lcov" <<'EOF'
+TN:
+SF:/repo/src/a.sh
+DA:1,1
+LF:100
+LH:25
+end_of_record
+EOF
+
+  assert_equals "25" "$(bash "$COVERAGE_PERCENT_SCRIPT" "$lcov")"
+  rm -f "$lcov"
+}
+
+function test_coverage_percent_aggregates_multiple_sections() {
+  local lcov
+  lcov=$(mktemp)
+  cat >"$lcov" <<'EOF'
+SF:/repo/src/a.sh
+LF:100
+LH:40
+end_of_record
+SF:/repo/src/b.sh
+LF:100
+LH:60
+end_of_record
+EOF
+
+  # (40 + 60) / (100 + 100) = 50%
+  assert_equals "50" "$(bash "$COVERAGE_PERCENT_SCRIPT" "$lcov")"
+  rm -f "$lcov"
+}
+
+function test_coverage_percent_rounds_to_nearest_integer() {
+  local lcov
+  lcov=$(mktemp)
+  cat >"$lcov" <<'EOF'
+SF:/repo/src/a.sh
+LF:3
+LH:2
+end_of_record
+EOF
+
+  # 2/3 = 66.6% -> 67
+  assert_equals "67" "$(bash "$COVERAGE_PERCENT_SCRIPT" "$lcov")"
+  rm -f "$lcov"
+}
+
+function test_coverage_percent_is_zero_when_no_lines_found() {
+  local lcov
+  lcov=$(mktemp)
+  cat >"$lcov" <<'EOF'
+TN:
+end_of_record
+EOF
+
+  assert_equals "0" "$(bash "$COVERAGE_PERCENT_SCRIPT" "$lcov")"
+  rm -f "$lcov"
+}
+
+function test_coverage_percent_is_zero_for_missing_file() {
+  assert_equals "0" "$(bash "$COVERAGE_PERCENT_SCRIPT" "/no/such/lcov.info")"
+}

--- a/tools/coverage_percent.sh
+++ b/tools/coverage_percent.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Print a single rounded coverage percentage (integer, no % sign) read from an
+# LCOV report. It sums the per-section LH (lines hit) and LF (lines found)
+# records and rounds LH/LF to the nearest integer. Prints 0 when the report is
+# missing, empty, or records no lines. Used by the coverage CI workflow to feed
+# a shields.io endpoint badge.
+#
+# Usage: coverage_percent.sh <path-to-lcov.info>
+
+set -eu
+
+lcov_file="${1:-}"
+
+if [ -z "$lcov_file" ] || [ ! -f "$lcov_file" ]; then
+  echo 0
+  exit 0
+fi
+
+awk -F: '
+  /^LH:/ { hit += $2 }
+  /^LF:/ { found += $2 }
+  END {
+    if (found <= 0) { print 0; exit }
+    printf "%d\n", (hit * 100 + found / 2) / found
+  }
+' "$lcov_file"


### PR DESCRIPTION
## 🤔 Background

Related #754

bashunit ships its own coverage engine but CI never ran it and the README had no coverage badge. Dogfooding it in CI both advertises the feature and guards it against regressions, without adding a third-party coverage service.

## 💡 Changes

- New `coverage.yml` workflow: on every push to `main` it runs `--coverage` over the unit suite, uploads `coverage/lcov.info` as an artifact, and publishes a shields.io endpoint badge to an orphan `badges` branch (referenced by a new README badge). Runs only on main / manual dispatch, so it never gates PR checks.
- The engine's own meta-tests (`tests/unit/coverage_*_test.sh`) are excluded from the measured run — running them under `--coverage` double-instruments `src/coverage.sh` and corrupts their assertions. Local measured coverage: ~26% of `src/` in ~2m.
- Add a unit-tested `tools/coverage_percent.sh` extractor (sums LCOV `LH`/`LF`) and a "this repo's own coverage" note in `docs/coverage.md`.