### PR TITLE
docs: agentic coding page and a drop-in agent skill

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -38,16 +38,25 @@ assert_fails "assert_equals 'a' 'b'"
 
 ## Test Doubles
 
+Helpers are namespaced (`bashunit::*`); assertions are bare. The unprefixed helper name
+is a `command not found`, not an alias.
+
 ```bash
 # Spies - track calls without changing behavior
-spy function_name
+bashunit::spy function_name
 assert_have_been_called function_name
-assert_have_been_called_times 2 function_name
-assert_have_been_called_with "arg" function_name
+assert_have_been_called_times 2 function_name          # count first, then spy
+assert_have_been_called_with function_name "arg"       # spy first, then expected
+assert_have_been_called_with function_name "arg" 1     # ...of call #1
+assert_have_been_called_nth_with 1 function_name "arg"
 
 # Mocks - replace behavior
-mock curl echo "mocked response"
+bashunit::mock date echo "2024-05-01"
+bashunit::mock uname <<< "Linux"    # heredoc form ignores the call's arguments
 ```
+
+Note `_times` takes the count first while `_with` takes the spy first — a swapped pair
+fails the assertion rather than erroring, so it reads like a real defect.
 
 ## Data Providers
 
@@ -79,7 +88,8 @@ assert_match_snapshot "$output"
 
 ## Test Isolation
 
