### PR TITLE
perf(runner): list functions with compgen builtin, not declare -F | awk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `--jobs auto` / `-j auto` caps parallel concurrency at the CPU core count (portable across Linux/macOS/BSD); the default stays unlimited (#766)
 
 ### Changed
+- Faster test runs: listing all defined functions uses the `compgen -A function` builtin instead of forking `declare -F | awk` (three call sites; 5 -> 3 `awk` forks per test file). No behaviour change
 - Faster test runs: ordering a file's test functions by definition line is pure bash now instead of an `awk | sort | awk` pipeline that ran twice per file, and the duplicate-function check sorts its (usually empty) result inside awk instead of piping through `sort` (9 -> 5 forks per test file). No behaviour change
 - Faster failure rendering: the "Source:" assert-line context of a failing test reads the test-function body in a single pass instead of forking `sed` per line and `grep` per line to find the closing brace (a 20-line body dropped from ~46 to ~2 forks here). No behaviour change
 - Faster test runs: each test's subshell result payload is emitted with `printf` (a builtin) instead of a `cat <<EOF` heredoc, removing one `cat` fork per test. No behaviour change

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -548,7 +548,7 @@ function bashunit::helper::find_total_tests() {
       # shellcheck source=/dev/null
       source "$file"
       local all_fn_names
-      all_fn_names=$(declare -F | awk '{print $3}')
+      all_fn_names=$(compgen -A function)
       local filtered_functions
       filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$all_fn_names") || true
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -421,8 +421,8 @@ function bashunit::runner::load_test_files() {
       bashunit::runner::restore_workdir
       continue
     fi
-    # Update function cache after sourcing new test file
-    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(declare -F | awk '{print $3}')
+    # Update function cache after sourcing new test file (compgen is a builtin)
+    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
     # Check if any tests match the filter before rendering header or running hooks
     local filtered_functions
     filtered_functions=$(bashunit::helper::get_functions_to_run "test" "$filter" "$_BASHUNIT_CACHED_ALL_FUNCTIONS")
@@ -530,8 +530,8 @@ function bashunit::runner::load_bench_files() {
     export BASHUNIT_CURRENT_SCRIPT_ID="$_BASHUNIT_HELPER_ID_OUT"
     # shellcheck source=/dev/null
     source "$bench_file"
-    # Update function cache after sourcing new bench file
-    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(declare -F | awk '{print $3}')
+    # Update function cache after sourcing new bench file (compgen is a builtin)
+    _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
     # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook
     bashunit::runner::run_set_up_before_script "$bench_file"
     local setup_before_script_status=$?

--- a/tests/acceptance/bashunit_run_forks_test.sh
+++ b/tests/acceptance/bashunit_run_forks_test.sh
@@ -123,3 +123,37 @@ function test_running_a_test_file_does_not_fork_sort() {
 
   assert_equals 0 "$sort_forks"
 }
+
+# Regression guard: listing all defined functions must use the `compgen -A
+# function` builtin, not a `declare -F | awk` fork. The remaining awk budget of
+# a plain run is the per-file file scans (data-provider map, which runs in both
+# the counting subshell and the runner, plus the duplicate-name check).
+function test_running_a_test_file_stays_within_the_awk_fork_budget() {
+  if bashunit::check_os::is_windows; then
+    bashunit::skip "PATH shims are unreliable under Git Bash" && return
+  fi
+
+  local real_awk
+  real_awk="$(command -v awk)"
+  local dir
+  dir="$(bashunit::temp_dir)"
+  local count_file="$dir/count"
+  {
+    echo '#!/usr/bin/env bash'
+    echo "echo x >> \"$count_file\""
+    echo "exec \"$real_awk\" \"\$@\""
+  } >"$dir/awk"
+  chmod +x "$dir/awk"
+
+  local fixture="$dir/awk_budget_test.sh"
+  printf 'function test_ok() { assert_true true; }\n' >"$fixture"
+
+  PATH="$dir:$PATH" ./bashunit --no-parallel "$fixture" >/dev/null 2>&1
+
+  local awk_forks=0
+  if [ -f "$count_file" ]; then
+    awk_forks="$(grep -c . "$count_file" || true)"
+  fi
+
+  assert_less_or_equal_than 3 "$awk_forks"
+}


### PR DESCRIPTION
## 🤔 Background

Continuing the fork-reduction series (#801-#809). Three call sites captured the defined-function list by piping `declare -F` through an `awk` fork.

## 💡 Changes

- Use the `compgen -A function` builtin — identical name-per-line, alphabetical output — so the capture costs only its subshell (5 → 3 `awk` forks per test file).
- Shim-based awk fork-budget regression test added. No behaviour change.