### PR TITLE
test(state): cover print_tap_line's seven output branches

### DIFF
--- a/tests/unit/state_test.sh
+++ b/tests/unit/state_test.sh
@@ -331,3 +331,79 @@ function test_calculate_total_assertions() {
 
   assert_same 15 "$(bashunit::state::calculate_total_assertions "$input")"
 }
+
+# --- print_tap_line -----------------------------------------------------------
+# Each capture runs in $(...) so mutating _BASHUNIT_TOTAL_TESTS_COUNT never
+# leaks into the suite's own counters.
+
+function test_tap_line_successful_strips_colors_and_duration() {
+  local line
+  line="$(printf '\033[32m✓ Passed\033[0m: Adds numbers 12ms')"
+
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=7
+    bashunit::state::print_tap_line "successful" "$line"
+  )
+
+  assert_same "ok 7 - Adds numbers" "$out"
+}
+
+function test_tap_line_failure_renders_yaml_block_without_the_header() {
+  local line
+  line=$'\033[31m✗ Failed\033[0m: Broken thing\n    Expected \'a\'\n    but got \'b\''
+
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=3
+    bashunit::state::print_tap_line "failed" "$line"
+  )
+
+  local expected
+  expected=$'not ok 3 - Broken thing\n  ---\n  Expected \'a\'\n  but got \'b\'\n  ...'
+  assert_same "$expected" "$out"
+}
+
+function test_tap_line_skipped_with_reason() {
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=2
+    bashunit::state::print_tap_line "skipped" "↷ Skipped: Needs jq   jq not installed"
+  )
+
+  assert_same "ok 2 - Needs jq # SKIP jq not installed" "$out"
+}
+
+function test_tap_line_skipped_without_reason() {
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=2
+    bashunit::state::print_tap_line "skipped" "↷ Skipped: No reason"
+  )
+
+  assert_same "ok 2 - No reason # SKIP" "$out"
+}
+
+function test_tap_line_incomplete_and_snapshot_and_risky_directives() {
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=5
+    bashunit::state::print_tap_line "incomplete" "✒ Incomplete: Pending"
+    bashunit::state::print_tap_line "snapshot" "✎ Snapshot: Rendered"
+    bashunit::state::print_tap_line "risky" "△ Risky: No asserts"
+  )
+
+  local expected
+  expected=$'ok 5 - Pending # TODO incomplete\nok 5 - Rendered # snapshot\nok 5 - No asserts # RISKY no assertions'
+  assert_same "$expected" "$out"
+}
+
+function test_tap_line_unknown_type_is_not_ok() {
+  local out
+  out=$(
+    _BASHUNIT_TOTAL_TESTS_COUNT=9
+    bashunit::state::print_tap_line "mystery" "?: Something odd"
+  )
+
+  assert_same "not ok 9 - Something odd" "$out"
+}


### PR DESCRIPTION
## 🤔 Background

`bashunit::state::print_tap_line` — the TAP output conversion — had no direct tests; its format was only pinned indirectly by two acceptance snapshots.

## 💡 Changes

- Unit tests for all seven branches: successful (colors + duration stripped), failure (`---` YAML block, header excluded, details re-indented), skipped with/without reason, incomplete, snapshot, risky, and the unknown-type fallback.
- Counter mutations stay inside `$()` captures — suite state untouched, parallel-safe.