-- Use `$temp_file` / `$temp_dir` (auto-cleaned) for file operations
+- Use `$(bashunit::temp_file)` / `$(bashunit::temp_dir)` (auto-cleaned) for file
+  operations — these are functions, not variables
 - No shared global state between tests
 - No network calls — mock external commands
 - No time dependencies — mock `date` if needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- Docs: an [Agentic coding](https://bashunit.com/ai-agents) page covering machine-readable results (`--report-json`, `--output tap`), the flags that keep an AI agent's edit-run loop tight (`--filter`, `--rerun-failed`, `--test-timeout`), and the API traps that make generated tests pass for the wrong reason. It also surfaces `llms.txt` / `llms-full.txt`, which were already published but linked from nowhere
+- A drop-in agent skill at [bashunit.com/bashunit-skill.md](https://bashunit.com/bashunit-skill.md) for Claude Code and other tools that load a `SKILL.md`
 - Per-line execution hit counts in the text report: `BASHUNIT_COVERAGE_SHOW_LINE_HITS=true` prints a `Line Hits` block listing each covered line as `<lineno>:<count>` per file. The LCOV report already carried the same counts in its `DA:<line>,<count>` records; those are now pinned by tests (#856)
 
 ### Changed

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,7 +9,7 @@ const LLMS_ORDER = [
   'assertions', 'custom-asserts', 'test-doubles', 'data-providers', 'snapshots',
   'skipping-incomplete', 'test-files', 'globals', 'common-patterns',
   'command-line', 'configuration', 'coverage', 'benchmarks', 'standalone',
-  'examples', 'support'
+  'ai-agents', 'examples', 'support'
 ]
 
 // https://vitepress.dev/reference/site-config
@@ -23,6 +23,8 @@ export default defineConfig({
 
   head: [
     ['link', { rel: 'icon', href: '/favicon.ico' }],
+    // Discoverability for agents: the docs are also published as plain text.
+    ['link', { rel: 'alternate', type: 'text/plain', href: 'https://bashunit.com/llms.txt', title: 'llms.txt' }],
     ['meta', { name: 'theme-color', content: '#22c55e' }],
     ['meta', { property: 'og:type', content: 'website' }],
     ['meta', { property: 'og:site_name', content: 'bashunit' }],
@@ -144,6 +146,7 @@ export default defineConfig({
           { text: 'Benchmarks', link: '/benchmarks' },
           { text: 'Standalone', link: '/standalone' },
           { text: 'Common patterns', link: '/common-patterns' },
+          { text: 'Agentic coding', link: '/ai-agents' },
         ],
       }, {
         text: 'Reference',
@@ -200,7 +203,10 @@ export default defineConfig({
   },
 
   srcExclude: [
-    'blog/0000-00-00-template.md'
+    'blog/0000-00-00-template.md',
+    // public/ is copied verbatim as static assets; without this, any .md in it is
+    // ALSO rendered as a page (/public/<name>) and lands in the sitemap.
+    'public/**/*.md'
   ],
 
   markdown: {

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,154 @@
+---
+description: Use bashunit with AI coding agents — machine-readable results, tight feedback loops, a ready-made skill, and the mistakes agents make writing bash tests.
+---
+
+# Agentic coding
+
+Coding agents write bash, and bash is the language they get wrong most often: quoting,
+exit codes and portability all fail quietly. A test suite is the only thing that turns
+"the agent says it works" into evidence.
+
+bashunit is well suited to that loop — it starts in tens of milliseconds, needs no
+runtime, and emits machine-readable results an agent can parse instead of eyeballing.
+
+## Point your agent at the docs
+
+Two files are published for machine consumption:
+
+| URL | What it is |
+|-----|------------|
+| [`bashunit.com/llms.txt`](https://bashunit.com/llms.txt) | Short index of every docs page, following the [llms.txt](https://llmstxt.org) convention |
+| [`bashunit.com/llms-full.txt`](https://bashunit.com/llms-full.txt) | The entire documentation as one plain-text file |
+
+Give an agent the second one and it stops inventing assertion names:
+
+```bash
+curl -s https://bashunit.com/llms-full.txt -o .agent/bashunit-docs.txt
+```
+
+## Machine-readable results
+
+Agents should read structured output, not scrape the terminal.
+
+`--report-json <file>` writes a summary plus one entry per test, including the failure
+message and the exact source line:
+
+```json
+{
+  "summary": { "total": 2, "passed": 1, "failed": 1, "skipped": 0, "incomplete": 0, "duration_ms": 24 },
+  "tests": [
+    { "file": "tests/math_test.sh", "name": "Passes", "status": "passed", "duration_ms": 9, "message": "" },
+    { "file": "tests/math_test.sh", "name": "Fails", "status": "failed", "duration_ms": 15,
+      "message": "✗ Failed: Fails\n    Expected 'a'\n    but got  'b'\n    at tests/math_test.sh:7" }
+  ]
+}
+```
+
+`--output tap` prints [TAP version 13](https://testanything.org) on stdout, which most
+harnesses already understand:
+
+```
+TAP version 13
+# tests/math_test.sh
+ok 1 - Passes
+not ok 2 - Fails
+  ---
+  Expected 'a'
+  but got  'b'
+  at tests/math_test.sh:7
+  ...
+
+1..2
+```
+
+`--report-tap <file>` and `--log-junit <file>` write the same information to disk.
+
+The exit code is `0` when everything passed and non-zero otherwise, so an agent can
+branch on `$?` before parsing anything.
+
+## Keep the loop tight
+
+An agent that re-runs the whole suite after every edit wastes most of its turn. These
+flags exist to avoid that:
+
+```bash
+bashunit --filter "parses the header" tests/   # one test by name
+bashunit --rerun-failed tests/                 # only what failed last run
+bashunit --failures-only --no-progress tests/  # drop the noise from the transcript
+bashunit --parallel tests/                     # full suite, concurrently
+bashunit --test-timeout 10 tests/              # stop an agent-written infinite loop
+```
+
+`--rerun-failed` reads `.bashunit/last-failed`, so the red-green cycle is: run once,
+then loop on `--rerun-failed` until it is empty. Add `.bashunit/` to your `.gitignore`.
+
+For a long agent session, `--test-timeout` matters more than it looks. A generated test
+with a `while` loop that never terminates will otherwise hang the run until the agent's
+own timeout fires, and the transcript will show nothing useful.
+
+## Drop-in rules for your repo
+
+Put this in your `AGENTS.md`, `CLAUDE.md`, or equivalent. It covers the mistakes agents
+actually make against this API:
+
+```markdown
+## Testing with bashunit
+
+- Test files end in `_test.sh`; test functions start with `test_`.
+- Run one test: `bashunit --filter "<name>" tests/`. Run everything: `bashunit tests/`.
+- Prefer `assert_same` (exact) over `assert_equals` (which trims/normalizes).
+- **Exit-code assertions take the code as the THIRD argument**, not the first:
+  `assert_general_error "" "" "$exit_code"`. With no arguments at all they read `$?`.
+- Capture an exit code before asserting, or `set -e` will kill the test first:
+  `local ec=0; my_command || ec=$?`
+- Use `$(temp_file)` / `$(temp_dir)` for scratch files — they are cleaned up
+  automatically and are safe under `--parallel`.
+- Never call the network in a test. Use `mock` / `spy` for external commands.
+- Do not delete a shared fixture in `tear_down_after_script`: under `--parallel` the
+  file's tests may still be running, and they will vanish from the totals silently.
+- Assertions are listed at https://bashunit.com/assertions — do not invent names.
+  `bashunit doc <filter>` prints them locally.
+```
+
+## A ready-made skill
+
+For agents that support loadable skills (Claude Code, and anything else reading a
+`SKILL.md`), install the bashunit skill:
+
+```bash
+mkdir -p .claude/skills/bashunit
+curl -sL https://bashunit.com/bashunit-skill.md -o .claude/skills/bashunit/SKILL.md
+```
+
+It teaches the write-run-fix cycle, the assertion catalogue, and the traps listed above.
+Invoke it with `/bashunit`, or let the agent pick it up when it starts writing tests.
+
+The file is plain markdown — read it before installing, and edit it to match your
+project's conventions.
+
+## Verifying what an agent wrote
+
+Agents write tests that pass for the wrong reason. Three cheap checks:
+
+```bash
+bashunit --fail-on-risky tests/   # a test with no assertions is a failure, not a pass
+bashunit --random-order tests/    # catches tests that depend on execution order
+bashunit --strict tests/          # set -euo pipefail; catches unset vars and silent failures
+```
+
+`--fail-on-risky` is the highest-value of the three. A test that calls the function under
+test and asserts nothing looks green in every report, and it is one of the most common
+things a generating model produces.
+
+Pair `--random-order` with `--seed <n>` to reproduce a specific shuffle once it finds
+something.
+
+## Coverage as a review signal
+
+```bash
+bashunit --coverage --coverage-report coverage/lcov.info tests/
+```
+
+Use it to answer "did the agent test the branch it just changed", not as a target to
+optimize — see [Coverage](/coverage). `--coverage-min <n>` fails the run below a
+threshold if you want it enforced.

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -63,8 +63,9 @@ not ok 2 - Fails
 
 `--report-tap <file>` and `--log-junit <file>` write the same information to disk.
 
-The exit code is `0` when everything passed and non-zero otherwise, so an agent can
-branch on `$?` before parsing anything.
+The exit code is non-zero when a test **failed**. It is `0` for a run that was entirely
+skipped, incomplete or risky, so `$?` alone does not mean "everything passed" — read
+`summary.total` against `summary.passed`, or add `--fail-on-risky`.
 
 ## Keep the loop tight
 
@@ -72,7 +73,7 @@ An agent that re-runs the whole suite after every edit wastes most of its turn. 
 flags exist to avoid that:
 
 ```bash
-bashunit --filter "parses the header" tests/   # one test by name
+bashunit --filter parses_the_header tests/     # one test — matches the FUNCTION name
 bashunit --rerun-failed tests/                 # only what failed last run
 bashunit --failures-only --no-progress tests/  # drop the noise from the transcript
 bashunit --parallel tests/                     # full suite, concurrently
@@ -95,7 +96,9 @@ actually make against this API:
 ## Testing with bashunit
 
 - Test files end in `_test.sh`; test functions start with `test_`.
-- Run one test: `bashunit --filter "<name>" tests/`. Run everything: `bashunit tests/`.
+- Run one test: `bashunit --filter <function_name> tests/` — it matches the function
+  name (`test_parses_the_header`), not the humanized title shown in the report, so a
+  filter with spaces silently matches nothing. Run everything: `bashunit tests/`.
 - Prefer `assert_same` (exact) over `assert_equals` (which trims/normalizes).
 - **Exit-code assertions take the code as the THIRD argument**, not the first:
   `assert_general_error "" "" "$exit_code"`. With no arguments at all they read `$?`.

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -101,9 +101,15 @@ actually make against this API:
   `assert_general_error "" "" "$exit_code"`. With no arguments at all they read `$?`.
 - Capture an exit code before asserting, or `set -e` will kill the test first:
   `local ec=0; my_command || ec=$?`
-- Use `$(temp_file)` / `$(temp_dir)` for scratch files — they are cleaned up
-  automatically and are safe under `--parallel`.
-- Never call the network in a test. Use `mock` / `spy` for external commands.
+- **Helpers are namespaced, assertions are not.** `assert_*` is bare; every helper needs
+  the prefix: `bashunit::temp_dir`, `bashunit::temp_file`, `bashunit::mock`,
+  `bashunit::spy`. The unprefixed form is `command not found`, not an alias.
+- Use `$(bashunit::temp_file)` / `$(bashunit::temp_dir)` for scratch files — they are
+  cleaned up automatically and are safe under `--parallel`.
+- Never call the network in a test. Use `bashunit::mock` / `bashunit::spy` instead.
+- Spy assertion argument order is inconsistent — check, don't guess:
+  `assert_have_been_called_times <count> <spy>` but
+  `assert_have_been_called_with <spy> <expected> [call_index]`.
 - Do not delete a shared fixture in `tear_down_after_script`: under `--parallel` the
   file's tests may still be running, and they will vanish from the totals silently.
 - Assertions are listed at https://bashunit.com/assertions — do not invent names.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -496,9 +496,9 @@ bashunit --env "tests/bootstrap.sh staging verbose" tests/
 BASHUNIT_DEV_LOG="dev.log"
 ```
 ```bash [Usage]
-log "I am tracing something..."
-log "error" "an" "error" "message"
-log "warning" "different log level messages!"
+bashunit::log "I am tracing something..."
+bashunit::log "error" "an" "error" "message"
+bashunit::log "warning" "different log level messages!"
 ```
 ```bash [Output: out.log]
 2024-10-03 21:27:23 [INFO]: I am tracing something... #tests/sample.sh:11

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "bashunit-docs",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bashunit-docs",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "MIT",
       "dependencies": {
-        "chart.js": "^4.4.9",
         "vanilla-tilt": "^1.8.1"
       },
       "devDependencies": {
@@ -773,12 +772,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1661,18 +1654,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/chart.js": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
-      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
       }
     },
     "node_modules/comma-separated-tokens": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,6 @@
     "preview": "vitepress preview ."
   },
   "dependencies": {
-    "chart.js": "^4.4.9",
     "vanilla-tilt": "^1.8.1"
   },
   "devDependencies": {

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -1,0 +1,147 @@
+---
+name: bashunit
+description: Write and run tests for bash scripts with bashunit. Use when adding or fixing tests for shell code, when a bashunit run fails, or when asked to raise coverage of a bash script. Covers the assertion catalogue, the fast edit-run loop, and the API traps that produce silently-passing tests.
+---
+
+# bashunit
+
+A testing framework for bash. Tests are plain bash functions; there is no runtime to
+install and a run starts in tens of milliseconds.
+
+Full docs: https://bashunit.com — machine-readable at https://bashunit.com/llms-full.txt
+
+## Layout
+
+Files end in `_test.sh`, functions start with `test_`:
+
+```bash
+#!/usr/bin/env bash
+
+function set_up() {           # before each test (optional)
+  TARGET_DIR="$(temp_dir)"
+}
+
+function test_it_writes_the_header() {
+  create_report "$TARGET_DIR/out.txt"
+
+  assert_file_contains "$TARGET_DIR/out.txt" "# Report"
+}
+```
+
+Lifecycle hooks: `set_up_before_script`, `set_up`, `tear_down`, `tear_down_after_script`.
+
+## The loop
+
+```bash
+bashunit tests/                                # everything
+bashunit --filter "writes the header" tests/   # one test, by name
+bashunit --rerun-failed tests/                 # only what failed last run
+bashunit --failures-only --no-progress tests/  # quiet output for a transcript
+bashunit --report-json out.json tests/         # structured results to parse
+```
+
+Work the cycle: run once, then loop on `--rerun-failed` until nothing fails. Do not
+re-run the whole suite after every edit.
+
+Exit code is 0 only when everything passed.
+
+## Assertions
+
+There are 66. `bashunit doc <filter>` prints them locally; the catalogue is at
+https://bashunit.com/assertions. **Do not invent names** — a wrong name is a runtime
+error, not a failed assertion.
+
+The ones worth memorising:
+
+- Equality: `assert_same` (exact), `assert_equals` (normalizing), `assert_not_same`
+- Strings: `assert_contains`, `assert_not_contains`, `assert_matches`,
+  `assert_string_starts_with`, `assert_string_ends_with`, `assert_empty`, `assert_not_empty`
+- Numbers: `assert_greater_than`, `assert_less_than`, `assert_within_delta`
+- Exit codes: `assert_successful_code`, `assert_general_error`, `assert_exit_code`,
+  `assert_command_not_found`
+- Files: `assert_file_exists`, `assert_file_contains`, `assert_is_file_empty`,
+  `assert_directory_exists`, `assert_file_permissions`
+- Arrays: `assert_array_contains`, `assert_array_length`, `assert_arrays_equal`
+- JSON: `assert_json_equals`, `assert_json_contains`, `assert_json_key_exists`
+- Snapshots: `assert_match_snapshot`
+
+Prefer `assert_same` over `assert_equals` unless you specifically want normalization.
+
+## Traps that produce silently-passing tests
+
+**Exit-code assertions take the code as the third argument.** This is the single most
+common mistake:
+
+```bash
+local ec=0
+my_command || ec=$?
+
+assert_general_error "" "" "$ec"     # correct
+assert_general_error "$ec"           # WRONG — $1 is ignored, $? is read instead
+```
+
+With no arguments they read `$?` directly, which only works immediately after the
+command.
+
+**Capture exit codes before asserting.** Under `--strict` (or a caller's `set -e`) a
+failing command ends the test before your assertion runs:
+
+```bash
+local ec=0
+failing_command || ec=$?      # correct
+local out; out=$(failing_command)   # WRONG under set -e
+```
+
+**A test with no assertions passes.** Always assert something. Run
+`bashunit --fail-on-risky tests/` to turn that into a failure.
+
+**Use `$(temp_file)` and `$(temp_dir)`** for scratch paths. They are cleaned up
+automatically and are safe under `--parallel`.
+
+**Do not delete shared fixtures in `tear_down_after_script`.** Under `--parallel` that
+file's tests may still be running; they crash and disappear from the totals without
+reporting a failure.
+
+**No network calls.** Mock the command instead.
+
+## Test doubles
+
+```bash
+mock curl echo "fixed response"      # replace behaviour
+spy send_email                       # record calls, keep behaviour
+assert_have_been_called_times 2 send_email
+assert_have_been_called_with "--to a@b.c" send_email
+```
+
+## Data providers
+
+```bash
+function data_provider_sums() {
+  echo "1 2 3"
+  echo "0 0 0"
+}
+
+# @data_provider data_provider_sums
+function test_add() {
+  assert_same "$3" "$(add "$1" "$2")"
+}
+```
+
+## Portability
+
+bashunit runs on Bash 3.0+, including the bash 3.2 that ships with macOS. If the code
+under test must run there too, avoid `declare -A`, `${var,,}`, `${array[-1]}` and `&>>`
+in both the code and the tests.
+
+## Verifying your own work
+
+```bash
+bashunit --fail-on-risky tests/   # assertion-free tests fail
+bashunit --random-order tests/    # catches order dependence
+bashunit --strict tests/          # set -euo pipefail
+bashunit --parallel tests/        # catches shared-state leaks
+```
+
+Before claiming a test is done, confirm it fails when the behaviour it covers is broken.
+A test that passes against both the fixed and the broken implementation is testing
+nothing.

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -1,6 +1,6 @@
 ---
 name: bashunit
-description: Write and run tests for bash scripts with bashunit. Use when adding or fixing tests for shell code, when a bashunit run fails, or when asked to raise coverage of a bash script. Covers the assertion catalogue, the fast edit-run loop, and the API traps that produce silently-passing tests.
+description: Write and run tests for bash scripts with bashunit. Use when adding or fixing tests for shell code, when a bashunit run fails, or when asked to raise coverage of a bash script. Covers loading the code under test, the assertion catalogue, the fast edit-run loop, and the API traps that produce silently-passing tests.
 ---
 
 # bashunit
@@ -10,50 +10,84 @@ install and a run starts in tens of milliseconds.
 
 Full docs: https://bashunit.com — machine-readable at https://bashunit.com/llms-full.txt
 
-## Layout
+## Anatomy of a test file
 
-Files end in `_test.sh`, functions start with `test_`:
+Files end in `_test.sh`, functions start with `test_`. **Load the code under test
+yourself** — bashunit does not do it for you:
 
 ```bash
 #!/usr/bin/env bash
 
-function set_up() {           # before each test (optional)
-  TARGET_DIR="$(bashunit::temp_dir)"
+function set_up() {
+  source "src/calculator.sh"      # relative to where you RUN bashunit
 }
 
-function test_it_writes_the_header() {
-  create_report "$TARGET_DIR/out.txt"
-
-  assert_file_contains "$TARGET_DIR/out.txt" "# Report"
+function test_add_two_positive_numbers() {
+  assert_same "5" "$(add 2 3)"
 }
 ```
 
-Lifecycle hooks: `set_up_before_script`, `set_up`, `tear_down`, `tear_down_after_script`.
+Run it from the project root: `bashunit tests/`. If the suite must work from any
+directory, anchor the path to the test file instead:
+
+```bash
+source "$(dirname "${BASH_SOURCE[0]}")/../src/calculator.sh"
+```
+
+Testing a whole script rather than a function? Execute it and assert on the result:
+
+```bash
+function test_script_rejects_a_missing_argument() {
+  local output ec=0
+  output=$(./src/deploy.sh 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "usage:" "$output"
+}
+```
+
+Lifecycle hooks: `set_up_before_script` (once per file), `set_up` (per test),
+`tear_down` (per test), `tear_down_after_script` (once per file).
 
 ## The loop
 
 ```bash
 bashunit tests/                                # everything
-bashunit --filter "writes the header" tests/   # one test, by name
+bashunit --filter "add two positive" tests/    # one test, by name
 bashunit --rerun-failed tests/                 # only what failed last run
 bashunit --failures-only --no-progress tests/  # quiet output for a transcript
 bashunit --report-json out.json tests/         # structured results to parse
 ```
 
-Work the cycle: run once, then loop on `--rerun-failed` until nothing fails. Do not
-re-run the whole suite after every edit.
+Run once, then loop on `--rerun-failed` until nothing fails. Do not re-run the whole
+suite after every edit. Exit code is 0 only when everything passed.
 
-Exit code is 0 only when everything passed.
+## The namespace rule
+
+**`assert_*` is bare. Every helper needs the `bashunit::` prefix.** The unprefixed name
+is not an alias — it is a runtime failure, and it is the single most common mistake:
+
+```bash
+d="$(bashunit::temp_dir)"       # correct   | temp_dir        -> command not found
+f="$(bashunit::temp_file)"      # correct   | temp_file       -> command not found
+bashunit::spy send_email        # correct   | spy             -> command not found
+bashunit::mock date echo "x"    # correct   | mock            -> command not found
+bashunit::skip "reason"         # correct   | skip            -> command not found
+bashunit::set_test_title "..."  # correct   | set_test_title  -> command not found
+bashunit::log "msg"             # correct   | log             -> on macOS this silently
+                                #           |                    runs /usr/bin/log
+```
+
+Use `$(bashunit::temp_file)` / `$(bashunit::temp_dir)` for all scratch paths: they are
+cleaned up automatically and are safe under `--parallel`.
 
 ## Assertions
 
-There are 66. `bashunit doc <filter>` prints them locally; the catalogue is at
+There are 66. `bashunit doc <filter>` lists them locally; the catalogue is at
 https://bashunit.com/assertions. **Do not invent names** — a wrong name is a runtime
 error, not a failed assertion.
 
-The ones worth memorising:
-
-- Equality: `assert_same` (exact), `assert_equals` (normalizing), `assert_not_same`
+- Equality: `assert_same`, `assert_not_same`, `assert_equals`, `assert_not_equals`
 - Strings: `assert_contains`, `assert_not_contains`, `assert_matches`,
   `assert_string_starts_with`, `assert_string_ends_with`, `assert_empty`, `assert_not_empty`
 - Numbers: `assert_greater_than`, `assert_less_than`, `assert_within_delta`
@@ -65,12 +99,14 @@ The ones worth memorising:
 - JSON: `assert_json_equals`, `assert_json_contains`, `assert_json_key_exists`
 - Snapshots: `assert_match_snapshot`
 
-Prefer `assert_same` over `assert_equals` unless you specifically want normalization.
+`assert_same` compares exactly. `assert_equals` first strips ANSI colour codes, tabs and
+newlines — useful for asserting on coloured CLI output, misleading everywhere else.
+**Default to `assert_same`**; reach for `assert_equals` only when you mean to ignore
+formatting.
 
 ## Traps that produce silently-passing tests
 
-**Exit-code assertions take the code as the third argument.** This is the single most
-common mistake:
+**Exit-code assertions take the code as the third argument:**
 
 ```bash
 local ec=0
@@ -80,59 +116,48 @@ assert_general_error "" "" "$ec"     # correct
 assert_general_error "$ec"           # WRONG — $1 is ignored, $? is read instead
 ```
 
-With no arguments they read `$?` directly, which only works immediately after the
-command.
+With no arguments they read `$?`, which only works immediately after the command.
 
-**Capture exit codes before asserting.** Under `--strict` (or a caller's `set -e`) a
-failing command ends the test before your assertion runs:
+**Capture exit codes; never let a failing command run bare.** Under `--strict` (or a
+caller's `set -e`) it ends the test before your assertion runs:
 
 ```bash
 local ec=0
-failing_command || ec=$?      # correct
+failing_command || ec=$?            # correct
 local out; out=$(failing_command)   # WRONG under set -e
 ```
 
-**A test with no assertions passes.** Always assert something. Run
-`bashunit --fail-on-risky tests/` to turn that into a failure.
-
-**Helpers and doubles are namespaced; assertions are not.** `assert_*` is called bare,
-but every helper needs the `bashunit::` prefix. The bare form is not an alias — it is a
-`command not found` at runtime:
-
-```bash
-d="$(bashunit::temp_dir)"    # correct
-d="$(temp_dir)"              # WRONG — command not found
-bashunit::spy send_email     # correct
-spy send_email               # WRONG — command not found
-```
-
-**Use `$(bashunit::temp_file)` and `$(bashunit::temp_dir)`** for scratch paths. They are
-cleaned up automatically and are safe under `--parallel`.
+**A test with no assertions passes.** Always assert something; `--fail-on-risky` turns
+that into a failure.
 
 **Do not delete shared fixtures in `tear_down_after_script`.** Under `--parallel` that
-file's tests may still be running; they crash and disappear from the totals without
-reporting a failure.
+file's tests may still be running; they crash and vanish from the totals without
+reporting a failure. Create per-test fixtures with `bashunit::temp_dir` instead and add
+no teardown.
 
-**No network calls.** Mock the command instead.
+**No network calls.** Mock the command.
 
 ## Test doubles
 
 ```bash
 bashunit::mock date echo "2024-05-01"   # replace behaviour
+bashunit::mock uname <<< "Linux"        # heredoc form ignores the call's arguments
 bashunit::spy send_email                # record calls, keep behaviour
 
 assert_have_been_called send_email
-assert_have_been_called_times 2 send_email          # count first, then spy
-assert_have_been_called_with send_email "--to a@b.c"  # spy first, then expected
+assert_have_been_called_times 2 send_email               # count FIRST, then spy
+assert_have_been_called_with send_email "--to a@b.c"     # spy FIRST, then expected
 assert_have_been_called_with send_email "--to a@b.c" 1   # ...of call #1
 assert_have_been_called_nth_with 1 send_email "--to a@b.c"
 ```
 
-The argument order is **not** consistent between these: `_times` takes the count first,
-`_with` takes the spy first. Getting it backwards produces a failed assertion, not an
-error, so check it against this list rather than guessing.
+The argument order is inconsistent between `_times` and `_with`. A swapped pair *fails
+the assertion* rather than erroring, so it reads like a real defect — check this list
+rather than guessing.
 
 ## Data providers
+
+Each line of the provider becomes one run, split on whitespace into `$1`, `$2`, …:
 
 ```bash
 function data_provider_sums() {
@@ -146,6 +171,26 @@ function test_add() {
 }
 ```
 
+## Selecting and annotating tests
+
+```bash
+# @tag slow
+function test_heavy_computation() { ...; }
+```
+
+```bash
+bashunit tests/ --tag slow            # only tagged tests (repeatable, OR)
+bashunit tests/ --exclude-tag slow    # everything else (exclusion wins)
+```
+
+Inside a test:
+
+```bash
+bashunit::skip "not supported on this platform" && return   # conditional skip
+bashunit::todo "needs a fixture for the error path"         # mark incomplete
+bashunit::set_test_title "handles a malformed header"       # display name only
+```
+
 ## Portability
 
 bashunit runs on Bash 3.0+, including the bash 3.2 that ships with macOS. If the code
@@ -156,7 +201,7 @@ in both the code and the tests.
 
 ```bash
 bashunit --fail-on-risky tests/   # assertion-free tests fail
-bashunit --random-order tests/    # catches order dependence
+bashunit --random-order tests/    # catches order dependence (--seed N to reproduce)
 bashunit --strict tests/          # set -euo pipefail
 bashunit --parallel tests/        # catches shared-state leaks
 ```

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -18,7 +18,7 @@ Files end in `_test.sh`, functions start with `test_`:
 #!/usr/bin/env bash
 
 function set_up() {           # before each test (optional)
-  TARGET_DIR="$(temp_dir)"
+  TARGET_DIR="$(bashunit::temp_dir)"
 }
 
 function test_it_writes_the_header() {
@@ -95,8 +95,19 @@ local out; out=$(failing_command)   # WRONG under set -e
 **A test with no assertions passes.** Always assert something. Run
 `bashunit --fail-on-risky tests/` to turn that into a failure.
 
-**Use `$(temp_file)` and `$(temp_dir)`** for scratch paths. They are cleaned up
-automatically and are safe under `--parallel`.
+**Helpers and doubles are namespaced; assertions are not.** `assert_*` is called bare,
+but every helper needs the `bashunit::` prefix. The bare form is not an alias — it is a
+`command not found` at runtime:
+
+```bash
+d="$(bashunit::temp_dir)"    # correct
+d="$(temp_dir)"              # WRONG — command not found
+bashunit::spy send_email     # correct
+spy send_email               # WRONG — command not found
+```
+
+**Use `$(bashunit::temp_file)` and `$(bashunit::temp_dir)`** for scratch paths. They are
+cleaned up automatically and are safe under `--parallel`.
 
 **Do not delete shared fixtures in `tear_down_after_script`.** Under `--parallel` that
 file's tests may still be running; they crash and disappear from the totals without
@@ -107,11 +118,19 @@ reporting a failure.
 ## Test doubles
 
 ```bash
-mock curl echo "fixed response"      # replace behaviour
-spy send_email                       # record calls, keep behaviour
-assert_have_been_called_times 2 send_email
-assert_have_been_called_with "--to a@b.c" send_email
+bashunit::mock date echo "2024-05-01"   # replace behaviour
+bashunit::spy send_email                # record calls, keep behaviour
+
+assert_have_been_called send_email
+assert_have_been_called_times 2 send_email          # count first, then spy
+assert_have_been_called_with send_email "--to a@b.c"  # spy first, then expected
+assert_have_been_called_with send_email "--to a@b.c" 1   # ...of call #1
+assert_have_been_called_nth_with 1 send_email "--to a@b.c"
 ```
+
+The argument order is **not** consistent between these: `_times` takes the count first,
+`_with` takes the spy first. Getting it backwards produces a failed assertion, not an
+error, so check it against this list rather than guessing.
 
 ## Data providers
 

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -53,14 +53,26 @@ Lifecycle hooks: `set_up_before_script` (once per file), `set_up` (per test),
 
 ```bash
 bashunit tests/                                # everything
-bashunit --filter "add two positive" tests/    # one test, by name
+bashunit --filter add_two_positive tests/      # one test — matches the FUNCTION name
 bashunit --rerun-failed tests/                 # only what failed last run
 bashunit --failures-only --no-progress tests/  # quiet output for a transcript
 bashunit --report-json out.json tests/         # structured results to parse
 ```
 
 Run once, then loop on `--rerun-failed` until nothing fails. Do not re-run the whole
-suite after every edit. Exit code is 0 only when everything passed.
+suite after every edit.
+
+`--rerun-failed` reads `.bashunit/last-failed` (add it to `.gitignore`). When that cache
+is empty it falls back to running everything — so the run that suddenly grows back to
+the full suite is the signal you are green, not a bug.
+
+`--filter` matches the **function name** (`test_add_two_positive_numbers`), not the
+humanized title in the report, so a filter containing spaces silently matches nothing
+and reports `0 total`.
+
+**A `0` exit code does not mean everything passed.** It means nothing *failed*: a run
+that is entirely skipped, incomplete or risky still exits `0`. Check the counts in
+`--report-json`, or add `--fail-on-risky`.
 
 ## The namespace rule
 
@@ -83,9 +95,9 @@ cleaned up automatically and are safe under `--parallel`.
 
 ## Assertions
 
-There are 66. `bashunit doc <filter>` lists them locally; the catalogue is at
-https://bashunit.com/assertions. **Do not invent names** — a wrong name is a runtime
-error, not a failed assertion.
+`bashunit doc` prints the full catalogue (64 assertions) locally; `bashunit doc contains`
+filters it. The same list is at https://bashunit.com/assertions. **Do not invent names**
+— a wrong name is a runtime error, not a failed assertion.
 
 - Equality: `assert_same`, `assert_not_same`, `assert_equals`, `assert_not_equals`
 - Strings: `assert_contains`, `assert_not_contains`, `assert_matches`,

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -27,6 +27,8 @@
 - [Code coverage](https://bashunit.com/coverage): Measure how much of your bash scripts your tests exercise.
 - [Benchmarks](https://bashunit.com/benchmarks): Measure script execution time and find performance bottlenecks.
 - [Standalone](https://bashunit.com/standalone): Use assertions outside test files for integration and end-to-end checks.
+- [Agentic coding](https://bashunit.com/ai-agents): Machine-readable results, fast feedback loops, and the API traps that make AI-written bash tests pass for the wrong reason.
+- [Agent skill (SKILL.md)](https://bashunit.com/bashunit-skill.md): Drop-in skill file teaching an agent to write and run bashunit tests correctly.
 
 ## More
 

--- a/docs/test-files.md
+++ b/docs/test-files.md
@@ -42,12 +42,12 @@ You're free to use any of Bash's syntax options to define these functions.
 ## Custom test titles
 
 By default, **bashunit** derives the name shown in reports from the test function name.
-If you need a more descriptive title, you can override it inside the test using `set_test_title`:
+If you need a more descriptive title, you can override it inside the test using `bashunit::set_test_title`:
 
 ::: code-group
 ```bash [Example]
 function test_handles_invalid_input() {
-  set_test_title "🔥 handles custom test names 🚀"
+  bashunit::set_test_title "🔥 handles custom test names 🚀"
   # test logic...
 }
 ```


### PR DESCRIPTION
## 🤔 Background

bashunit already publishes `llms.txt` and `llms-full.txt`, but nothing on the site linked to either, so neither a human nor an agent could discover them. There was also no guidance for the fastest-growing way people write bash tests today — with a coding agent.

Writing that guidance surfaced a second problem: the `bashunit::` namespace was documented incorrectly in four places, including the repo's own agent rules. Bare helper names are not aliases — they are `command not found`, except `log`, which on macOS silently runs Apple's `/usr/bin/log`.

## 💡 Changes

- Adds an **Agentic coding** page: structured results (`--report-json`, `--output tap`), the flags that keep an agent's edit-run loop tight (`--filter`, `--rerun-failed`, `--test-timeout`), a copy-pasteable `AGENTS.md` block, and the traps that make generated tests pass for the wrong reason.
- Ships a drop-in skill at `/bashunit-skill.md`, curl-able into `.claude/skills/`. It covers loading the code under test, the assertion catalogue, doubles, data providers, tags/skip/todo, and self-verification. Every example is backed by a test file that runs green.
- Corrects the namespace in `.claude/rules/testing.md` (bare `temp_file`/`temp_dir`/`mock`/`spy`, plus reversed `assert_have_been_called_with` arguments), `configuration.md` (bare `log`) and `test-files.md` (bare `set_test_title`, which exits 127).
- Site: excludes `public/**/*.md` from page discovery — VitePress was rendering the skill a second time at `/public/bashunit-skill` and putting that duplicate URL in the sitemap — and drops `chart.js`, unused since the downloads chart was removed in 0.40.