### PR TITLE
test(assert): drop jq from flaky custom-assertion test

### DIFF
--- a/tests/unit/custom_assertions_test.sh
+++ b/tests/unit/custom_assertions_test.sh
@@ -1,15 +1,19 @@
 #!/usr/bin/env bash
 
-# Custom assertion that uses fail internally
+# Custom assertion that uses fail internally.
+# jq-free on purpose: this scaffolding only needs to route a failure through
+# bashunit::fail deterministically; depending on the external jq binary made the
+# test flaky on the macOS CI runner while the pure-bash sibling tests never were.
 function _assert_valid_json() {
   local json="$1"
 
-  if ! echo "$json" | jq . >/dev/null 2>&1; then
+  case "$json" in
+  '{'*'}' | '['*']') bashunit::state::add_assertions_passed ;;
+  *)
     bashunit::fail "Invalid json: $json"
     return
-  fi
-
-  bashunit::state::add_assertions_passed
+    ;;
+  esac
 }
 
 # Custom assertion that uses bashunit::assertion_failed


### PR DESCRIPTION
## 🤔 Background

The macOS CI job has been intermittently red on `main` (e.g. a docs-only commit failed while the preceding code commit passed) on a single test: "Custom assertion with fail shows correct test name". It is the only one of its three sibling tests that shells out to `jq`, and the only one that flakes; the two pure-bash siblings never do. Not reproducible locally (0 failures across 65+ isolated and full-suite runs).

## 💡 Changes

- Make the test's `_assert_valid_json` scaffolding jq-free — route the failure through `bashunit::fail` with a pure-bash JSON check, removing the external-binary dependency that distinguished the flaky test from its stable siblings
- No production code change; the other two custom-assertion tests are untouched