### PR TITLE
docs(readme): remove Ask DeepWiki badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@
     <a href="https://github.com/TypedDevs/bashunit/blob/main/LICENSE">
         <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT Software License">
     </a>
-    <a href="https://deepwiki.com/TypedDevs/bashunit">
-        <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
-    </a>
 </p>
 <br>
 <p align="center">


### PR DESCRIPTION
## 🤔 Background

Removes the third-party "Ask DeepWiki" badge from the README header.

## 💡 Changes

- Drop the DeepWiki badge link and image from the README badge row.