### PR TITLE
perf(runner): detect base64 -w with a case match, drop a grep fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `--jobs auto` / `-j auto` caps parallel concurrency at the CPU core count (portable across Linux/macOS/BSD); the default stays unlimited (#766)
 
 ### Changed
+- Faster cold start: the base64 `-w` capability is detected with a shell `case` on `base64 --help` instead of piping into a `grep` fork (1 -> 0 `grep` forks per cold start). Same detection, no behaviour change
 - Faster cold start: selecting the `perl` clock reads the time once instead of an empty `Time::HiRes` probe followed by a separate first read (2 -> 1 `perl` fork per cold start on bash 3.2 / macOS). No behaviour change
 - Faster cold start: the deferred-output scratch files (failures/skipped/incomplete/risky/profile/rerun) now share one run-unique directory instead of forking `mktemp` once each (6 -> 0 `mktemp` forks per cold start; ~62ms -> ~50ms per nested run on bash 3.2). No behaviour change (#798)
 - Faster cold start: `check_os` detects the OS with a single `uname` fork at load instead of two (matters across the acceptance suite's nested `bashunit` runs). No behaviour change (#798)

--- a/src/state.sh
+++ b/src/state.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
-# Cache base64 -w flag support (Alpine needs -w 0, macOS does not support -w)
-if [ "$(base64 --help 2>&1 | "$GREP" -c -- "-w" || true)" -gt 0 ]; then
-  _BASHUNIT_BASE64_WRAP_FLAG=true
-else
-  _BASHUNIT_BASE64_WRAP_FLAG=false
-fi
+# Cache base64 -w flag support (Alpine needs -w 0, macOS does not support -w).
+# Scrape `base64 --help` once and match with a shell `case` instead of piping
+# into a `grep` fork — same detection, one fewer fork per cold start.
+_bashunit_base64_help="$(base64 --help 2>&1 || true)"
+case "$_bashunit_base64_help" in
+*-w*) _BASHUNIT_BASE64_WRAP_FLAG=true ;;
+*) _BASHUNIT_BASE64_WRAP_FLAG=false ;;
+esac
+unset _bashunit_base64_help
 
 _BASHUNIT_TESTS_PASSED=0
 _BASHUNIT_TESTS_FAILED=0

--- a/tests/acceptance/bashunit_coldstart_forks_test.sh
+++ b/tests/acceptance/bashunit_coldstart_forks_test.sh
@@ -45,3 +45,23 @@ function test_coldstart_selects_clock_impl_without_a_probe_fork() {
 
   assert_less_or_equal_than 1 "$interp_forks"
 }
+
+# Regression guard for the base64 `-w` capability probe. It used to pipe
+# `base64 --help` into a `grep -c -- -w` fork at load; a shell `case` match on
+# the captured help text needs no fork. A cold start must not fork `grep` to
+# detect base64 wrapping (nothing else forks grep at cold start).
+function test_coldstart_does_not_fork_grep_to_detect_base64_wrap() {
+  if bashunit::check_os::is_windows; then
+    bashunit::skip "process tracing is unreliable under Git Bash" && return
+  fi
+
+  local trace
+  trace="$(PS4='+ ' bash -x ./bashunit --version 2>&1 >/dev/null)"
+
+  # Count real `grep` process executions (resolved absolute path with args).
+  # `command -v grep` is a builtin and never shows as an executed command line.
+  local grep_forks
+  grep_forks="$(printf '%s\n' "$trace" | grep -cE '^\++ +/[^ ]*grep ' || true)"
+
+  assert_equals 0 "$grep_forks"
+}


### PR DESCRIPTION
## 🤔 Background

Continuing the cold-start fork reduction from #798/#802. `state.sh` scraped `base64 --help` through a `grep` fork at load to cache whether base64 supports `-w`.

## 💡 Changes

- Match the captured `base64 --help` text with a shell `case` instead of piping into `grep` — identical detection, one fewer fork on every cold start (1 → 0 grep forks).
- Matters across the acceptance suite's ~258 nested runs.
- Regression test extended (fork census). No behaviour change.