### PR TITLE
ci(coverage): make Coverage nightly + optional, fix job timeout

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,10 @@ jobs:
   coverage:
     name: "Measure and publish coverage"
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # Coverage instruments every executed line across the whole unit suite, so
+    # the run is inherently heavy. This is a nightly, non-blocking job, so a
+    # generous timeout is free insurance against slow runners.
+    timeout-minutes: 40
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,19 +1,22 @@
 name: Coverage
 
-# Dogfoods bashunit's own --coverage engine. On every push to main it measures
-# how much of src/ the unit suite exercises, uploads the LCOV report as a build
-# artifact, and publishes a shields.io endpoint badge to the orphan `badges`
-# branch (which the README badge reads). It runs only on main / manual dispatch,
-# so a failure here never gates pull-request checks.
+# Dogfoods bashunit's own --coverage engine. Nightly (and on manual dispatch) it
+# measures how much of src/ the unit suite exercises, uploads the LCOV report as
+# a build artifact, and publishes a shields.io endpoint badge to the orphan
+# `badges` branch (which the README badge reads).
+#
+# This is an OPTIONAL, non-blocking job: it never runs on push or pull_request,
+# so it is not a status check on any commit and cannot gate merges. Coverage is
+# CPU-heavy, so a scheduled cadence keeps it off the critical path.
 #
 # The coverage engine's own meta-tests (tests/unit/coverage_*_test.sh) are
 # excluded from the measured run: executing them under --coverage double-
 # instruments src/coverage.sh and corrupts their assertions.
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # Nightly at 04:17 UTC (odd minute to avoid the top-of-hour scheduler rush).
+    - cron: "17 4 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
   coverage:
     name: "Measure and publish coverage"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -41,10 +41,14 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y jq
 
       - name: Run coverage on the unit suite
+        # Coverage instrumentation is CPU-heavy; --parallel --jobs auto keeps the
+        # run well under the job timeout on the multi-core runner. Parallel LCOV
+        # aggregation is deterministic (same total as a sequential run).
         run: |
           files=$(ls tests/unit/*_test.sh | grep -v '/coverage_')
           # shellcheck disable=SC2086
-          ./bashunit --coverage --coverage-report coverage/lcov.info --coverage-paths src $files
+          ./bashunit --coverage --parallel --jobs auto \
+            --coverage-report coverage/lcov.info --coverage-paths src $files
 
       - name: Upload LCOV report
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `--test-timeout` no longer intermittently reports a fast test as timed out. The watchdog's process-group kill could miss when `set -m` had not made the backgrounded subshell a group leader, leaving it to sleep the full timeout and fire against an already-finished test; it is now signalled by pid directly and skips marking a test that already completed
 
 ### Added
-- Coverage badge: a `coverage.yml` CI workflow dogfoods `--coverage` on every push to `main`, uploads `coverage/lcov.info` as an artifact, and publishes a shields.io endpoint badge (now shown in the README) to an orphan `badges` branch — no third-party coverage service. The engine's own meta-tests are excluded from the measured run to avoid double-instrumenting `src/coverage.sh` (#754)
+- Coverage badge: an optional, nightly `coverage.yml` CI workflow dogfoods `--coverage` over the unit suite, uploads `coverage/lcov.info` as an artifact, and publishes a shields.io endpoint badge (now shown in the README) to an orphan `badges` branch — no third-party coverage service. It runs on a schedule / manual dispatch only (never on push or pull requests, so it never gates merges). The engine's own meta-tests are excluded from the measured run to avoid double-instrumenting `src/coverage.sh` (#754)
 - `--jobs auto` (and `-j auto`) caps parallel concurrency at the detected CPU core count, portable across Linux/macOS/BSD (`nproc`, then `sysctl`, then `getconf`, falling back to 4). The default stays unlimited (`--jobs 0`) (#766)
 
 ### Changed

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -489,13 +489,14 @@ See `adrs/adr-007-branch-coverage-mvp.md` for the design rationale and the rejec
 
 ## This repo's own coverage
 
-bashunit dogfoods its own coverage engine. On every push to `main`, the
+bashunit dogfoods its own coverage engine. The
 [`coverage.yml`](https://github.com/TypedDevs/bashunit/blob/main/.github/workflows/coverage.yml)
-workflow runs `--coverage` over the unit suite, uploads the `coverage/lcov.info`
-report as a build artifact, and publishes the total percentage as a
-[shields.io endpoint](https://shields.io/badges/endpoint-badge) badge (shown in the
-README). It is a real-world example of wiring the coverage engine into CI without a
-third-party coverage service.
+workflow runs nightly (and on manual dispatch), measuring `--coverage` over the unit
+suite, uploading the `coverage/lcov.info` report as a build artifact, and publishing
+the total percentage as a [shields.io endpoint](https://shields.io/badges/endpoint-badge)
+badge (shown in the README). It is an optional, non-blocking job — it never runs on push
+or pull requests, so it is not a status check on any commit. A real-world example of
+wiring the coverage engine into CI without a third-party coverage service.
 
 Note the workflow excludes the engine's own meta-tests (`tests/unit/coverage_*_test.sh`)
 from the measured run: executing them under `--coverage` double-instruments


### PR DESCRIPTION
## 🤔 Background

Related #754

The Coverage workflow from #784 triggered on push to `main`, so it showed up as a status check on every main commit — and the sequential run exceeded its 15m timeout and got cancelled, making `main` look like it had a failing CI job. Coverage is meant to be an optional, informational badge, not a per-commit gate.

## 💡 Changes

- Trigger is now a nightly `schedule` + `workflow_dispatch` only — never on push or pull_request, so Coverage is not a status check on any commit and cannot gate merges.
- Run coverage with `--parallel --jobs auto` and a 40m timeout so the nightly finishes comfortably on slow runners (LCOV aggregation is deterministic — same total as sequential).
- Update README/docs/CHANGELOG wording to describe the job as optional/nightly.