### PR TITLE
perf(runner): ordinal naming for parallel result files

### DIFF
--- a/.claude/rules/perf-fork-budget.md
+++ b/.claude/rules/perf-fork-budget.md
@@ -87,10 +87,14 @@ sourcing `src/` (irreducible without lazy-loading, rejected in #798).
 (decision-cache miss: grep|head + dirname) — bounded by file count, nightly
 non-gating workflow, not worth chasing.
 
-**Parallel 10-test file run (CI's mode):** ~21 forks — 10 `mktemp` (one per
-test: the unique result file; deterministic names collide because different
-provider args can sanitize identically and workers can't make unique tokens on
-Bash 3 — subshells inherit `$$` and the `RANDOM` state, and `BASHPID` is 4.0+),
-3 `mkdir`, 4 `rm`, 3 `awk` (#813; was 61). `wait_for_job_slot` already uses
-`wait -n` on Bash 4.3+ and an adaptive sleep-poll fallback — don't "fix" it.
-The spinner forks `sleep` ~1/s on non-tty; not worth chasing.
+**Parallel 10-test file run (CI's mode):** ~11 forks — 3 `mkdir`, 4 `rm`,
+3 `awk` (#813; was 61). The per-test result file is named by a per-suite
+ordinal the single-threaded dispatcher assigns just before each `&` (the fork
+inherits it), so it costs **no** `mktemp` + `mv` per test (#851; was 10
+`mktemp` + 10 `mv`). This replaced the old sanitized-test-name scheme, whose
+deterministic names could collide (different provider args sanitize identically)
+because Bash 3 workers can't mint a unique token — subshells inherit `$$` and
+the `RANDOM` state, and `BASHPID` is 4.0+; an ordinal sidesteps that entirely.
+`wait_for_job_slot` already uses `wait -n` on Bash 4.3+ and an adaptive
+sleep-poll fallback — don't "fix" it. The spinner forks `sleep` ~1/s on
+non-tty; not worth chasing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Core string assertions (`assert_contains`/`assert_not_contains`, `assert_matches`/`assert_not_matches`, `assert_string_starts_with`/`assert_string_ends_with` and their negations) no longer fork a subshell per call to join their arguments; a fork-free join with identical behaviour replaces it (#844)
 - The array, date, duration, json, files and folders assertions now resolve their failure label through the fork-free slot helper instead of a per-call command substitution — same labels, fewer forks
+- Parallel test workers name their per-test result file by a per-suite ordinal instead of `mktemp` + `mv`, removing two forks per test (plus the `echo \| tr \| sed` arg sanitizing for data-provider tests) with identical result aggregation (#851)
 
 ## [0.42.0](https://github.com/TypedDevs/bashunit/compare/0.41.0...0.42.0) - 2026-07-20
 

--- a/src/runner.sh
+++ b/src/runner.sh
@@ -140,6 +140,11 @@ _BASHUNIT_RUNNER_COUNTS_SNAPSHOT_OUT=0
 _BASHUNIT_RUNNER_COUNTS_EXIT_CODE_OUT=0
 _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT=""
 _BASHUNIT_RUNNER_SUBSHELL_OUTPUT_OUT=""
+# Per-suite ordinal for naming a parallel worker's `.result` file. Set by
+# call_test_functions (single-threaded dispatch) just before each backgrounded
+# run_test; the fork inherits the value, so every test in a file gets a unique,
+# collision-free name in its per-suite dir without forking mktemp/mv.
+_BASHUNIT_RUNNER_RESULT_ORDINAL=0
 # Suffix appended to a passed-test line when it only passed after retrying.
 _BASHUNIT_RETRY_NOTE=""
 
@@ -846,6 +851,8 @@ function bashunit::runner::call_test_functions() {
   local provider_data_count=0
   local -a parsed_data=()
   local parsed_data_count=0
+  # Monotonic within this file; names each parallel worker's .result file.
+  local _test_ordinal=0
 
   # Scan the file once; per-test provider lookups below are pure-bash (#763).
   # The same pass also detects the no-parallel-tests opt-out (#774).
@@ -874,6 +881,8 @@ function bashunit::runner::call_test_functions() {
     if [ -z "$_BASHUNIT_PROVIDER_FN_OUT" ]; then
       if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
         bashunit::runner::wait_for_job_slot
+        _test_ordinal=$((_test_ordinal + 1))
+        _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" &
       else
         bashunit::runner::run_test "$script" "$fn_name"
@@ -904,6 +913,8 @@ function bashunit::runner::call_test_functions() {
       done <<<"$(bashunit::runner::parse_data_provider_args "$data")"
       if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
         bashunit::runner::wait_for_job_slot
+        _test_ordinal=$((_test_ordinal + 1))
+        _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"} &
       else
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"}
@@ -1581,39 +1592,16 @@ function bashunit::runner::parse_result_parallel() {
   local fn_name=$1
   shift
   local execution_result=$1
-  shift
-  local IFS=$' \t\n'
-  local -a args
-  args=("$@")
-
   # This runs once per test in every parallel worker, so avoid per-test forks:
   # derive the suite dir name with parameter expansion (no basename), only
   # mkdir when the dir is missing (first test of the file wins the race,
-  # `-p` makes the losers no-ops), and skip arg sanitizing entirely for the
-  # common no-provider-args case.
+  # `-p` makes the losers no-ops), and name the result file by the per-suite
+  # ordinal the dispatcher assigned — unique without forking mktemp or mv.
   local test_suite_base="${test_file##*/}"
   local test_suite_dir="${TEMP_DIR_PARALLEL_TEST_SUITE}/${test_suite_base%.sh}"
   [ -d "$test_suite_dir" ] || mkdir -p "$test_suite_dir"
 
-  local sanitized_args=""
-  if [ -n "${args[*]+"${args[*]}"}" ]; then
-    sanitized_args=$(echo "${args[*]}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-|-$//')
-  fi
-  local template
-  if [ -z "$sanitized_args" ]; then
-    template="${fn_name}.XXXXXX"
-  else
-    template="${fn_name}-${sanitized_args}.XXXXXX"
-  fi
-
-  local unique_test_result_file
-  if unique_test_result_file=$("$MKTEMP" -p "$test_suite_dir" "$template" 2>/dev/null); then
-    true
-  else
-    unique_test_result_file=$("$MKTEMP" "$test_suite_dir/$template")
-  fi
-  mv "$unique_test_result_file" "${unique_test_result_file}.result"
-  unique_test_result_file="${unique_test_result_file}.result"
+  local unique_test_result_file="${test_suite_dir}/${_BASHUNIT_RUNNER_RESULT_ORDINAL}.result"
 
   bashunit::internal_log "[PARA]" "fn_name:$fn_name" "execution_result:$execution_result"
 

--- a/tests/acceptance/bashunit_run_forks_test.sh
+++ b/tests/acceptance/bashunit_run_forks_test.sh
@@ -186,10 +186,12 @@ function test_run_removes_its_run_output_dir() {
 
 # Regression guard for the parallel per-test result path. Publishing each
 # test's result file used to fork `basename` (suite dir name), `mkdir -p`
-# (suite dir, per test) and an `echo | tr | sed` pipeline (arg sanitizing, even
-# with no args) — ~4 forks per test in the mode CI runs everything in. The dir
-# name is parameter expansion now, mkdir is guarded by a `[ -d ]` builtin check,
-# and arg sanitizing is skipped when there are no provider args.
+# (suite dir, per test), an `echo | tr | sed` pipeline (arg sanitizing, even
+# with no args) and a final `mv` (adding the `.result` suffix to the mktemp
+# name) — ~5 forks per test in the mode CI runs everything in. The dir name is
+# parameter expansion now, mkdir is guarded by a `[ -d ]` builtin check, arg
+# sanitizing is skipped when there are no provider args, and the result file is
+# named by a per-suite ordinal (no mktemp, no mv).
 function test_parallel_result_publishing_does_not_fork_per_test() {
   if bashunit::check_os::is_windows; then
     bashunit::skip "PATH shims are unreliable under Git Bash" && return
@@ -199,7 +201,7 @@ function test_parallel_result_publishing_does_not_fork_per_test() {
   dir="$(bashunit::temp_dir)"
   local count_file="$dir/count"
   local bin
-  for bin in basename tr sed; do
+  for bin in basename tr sed mv; do
     local real_bin
     real_bin="$(command -v "$bin")"
     {


### PR DESCRIPTION
## 🤔 Background

Related #851

Every `--parallel` worker forked `mktemp` + `mv` to publish each test's `.result` file (plus an `echo \| tr \| sed` pipeline to sanitize data-provider args into the name) — the largest remaining chunk of the per-test parallel fork budget.

## 💡 Changes

- The single-threaded dispatcher assigns a per-suite ordinal (global slot inherited by the fork) before each backgrounded `run_test`; the worker names its file `<N>.result` — no `mktemp`, no `mv`, no arg sanitizing.
- Ordinals are unique per suite, so the old sanitized-name scheme (which could collide when different provider args sanitize identically) is removed; aggregation reads file content, not names, so results are identical.
- Fork-budget regression test tightened to also assert `mv` is not forked per test; `perf-fork-budget.md` updated (~21 → ~11 forks for a 10-test parallel file).