### PR TITLE
test(runner): fix flaky redirect_error test under --parallel

### DIFF
--- a/tests/unit/redirect_error_test.sh
+++ b/tests/unit/redirect_error_test.sh
@@ -1,21 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-_ERROR_LOG=temp_error.log
-
-function tear_down() {
-  rm -f "$_ERROR_LOG"
-}
-
 function test_redirect_error_with_log() {
-  exec 2>&3 2>$_ERROR_LOG
+  # A per-test temp file, not a fixed name in CWD: under --parallel a shared
+  # filename races concurrent workers and intermittently reads empty/stale data.
+  local error_log
+  error_log=$(bashunit::temp_file redirect_error)
+  exec 2>&3 2>"$error_log"
 
   local exit_code=0
   _="$(render_into_error_fd_and_exit "arg1" "arg2")" || exit_code=$?
   assert_same 1 "$exit_code"
 
   local error_output
-  error_output=$(<$_ERROR_LOG)
+  error_output=$(<"$error_log")
   assert_same "arg1 arg2" "$error_output"
 }
 


### PR DESCRIPTION
## 🤔 Background

The "Redirect error with log" test intermittently failed in the Ubuntu parallel CI job. It wrote to a fixed `temp_error.log` in the working directory, shared across tests and parallel workers, so a concurrent write/`rm` could race the read and yield empty/stale output. Not reproducible in isolation (0 failures across many parallel runs of the file alone).

## 💡 Changes

- Use a per-test `bashunit::temp_file` (unique, auto-cleaned) instead of a fixed shared filename, removing the parallel race
- Drop the now-unneeded `tear_down` cleanup of the shared file