### PR TITLE
feat(coverage): surface per-line execution hit counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- Per-line execution hit counts in the text report: `BASHUNIT_COVERAGE_SHOW_LINE_HITS=true` prints a `Line Hits` block listing each covered line as `<lineno>:<count>` per file. The LCOV report already carried the same counts in its `DA:<line>,<count>` records; those are now pinned by tests (#856)
+
 ## [0.43.0](https://github.com/TypedDevs/bashunit/compare/0.42.0...0.43.0) - 2026-07-24
 
 ### Added

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -114,7 +114,14 @@ BASHUNIT_COVERAGE_THRESHOLD_HIGH=80  # Green above this, yellow between
 # Optional text-report blocks (off by default, opt-in for verbose runs)
 BASHUNIT_COVERAGE_SHOW_FUNCTIONS=true   # Print per-function coverage
 BASHUNIT_COVERAGE_SHOW_UNCOVERED=true   # Print missed line ranges per file
+BASHUNIT_COVERAGE_SHOW_LINE_HITS=true   # Print per-line execution counts (lineno:count)
 ```
+
+Per-line execution counts are always written to the LCOV report as the count
+field of each `DA:<line>,<count>` record (consumable by `genhtml`, Codecov and
+Coveralls). `BASHUNIT_COVERAGE_SHOW_LINE_HITS=true` additionally surfaces them
+in the text report as a `Line Hits` block listing each covered line as
+`<lineno>:<count>` per file.
 
 ## Examples
 

--- a/src/coverage.sh
+++ b/src/coverage.sh
@@ -1178,6 +1178,11 @@ function bashunit::coverage::report_text() {
     bashunit::coverage::report_text_uncovered
   fi
 
+  # Optional per-line execution counts (gated on BASHUNIT_COVERAGE_SHOW_LINE_HITS)
+  if [ "${BASHUNIT_COVERAGE_SHOW_LINE_HITS:-false}" = "true" ]; then
+    bashunit::coverage::report_text_line_hits
+  fi
+
   # Show report location if generated
   if [ -n "$BASHUNIT_COVERAGE_REPORT" ]; then
     echo ""
@@ -1261,6 +1266,49 @@ function bashunit::coverage::report_text_uncovered() {
     out="$_BASHUNIT_RANGES_OUT"
 
     printf "%s%s:%s%s\n" "$color" "$display_file" "$out" "$reset"
+  done < <(bashunit::coverage::get_tracked_files)
+}
+
+# Per-line execution hit counts, gated on BASHUNIT_COVERAGE_SHOW_LINE_HITS=true.
+# Lists each covered executable line as "<lineno>:<count>", where count is the
+# number of times the line ran (the same value LCOV emits in its DA records).
+function bashunit::coverage::report_text_line_hits() {
+  local IFS=$' \t\n'
+  local file
+  local printed_header=false
+  while IFS= read -r file; do
+    { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
+
+    local -a hits_by_line=()
+    local _hl_ln _hl_cnt
+    while IFS=: read -r _hl_ln _hl_cnt; do
+      [ -n "$_hl_ln" ] && hits_by_line[_hl_ln]=$_hl_cnt
+    done < <(bashunit::coverage::get_all_line_hits "$file")
+
+    local -a hit_specs=()
+    local _hc=0
+    local lineno=0 line
+    while IFS= read -r line || [ -n "$line" ]; do
+      lineno=$((lineno + 1))
+      bashunit::coverage::is_executable_line "$line" "$lineno" || continue
+      local lh="${hits_by_line[$lineno]:-0}"
+      if [ "$lh" -gt 0 ]; then
+        hit_specs[_hc]="${lineno}:${lh}"
+        _hc=$((_hc + 1))
+      fi
+    done <"$file"
+
+    [ "$_hc" -eq 0 ] && continue
+
+    if [ "$printed_header" != "true" ]; then
+      echo ""
+      echo "Line Hits"
+      echo "---------"
+      printed_header=true
+    fi
+
+    local display_file="${file#"$(pwd)"/}"
+    printf "%s: %s\n" "$display_file" "${hit_specs[*]}"
   done < <(bashunit::coverage::get_tracked_files)
 }
 

--- a/tests/unit/coverage_reporting_test.sh
+++ b/tests/unit/coverage_reporting_test.sh
@@ -147,6 +147,61 @@ EOF
   rm -f "$temp_file" "$report_file"
 }
 
+function test_coverage_report_lcov_da_records_carry_execution_counts() {
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "hot"
+echo "once"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  # Line 2 executed three times, line 3 once.
+  printf '%s:2\n%s:2\n%s:2\n%s:3\n' \
+    "$temp_file" "$temp_file" "$temp_file" "$temp_file" >>"$_BASHUNIT_COVERAGE_DATA_FILE"
+
+  local report_file
+  report_file=$(mktemp)
+  bashunit::coverage::report_lcov "$report_file"
+  local content
+  content=$(cat "$report_file")
+
+  # DA counts are the real per-line execution counts, not a boolean.
+  assert_contains "DA:2,3" "$content"
+  assert_contains "DA:3,1" "$content"
+
+  rm -f "$temp_file" "$report_file"
+}
+
+function test_coverage_report_text_line_hits_lists_covered_lines_with_counts() {
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "hot"
+echo "cold"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  printf '%s:2\n%s:2\n%s:2\n' "$temp_file" "$temp_file" "$temp_file" >>"$_BASHUNIT_COVERAGE_DATA_FILE"
+
+  local output
+  output=$(bashunit::coverage::report_text_line_hits)
+
+  assert_contains "Line Hits" "$output"
+  # Covered line 2 ran three times.
+  assert_contains "2:3" "$output"
+
+  rm -f "$temp_file"
+}
+
 function test_coverage_report_lcov_completes_under_set_e() {
   BASHUNIT_COVERAGE="true"
   bashunit::coverage::init


### PR DESCRIPTION
## 🤔 Background

Related #856

Coverage's LCOV report already carried real per-line execution counts in its `DA:<line>,<count>` records, but the count value was never pinned by a test and the text report exposed none.

## 💡 Changes

- New opt-in text block `BASHUNIT_COVERAGE_SHOW_LINE_HITS=true` (default off, gated like `SHOW_UNCOVERED`/`SHOW_FUNCTIONS`) prints a `Line Hits` section listing each covered line as `<lineno>:<count>` per file, reusing `get_all_line_hits`.
- Tests pin the LCOV `DA` execution-count value (a thrice-hit line → `DA:…,3`) and the new view.
- Docs note that per-line counts ship in LCOV and via the new flag. Default output unchanged.