### PR TITLE
perf(test): run release sandbox tests from a tiny fixture dir

### DIFF
--- a/tests/unit/release_sandbox_test.sh
+++ b/tests/unit/release_sandbox_test.sh
@@ -8,6 +8,7 @@ if [[ "${BASH_VERSINFO[0]}" -eq 3 ]] && [[ "${BASH_VERSINFO[1]}" -lt 1 ]]; then
 fi
 
 RELEASE_SCRIPT_DIR=""
+FIXTURE_DIR=""
 
 function set_up_before_script() {
   RELEASE_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -15,6 +16,20 @@ function set_up_before_script() {
   # Source release.sh to get access to functions
   # shellcheck source=/dev/null
   source "$RELEASE_SCRIPT_DIR/release.sh"
+
+  # Tiny fake project dir: release::sandbox::create tars $(pwd), so running it
+  # from the repo root copies ~21MB per call. The fixture keeps it to a few KB
+  # and makes the exclusion tests self-contained (#825). bashunit::temp_dir is
+  # cleaned by the framework after all workers finish — a manual rm -rf in
+  # tear_down_after_script would race the parallel workers, which start before
+  # the file-level teardown runs.
+  FIXTURE_DIR=$(bashunit::temp_dir "release-fixture")
+  echo '#!/usr/bin/env bash' >"$FIXTURE_DIR/bashunit"
+  echo '#!/usr/bin/env bash' >"$FIXTURE_DIR/build.sh"
+  echo '# Changelog' >"$FIXTURE_DIR/CHANGELOG.md"
+  mkdir "$FIXTURE_DIR/.git" "$FIXTURE_DIR/.release-state"
+  echo 'ref: refs/heads/main' >"$FIXTURE_DIR/.git/HEAD"
+  echo 'state' >"$FIXTURE_DIR/.release-state/state.txt"
 }
 
 ##########################
@@ -22,17 +37,24 @@ function set_up_before_script() {
 ##########################
 
 function test_sandbox_create_creates_temp_directory() {
+  local original_dir
+  original_dir=$(pwd)
+
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
+
   assert_not_empty "$SANDBOX_DIR"
   assert_directory_exists "$SANDBOX_DIR"
+
   rm -rf "$SANDBOX_DIR"
+  cd "$original_dir" || return
 }
 
 function test_sandbox_create_copies_project_files() {
   local original_dir
   original_dir=$(pwd)
 
-  cd "$RELEASE_SCRIPT_DIR" || return
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
 
   # Check that key files were copied
@@ -48,10 +70,10 @@ function test_sandbox_create_excludes_git_directory() {
   local original_dir
   original_dir=$(pwd)
 
-  cd "$RELEASE_SCRIPT_DIR" || return
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
 
-  # .git should NOT be copied
+  # .git exists in the fixture but should NOT be copied
   assert_directory_not_exists "$SANDBOX_DIR/.git"
 
   rm -rf "$SANDBOX_DIR"
@@ -62,16 +84,13 @@ function test_sandbox_create_excludes_release_state() {
   local original_dir
   original_dir=$(pwd)
 
-  cd "$RELEASE_SCRIPT_DIR" || return
-
-  # Create a .release-state directory to test exclusion
-  mkdir -p .release-state/test
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
 
-  # .release-state should NOT be copied
+  # .release-state exists in the fixture but should NOT be copied
   assert_directory_not_exists "$SANDBOX_DIR/.release-state"
 
-  rm -rf "$SANDBOX_DIR" .release-state
+  rm -rf "$SANDBOX_DIR"
   cd "$original_dir" || return
 }
 
@@ -83,7 +102,7 @@ function test_sandbox_setup_git_initializes_repo() {
   local original_dir
   original_dir=$(pwd)
 
-  cd "$RELEASE_SCRIPT_DIR" || return
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
   release::sandbox::setup_git 2>/dev/null
 
@@ -102,7 +121,7 @@ function test_sandbox_setup_git_creates_initial_commit() {
   local original_dir
   original_dir=$(pwd)
 
-  cd "$RELEASE_SCRIPT_DIR" || return
+  cd "$FIXTURE_DIR" || return
   release::sandbox::create 2>/dev/null
   release::sandbox::setup_git 2>/dev/null
 


### PR DESCRIPTION
## 🤔 Background

Related #825

`release::sandbox::create` tars the current working directory, so the 6 calls in `release_sandbox_test.sh` each copied the ~21MB repo into /tmp, making it the slowest unit test file (~5.8s).

## 💡 Changes

- Build a few-KB fake project once per script and run every sandbox test from there: ~5.8s → ~0.9s
- Fixture ships its own `.git/` and `.release-state/`, so the exclusion tests no longer depend on the real repo's state
- Fixture lives in `bashunit::temp_dir` (framework-cleaned after workers finish) — a manual `rm -rf` in `tear_down_after_script` races parallel workers, which start before file-level teardown
- No changes to `release.sh`

https://claude.ai/code/session_01JSeB8UzLCpqst55hAK6dED