### PR TITLE
ref: dead-code and duplication cleanup

### DIFF
--- a/src/clock.sh
+++ b/src/clock.sh
@@ -195,16 +195,6 @@ function bashunit::clock::total_runtime_in_milliseconds() {
   fi
 }
 
-function bashunit::clock::total_runtime_in_nanoseconds() {
-  local end_time
-  end_time=$(bashunit::clock::now)
-  if [ -n "$end_time" ]; then
-    bashunit::math::calculate "$end_time - $_BASHUNIT_START_TIME"
-  else
-    echo ""
-  fi
-}
-
 function bashunit::clock::init() {
   _BASHUNIT_START_TIME=$(bashunit::clock::now)
 }

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -143,29 +143,13 @@ function bashunit::console_results::print_execution_time() {
   time="${time%%.*}"
   time="${time:-0}"
 
-  if [ "$time" -lt 1000 ]; then
-    printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-      "Time taken: ${time}ms"
-    return
-  fi
-
-  local time_in_seconds=$((time / 1000))
-
-  if [ "$time_in_seconds" -ge 60 ]; then
-    local minutes=$((time_in_seconds / 60))
-    local seconds=$((time_in_seconds % 60))
-    printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-      "Time taken: ${minutes}m ${seconds}s"
-    return
-  fi
-
-  local integer_part=$((time / 1000))
-  local decimal_part=$(( (time % 1000) / 10 ))
-  local formatted_seconds
-  formatted_seconds=$(printf "%d.%02d" "$integer_part" "$decimal_part")
+  # Reuse the shared ms formatter (Xm Ys / X.XXs / Xms) instead of re-deriving it;
+  # this runs once per run, so the command-substitution fork is negligible.
+  local formatted
+  formatted=$(bashunit::console_results::format_duration "$time")
 
   printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
-    "Time taken: ${formatted_seconds}s"
+    "Time taken: ${formatted}"
 }
 
 function bashunit::console_results::format_duration() {

--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -857,23 +857,6 @@ function bashunit::helper::tags_for_function() {
 }
 
 #
-# Extracts @tag annotations for a specific function from a test file.
-# Thin wrapper over the cached tags map, kept for callers that want the tags
-# on stdout. Hot-path call sites use build_tags_map + tags_for_function to
-# avoid the subshell fork.
-#
-# @param $1 string Function name
-# @param $2 string Script file path
-#
-# @return string Comma-separated list of tags, or empty if none
-#
-function bashunit::helper::get_tags_for_function() {
-  bashunit::helper::build_tags_map "$2"
-  bashunit::helper::tags_for_function "$1"
-  echo "$_BASHUNIT_TAGS_OUT"
-}
-
-#
 # Checks if a function's tags match the include/exclude filters.
 # Include uses OR logic (any match passes).
 # Exclude uses OR logic (any match fails).

--- a/src/state.sh
+++ b/src/state.sh
@@ -148,16 +148,8 @@ function bashunit::state::add_test_output() {
   _BASHUNIT_TEST_OUTPUT="$_BASHUNIT_TEST_OUTPUT$1"
 }
 
-function bashunit::state::get_test_exit_code() {
-  echo "$_BASHUNIT_TEST_EXIT_CODE"
-}
-
 function bashunit::state::set_test_exit_code() {
   _BASHUNIT_TEST_EXIT_CODE="$1"
-}
-
-function bashunit::state::get_test_title() {
-  echo "$_BASHUNIT_TEST_TITLE"
 }
 
 function bashunit::state::set_test_title() {
@@ -168,10 +160,6 @@ function bashunit::state::reset_test_title() {
   _BASHUNIT_TEST_TITLE=""
 }
 
-function bashunit::state::get_current_test_interpolated_function_name() {
-  echo "$_BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME"
-}
-
 function bashunit::state::set_current_test_interpolated_function_name() {
   _BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME="$1"
 }
@@ -180,32 +168,12 @@ function bashunit::state::reset_current_test_interpolated_function_name() {
   _BASHUNIT_CURRENT_TEST_INTERPOLATED_NAME=""
 }
 
-function bashunit::state::get_test_hook_failure() {
-  echo "$_BASHUNIT_TEST_HOOK_FAILURE"
-}
-
 function bashunit::state::set_test_hook_failure() {
   _BASHUNIT_TEST_HOOK_FAILURE="$1"
 }
 
-function bashunit::state::reset_test_hook_failure() {
-  _BASHUNIT_TEST_HOOK_FAILURE=""
-}
-
-function bashunit::state::get_test_hook_message() {
-  echo "$_BASHUNIT_TEST_HOOK_MESSAGE"
-}
-
 function bashunit::state::set_test_hook_message() {
   _BASHUNIT_TEST_HOOK_MESSAGE="$1"
-}
-
-function bashunit::state::reset_test_hook_message() {
-  _BASHUNIT_TEST_HOOK_MESSAGE=""
-}
-
-function bashunit::state::is_assertion_failed_in_test() {
-  ((_BASHUNIT_ASSERTION_FAILED_IN_TEST))
 }
 
 function bashunit::state::mark_assertion_failed_in_test() {

--- a/tests/unit/helpers_tag_test.sh
+++ b/tests/unit/helpers_tag_test.sh
@@ -1,39 +1,6 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2317
 
-function test_get_tags_for_function_returns_tags() {
-  local script="tests/acceptance/fixtures/test_bashunit_with_tags.sh"
-  local result
-  result=$(bashunit::helper::get_tags_for_function "test_slow_operation" "$script")
-
-  assert_same "slow" "$result"
-}
-
-function test_get_tags_for_function_returns_multiple_tags() {
-  local script="tests/acceptance/fixtures/test_bashunit_with_tags.sh"
-  local result
-  result=$(bashunit::helper::get_tags_for_function "test_slow_database_query" "$script")
-
-  assert_contains "slow" "$result"
-  assert_contains "database" "$result"
-}
-
-function test_get_tags_for_function_returns_empty_when_no_tags() {
-  local script="tests/acceptance/fixtures/test_bashunit_with_tags.sh"
-  local result
-  result=$(bashunit::helper::get_tags_for_function "test_no_tags" "$script")
-
-  assert_empty "$result"
-}
-
-function test_get_tags_for_function_returns_empty_for_nonexistent_function() {
-  local script="tests/acceptance/fixtures/test_bashunit_with_tags.sh"
-  local result
-  result=$(bashunit::helper::get_tags_for_function "test_nonexistent" "$script")
-
-  assert_empty "$result"
-}
-
 function test_function_matches_tags_include_match() {
   local tags="slow,database"
   local include_tags="slow"


### PR DESCRIPTION
## 🤔 Background

A multi-agent audit swept the codebase across eight quality axes (DRY, shared constants, dead code, source cycles, fragile constructs, error-hiding defensive code, legacy/fallback code, comment slop). Five axes were already clean; three surfaced provably-safe removals.

## 💡 Changes

- Reuse the existing `format_duration` helper in `print_execution_time` instead of open-coding the same ms→`Xm Ys`/`X.XXs`/`Xms` branching (branch-equivalence verified at the 1000/60000 ms boundaries; off the per-test hot path).
- Drop the superseded `get_tags_for_function` stdout wrapper and its 4 tests — `runner.sh` uses the fork-free `build_tags_map` + `tags_for_function` pair directly, leaving zero production callers.
- Remove 9 internal state/clock accessor functions with zero call sites anywhere in the tracked repo (backing `_BASHUNIT_*` vars are read/written directly).

Internal only — no user-facing behavior change, so no CHANGELOG entry. Full gate green: sequential + `--parallel --simple --strict` (1380 passed), `make sa`, `make lint`, `./build.sh --verify`.

https://claude.ai/code/session_01JSeB8UzLCpqst55hAK6dED