### PR TITLE
docs(assert): document assert_not_equals in the catalog

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -1103,6 +1103,25 @@ function test_failure() {
 ```
 :::
 
+## assert_not_equals
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
+
+- [assert_equals](#assert-equals) is the inverse of this assertion and takes the same arguments.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_not_equals "foo" "bar"
+}
+
+function test_failure() {
+  assert_not_equals "foo" "foo"
+}
+```
+:::
+
 ## assert_not_same
 > `assert_not_same "expected" "actual"`
 

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -431,6 +431,15 @@ Reports an error if `expected` and `actual` are not equals.
 - assert_files_not_equals is the inverse of this assertion and takes the same arguments.
 
 
+## assert_not_equals
+--------------
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
+
+- assert_equals is the inverse of this assertion and takes the same arguments.
+
+
 ## assert_not_same
 --------------
 > `assert_not_same "expected" "actual"`
@@ -614,5 +623,3 @@ Reports an error if `command` completes in `threshold_ms` milliseconds or less. 
 
 Unambiguously reports an error message. Useful for reporting specific message
 when testing situations not covered by any `assert_*` functions.
-
-

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_filtered_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_filtered_assert_docs.snapshot
@@ -33,6 +33,15 @@ Reports an error if `expected` and `actual` are not equals.
 - assert_files_not_equals is the inverse of this assertion and takes the same arguments.
 
 
+## assert_not_equals
+--------------
+> `assert_not_equals "expected" "actual"`
+
+Reports an error if the two variables `expected` and `actual` are equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
+
+- assert_equals is the inverse of this assertion and takes the same arguments.
+
+
 ## assert_files_not_equals
 --------------
 > `assert_files_not_equals "expected" "actual"`


### PR DESCRIPTION
## 🤔 Background

A README/docs audit found `assert_not_equals` ships and is tested but is absent from the `docs/assertions.md` catalog, even though its twin `assert_equals` is documented. Everything else checked out — all 48 CLI flags documented, user-facing env vars covered, install paths consistent, versions dynamic.

## 💡 Changes

- Add the `assert_not_equals` entry to the negative-assertions cluster in `docs/assertions.md` (standard signature, description, example, cross-ref to `assert_equals`).
- Regenerate the two `bashunit doc` acceptance snapshots — it now appears in the full listing and in the `doc equals` filtered output.

No code change; the assertion itself is unchanged. Full gate green: `./bashunit tests/` + `--parallel --simple --strict` (1384 passed), `make sa`, `make lint`, `./build.sh --verify`.

https://claude.ai/code/session_01JSeB8UzLCpqst55hAK6dED