### PR TITLE
perf(test): mock measure_ms in assert_duration failure paths

### DIFF
--- a/tests/unit/assert_duration_test.sh
+++ b/tests/unit/assert_duration_test.sh
@@ -9,12 +9,17 @@ function test_successful_assert_duration_within_fast_command() {
   assert_empty "$(assert_duration "echo hello" 5000)"
 }
 
+# Failure paths mock bashunit::duration::measure_ms: they exercise the
+# threshold comparison and failure message, not the timing itself, so a real
+# `sleep 1` per test only slowed the suite down (#826).
 function test_unsuccessful_assert_duration_exceeds_threshold() {
+  bashunit::mock bashunit::duration::measure_ms <<<"2000"
+
   assert_same \
     "$(bashunit::console_results::print_failed_test \
       "Unsuccessful assert duration exceeds threshold" \
-      "1000" "to complete within (ms)" "sleep 1")" \
-    "$(assert_duration "sleep 1" 1000)"
+      "1000" "to complete within (ms)" "fake_slow_command")" \
+    "$(assert_duration "fake_slow_command" 1000)"
 }
 
 function test_successful_assert_duration_less_than() {
@@ -22,21 +27,33 @@ function test_successful_assert_duration_less_than() {
 }
 
 function test_unsuccessful_assert_duration_less_than() {
+  bashunit::mock bashunit::duration::measure_ms <<<"2000"
+
   assert_same \
     "$(bashunit::console_results::print_failed_test \
       "Unsuccessful assert duration less than" \
-      "100" "to complete within (ms)" "sleep 1")" \
-    "$(assert_duration_less_than "sleep 1" 100)"
+      "100" "to complete within (ms)" "fake_slow_command")" \
+    "$(assert_duration_less_than "fake_slow_command" 100)"
 }
 
+# Keep one success path on a real (short) sleep so measure_ms integration
+# stays covered end-to-end. The last-resort date-seconds clock has 1s
+# resolution and would measure a sub-second sleep as 0ms, so skip there.
 function test_successful_assert_duration_greater_than() {
-  assert_empty "$(assert_duration_greater_than "sleep 1" 500)"
+  bashunit::clock::now_to_slot >/dev/null 2>&1 || true
+  if [ "${_BASHUNIT_CLOCK_NOW_IMPL:-}" = "date-seconds" ]; then
+    bashunit::skip "clock has 1s resolution" && return
+  fi
+
+  assert_empty "$(assert_duration_greater_than "sleep 0.2" 100)"
 }
 
 function test_unsuccessful_assert_duration_greater_than() {
+  bashunit::mock bashunit::duration::measure_ms <<<"3"
+
   assert_same \
     "$(bashunit::console_results::print_failed_test \
       "Unsuccessful assert duration greater than" \
-      "5000" "to take at least (ms)" "echo hello")" \
-    "$(assert_duration_greater_than "echo hello" 5000)"
+      "5000" "to take at least (ms)" "fake_fast_command")" \
+    "$(assert_duration_greater_than "fake_fast_command" 5000)"
 }


### PR DESCRIPTION
## 🤔 Background

Related #826

The three failure-path tests in `assert_duration_test.sh` each paid a real `sleep 1` — 3s of the file's 3.3s runtime — only to exercise the threshold comparison and failure message.

## 💡 Changes

- Mock `bashunit::duration::measure_ms` (heredoc form, so call args aren't appended to the fake reading) in failure-path tests: ~3.3s → ~0.4s
- Keep one success path on a real short sleep so `measure_ms` integration stays covered end-to-end
- Guard that test to skip under the last-resort `date-seconds` clock, whose 1s resolution would read `sleep 0.2` as 0ms
- No changes to `src/`

https://claude.ai/code/session_01JSeB8UzLCpqst55hAK6dED