### PR TITLE
perf(runner): single uname fork at cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `--jobs auto` / `-j auto` caps parallel concurrency at the CPU core count (portable across Linux/macOS/BSD); the default stays unlimited (#766)
 
 ### Changed
+- Faster cold start: `check_os` detects the OS with a single `uname` fork at load instead of two (matters across the acceptance suite's nested `bashunit` runs). No behaviour change (#798)
 - Faster test execution: removed the remaining round-2 fork leftovers — `wait_for_job_slot` counts running background jobs without forking `wc` on every poll (145 -> 0 `wc` forks across a small parallel run), and `check_duplicate_functions` folds its per-file grep+awk+sort+uniq scan into a single awk pass. No behaviour change (#761)
 - `assert_equals`/`assert_same` failures with multiline values now render a git word-diff below the header (requires git, opt out with `BASHUNIT_NO_DIFF=true`, respects `--no-color`); machine reports keep the raw values (#777)
 - Faster `assert_match_snapshot`: fork-free success path, byte-compatible snapshots; 500 snapshot assertions ~7.5s -> ~3.0s on bash 3.2 (#775)

--- a/src/check_os.sh
+++ b/src/check_os.sh
@@ -40,8 +40,6 @@ function bashunit::check_os::is_nixos() {
   grep -q '^ID=nixos' /etc/os-release 2>/dev/null
 }
 
-_BASHUNIT_UNAME="$(uname)"
-
 function bashunit::check_os::is_linux() {
   [ "$_BASHUNIT_UNAME" = "Linux" ]
 }

--- a/tests/unit/check_os_test.sh
+++ b/tests/unit/check_os_test.sh
@@ -78,6 +78,14 @@ function test_not_alpine_is_not_busybox() {
   assert_general_error "$(bashunit::check_os::is_busybox)"
 }
 
+function test_module_load_detects_os_with_a_single_uname_call() {
+  bashunit::spy uname
+
+  source "$BASHUNIT_ROOT_DIR/src/check_os.sh"
+
+  assert_have_been_called_times 1 uname
+}
+
 function test_nproc_uses_nproc_when_available() {
   bashunit::mock nproc echo "8"
 


### PR DESCRIPTION
## 🤔 Background

Related #798

Profiling the acceptance suite's nested `bashunit` cold starts (the frontier from #761) showed `check_os.sh` forking `uname` twice on every load.

## 💡 Changes

- Drop the redundant module-scope `uname` call; `check_os::init` (run at load) already sets `_BASHUNIT_UNAME` before any reader, cutting one fork per cold start.
- Add a regression test asserting module load detects the OS with a single `uname` call.