### PR TITLE
docs: complete the assertion catalogue and make the reference navigable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@
 - Per-line execution hit counts in the text report: `BASHUNIT_COVERAGE_SHOW_LINE_HITS=true` prints a `Line Hits` block listing each covered line as `<lineno>:<count>` per file. The LCOV report already carried the same counts in its `DA:<line>,<count>` records; those are now pinned by tests (#856)
 
 ### Changed
+- `bashunit doc` and the [Assertions](https://bashunit.com/assertions) reference now cover all 71 assertions instead of 64. The two snapshot assertions and all five spy assertions were documented only on their own pages, so `bashunit doc` — the command the docs tell agents to use so they do not invent names — listed no spy assertion at all
+- The [Assertions](https://bashunit.com/assertions) page opens with a grouped quick-reference table linking every assertion, instead of running straight into the first entry of a 1,700-line catalogue
+- The docs sidebar outline now lists `h3` headings as well as `h2`. Per-flag and per-pattern detail lives at `h3` (27 headings on Command line, 24 on Common patterns, 23 on Coverage) and was hidden from the "On this page" navigation
 - The `--parallel` unsupported-OS warning no longer claims Alpine is excluded: Alpine has been a supported parallel platform since the race conditions were fixed, the message was simply never updated
 
 ### Fixed
+- The quickstart's sample output showed durations as `16 ms` / `90 ms`; bashunit prints `16ms` / `90ms`
 - `.env.example` documented `BASHUNIT_SHOW_EXECUTION_TIME` as defaulting to `true`; the actual default has been `auto` since #765
 - bashunit now aborts with an actionable error when its scratch directories under `TMPDIR` cannot be created. Previously the run continued with every failure/skip collector writing nowhere, so a failing suite still exited non-zero but lost its assertion detail and leaked raw `src/runner.sh: line N: ...: Not a directory` errors instead of reporting the cause
 - A test file whose `set_up_before_script` changes directory no longer silently drops the remaining files from the run when the original working directory has become unreachable; the run aborts with a clear error instead

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -100,6 +100,13 @@ export default defineConfig({
     externalLinkIcon: true,
     siteTitle: false,
 
+    // Reference pages carry their per-flag and per-pattern detail at H3 (27 of them on
+    // command-line, 24 on common-patterns, 23 on coverage). The VitePress default of
+    // H2-only hides exactly the headings people navigate to. Must live under
+    // themeConfig: the outline is read as `frontmatter.outline ?? theme.outline`,
+    // so a top-level `outline` is silently ignored.
+    outline: [2, 3],
+
     editLink: {
       pattern: 'https://github.com/TypedDevs/bashunit/edit/main/docs/:path'
     },

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -161,3 +161,10 @@ bashunit --coverage --coverage-report coverage/lcov.info tests/
 Use it to answer "did the agent test the branch it just changed", not as a target to
 optimize — see [Coverage](/coverage). `--coverage-min <n>` fails the run below a
 threshold if you want it enforced.
+
+## Related
+
+- [Command line](/command-line) — every flag referenced above
+- [Assertions](/assertions) — the catalogue agents should pick names from
+- [Test doubles](/test-doubles) — mocking the network and other side effects
+- [Configuration](/configuration) — set these flags once via `.bashunitrc`

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -8,6 +8,30 @@ When creating tests, you'll need to verify your commands and functions.
 We provide assertions for these checks.
 Below is their documentation.
 
+Assertions are called **unprefixed** — `assert_same`, not `bashunit::assert_same`. Every
+other helper does take the `bashunit::` prefix; see [Globals](/globals).
+
+Run `bashunit doc` to print this catalogue in your terminal, or `bashunit doc <filter>`
+to narrow it (`bashunit doc json`).
+
+## Quick reference
+
+| Group | Assertions |
+|-------|------------|
+| **Booleans and equality** | [assert_true](#assert-true) · [assert_false](#assert-false) · [assert_same](#assert-same) · [assert_not_same](#assert-not-same) · [assert_equals](#assert-equals) · [assert_not_equals](#assert-not-equals) |
+| **Strings** | [assert_contains](#assert-contains) · [assert_not_contains](#assert-not-contains) · [assert_contains_ignore_case](#assert-contains-ignore-case) · [assert_matches](#assert-matches) · [assert_not_matches](#assert-not-matches) · [assert_string_starts_with](#assert-string-starts-with) · [assert_string_not_starts_with](#assert-string-not-starts-with) · [assert_string_ends_with](#assert-string-ends-with) · [assert_string_not_ends_with](#assert-string-not-ends-with) · [assert_string_matches_format](#assert-string-matches-format) · [assert_string_not_matches_format](#assert-string-not-matches-format) · [assert_empty](#assert-empty) · [assert_not_empty](#assert-not-empty) · [assert_line_count](#assert-line-count) |
+| **Numbers** | [assert_less_than](#assert-less-than) · [assert_less_or_equal_than](#assert-less-or-equal-than) · [assert_greater_than](#assert-greater-than) · [assert_greater_or_equal_than](#assert-greater-or-equal-than) · [assert_within_delta](#assert-within-delta) |
+| **Dates** | [assert_date_equals](#assert-date-equals) · [assert_date_before](#assert-date-before) · [assert_date_after](#assert-date-after) · [assert_date_within_range](#assert-date-within-range) · [assert_date_within_delta](#assert-date-within-delta) |
+| **Exit codes and commands** | [assert_exit_code](#assert-exit-code) · [assert_successful_code](#assert-successful-code) · [assert_unsuccessful_code](#assert-unsuccessful-code) · [assert_general_error](#assert-general-error) · [assert_command_not_found](#assert-command-not-found) · [assert_exec](#assert-exec) |
+| **Files** | [assert_file_exists](#assert-file-exists) · [assert_file_not_exists](#assert-file-not-exists) · [assert_file_contains](#assert-file-contains) · [assert_file_not_contains](#assert-file-not-contains) · [assert_is_file](#assert-is-file) · [assert_is_file_empty](#assert-is-file-empty) · [assert_file_permissions](#assert-file-permissions) · [assert_files_equals](#assert-files-equals) · [assert_files_not_equals](#assert-files-not-equals) |
+| **Directories** | [assert_directory_exists](#assert-directory-exists) · [assert_directory_not_exists](#assert-directory-not-exists) · [assert_is_directory](#assert-is-directory) · [assert_is_directory_empty](#assert-is-directory-empty) · [assert_is_directory_not_empty](#assert-is-directory-not-empty) · [assert_is_directory_readable](#assert-is-directory-readable) · [assert_is_directory_not_readable](#assert-is-directory-not-readable) · [assert_is_directory_writable](#assert-is-directory-writable) · [assert_is_directory_not_writable](#assert-is-directory-not-writable) |
+| **Arrays** | [assert_arrays_equal](#assert-arrays-equal) · [assert_array_contains](#assert-array-contains) · [assert_array_not_contains](#assert-array-not-contains) · [assert_array_length](#assert-array-length) |
+| **JSON** | [assert_json_equals](#assert-json-equals) · [assert_json_contains](#assert-json-contains) · [assert_json_key_exists](#assert-json-key-exists) |
+| **Duration** | [assert_duration](#assert-duration) · [assert_duration_less_than](#assert-duration-less-than) · [assert_duration_greater_than](#assert-duration-greater-than) |
+| **Snapshots** | [assert_match_snapshot](#assert-match-snapshot) · [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors) |
+| **Spies** | [assert_have_been_called](#assert-have-been-called) · [assert_not_called](#assert-not-called) · [assert_have_been_called_with](#assert-have-been-called-with) · [assert_have_been_called_nth_with](#assert-have-been-called-nth-with) · [assert_have_been_called_times](#assert-have-been-called-times) |
+| **Manual failure** | [bashunit::fail](#bashunit-fail) |
+
 ## assert_true
 > `assert_true bool|function|command`
 
@@ -1566,6 +1590,160 @@ function test_success() {
 
 function test_failure() {
   assert_duration_greater_than "echo hello" 5000
+}
+```
+:::
+
+## assert_match_snapshot
+> `assert_match_snapshot "actual" ["snapshot_file"]`
+
+Reports an error if `actual` differs from the stored snapshot. On the first run no snapshot exists, so one is written from `actual` and the assertion passes — review and commit that file.
+
+Pass `snapshot_file` to share one snapshot between tests; by default each test gets its own, named after the test function.
+
+See [Snapshots](/snapshots) for the full workflow, including how to update a snapshot after an intentional change.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot "$(./bin/render --help)"
+}
+
+function test_failure() {
+  assert_match_snapshot "output that no longer matches the stored snapshot"
+}
+```
+:::
+
+## assert_match_snapshot_ignore_colors
+> `assert_match_snapshot_ignore_colors "actual" ["snapshot_file"]`
+
+Same as [assert_match_snapshot](#assert-match-snapshot), but strips ANSI escape sequences from `actual` before comparing. Use it for commands whose colouring depends on the terminal.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_match_snapshot_ignore_colors "$(./bin/render --help)"
+}
+
+function test_failure() {
+  assert_match_snapshot_ignore_colors "output that no longer matches the stored snapshot"
+}
+```
+:::
+
+## assert_have_been_called
+> `assert_have_been_called "command"`
+
+Reports an error if the spied `command` was never called. Requires `bashunit::spy command` first — see [Test doubles](/test-doubles).
+
+::: code-group
+```bash [Example]
+function test_success() {
+  bashunit::spy send_email
+  notify_user
+
+  assert_have_been_called send_email
+}
+
+function test_failure() {
+  bashunit::spy send_email
+
+  assert_have_been_called send_email
+}
+```
+:::
+
+## assert_have_been_called_with
+> `assert_have_been_called_with "command" "expected_args" [nth]`
+
+Reports an error if the spied `command` was not called with `expected_args`. Checks the **last** call unless a trailing all-digits `nth` selects a specific one.
+
+Note the argument order: the spy comes first here, but *second* in [assert_have_been_called_times](#assert-have-been-called-times).
+
+::: code-group
+```bash [Example]
+function test_success() {
+  bashunit::spy send_email
+  notify_user "a@b.c"
+
+  assert_have_been_called_with send_email "--to a@b.c"
+}
+
+function test_failure() {
+  bashunit::spy send_email
+  notify_user "a@b.c"
+
+  assert_have_been_called_with send_email "--to nobody@example.com"
+}
+```
+:::
+
+## assert_have_been_called_times
+> `assert_have_been_called_times "expected_count" "command"`
+
+Reports an error if the spied `command` was not called exactly `expected_count` times. The count comes **first**, the spy second.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  bashunit::spy send_email
+  notify_all "a@b.c" "d@e.f"
+
+  assert_have_been_called_times 2 send_email
+}
+
+function test_failure() {
+  bashunit::spy send_email
+  notify_all "a@b.c" "d@e.f"
+
+  assert_have_been_called_times 1 send_email
+}
+```
+:::
+
+## assert_have_been_called_nth_with
+> `assert_have_been_called_nth_with "nth" "command" "expected_args"`
+
+Reports an error if call number `nth` of the spied `command` did not receive `expected_args`. Calls are numbered from 1.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  bashunit::spy send_email
+  notify_all "a@b.c" "d@e.f"
+
+  assert_have_been_called_nth_with 1 send_email "--to a@b.c"
+}
+
+function test_failure() {
+  bashunit::spy send_email
+  notify_all "a@b.c" "d@e.f"
+
+  assert_have_been_called_nth_with 1 send_email "--to d@e.f"
+}
+```
+:::
+
+## assert_not_called
+> `assert_not_called "command"`
+
+Reports an error if the spied `command` was called at all. The inverse of [assert_have_been_called](#assert-have-been-called).
+
+::: code-group
+```bash [Example]
+function test_success() {
+  bashunit::spy send_email
+  notify_user --dry-run
+
+  assert_not_called send_email
+}
+
+function test_failure() {
+  bashunit::spy send_email
+  notify_user
+
+  assert_not_called send_email
 }
 ```
 :::

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -95,7 +95,7 @@ cleaned up automatically and are safe under `--parallel`.
 
 ## Assertions
 
-`bashunit doc` prints the full catalogue (64 assertions) locally; `bashunit doc contains`
+`bashunit doc` prints the full catalogue (71 assertions) locally; `bashunit doc contains`
 filters it. The same list is at https://bashunit.com/assertions. **Do not invent names**
 — a wrong name is a runtime error, not a failed assertion.
 
@@ -109,7 +109,9 @@ filters it. The same list is at https://bashunit.com/assertions. **Do not invent
   `assert_directory_exists`, `assert_file_permissions`
 - Arrays: `assert_array_contains`, `assert_array_length`, `assert_arrays_equal`
 - JSON: `assert_json_equals`, `assert_json_contains`, `assert_json_key_exists`
-- Snapshots: `assert_match_snapshot`
+- Snapshots: `assert_match_snapshot`, `assert_match_snapshot_ignore_colors`
+- Spies: `assert_have_been_called`, `assert_not_called`, `assert_have_been_called_with`,
+  `assert_have_been_called_times`, `assert_have_been_called_nth_with`
 
 `assert_same` compares exactly. `assert_equals` first strips ANSI colour codes, tabs and
 newlines — useful for asserting on coloured CLI output, misleading everywhere else.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -84,13 +84,13 @@ Alternatively, create your tests manually:
     ```-vue
     bashunit - {{ pkg.version }} | Tests: 1
     Running tests/example_test.sh
-    ✓ Passed: Bashunit is working                                         16 ms
+    ✓ Passed: Bashunit is working                                          16ms
 
     Tests:      1 passed, 1 total
     Assertions: 1 passed, 1 total
 
     All tests passed
-    Time taken: 90 ms
+    Time taken: 90ms
     ```
 
 5.  Now you can start testing the functionalities of your own Bash scripts.

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -617,6 +617,61 @@ Reports an error if `command` takes `threshold_ms` milliseconds or more to execu
 Reports an error if `command` completes in `threshold_ms` milliseconds or less. Useful for verifying that a command takes at least a minimum amount of time.
 
 
+## assert_match_snapshot
+--------------
+> `assert_match_snapshot "actual" "snapshot_file"`
+
+Reports an error if `actual` differs from the stored snapshot. On the first run no snapshot exists, so one is written from `actual` and the assertion passes — review and commit that file.
+
+Pass `snapshot_file` to share one snapshot between tests; by default each test gets its own, named after the test function.
+
+See Snapshots(/snapshots) for the full workflow, including how to update a snapshot after an intentional change.
+
+
+## assert_match_snapshot_ignore_colors
+--------------
+> `assert_match_snapshot_ignore_colors "actual" "snapshot_file"`
+
+Same as assert_match_snapshot, but strips ANSI escape sequences from `actual` before comparing. Use it for commands whose colouring depends on the terminal.
+
+
+## assert_have_been_called
+--------------
+> `assert_have_been_called "command"`
+
+Reports an error if the spied `command` was never called. Requires `bashunit::spy command` first — see Test doubles(/test-doubles).
+
+
+## assert_have_been_called_with
+--------------
+> `assert_have_been_called_with "command" "expected_args" nth`
+
+Reports an error if the spied `command` was not called with `expected_args`. Checks the **last** call unless a trailing all-digits `nth` selects a specific one.
+
+Note the argument order: the spy comes first here, but *second* in assert_have_been_called_times.
+
+
+## assert_have_been_called_times
+--------------
+> `assert_have_been_called_times "expected_count" "command"`
+
+Reports an error if the spied `command` was not called exactly `expected_count` times. The count comes **first**, the spy second.
+
+
+## assert_have_been_called_nth_with
+--------------
+> `assert_have_been_called_nth_with "nth" "command" "expected_args"`
+
+Reports an error if call number `nth` of the spied `command` did not receive `expected_args`. Calls are numbered from 1.
+
+
+## assert_not_called
+--------------
+> `assert_not_called "command"`
+
+Reports an error if the spied `command` was called at all. The inverse of assert_have_been_called.
+
+
 ## bashunit::fail
 --------------
 > `bashunit::fail "failure message"`


### PR DESCRIPTION
## 🤔 Background

`bashunit doc` reads `docs/assertions.md` and nothing else, so the two snapshot
assertions and all five spy assertions — documented only on their own pages — were
missing from both the reference page and the command. The docs tell agents to run
`bashunit doc` so they don't invent assertion names, and it listed no spy assertion
at all.

Found while auditing every docs page for accuracy and consultability.

## 💡 Changes

- Add the 7 missing assertion entries; `bashunit doc` now lists 71, matching `src/`
- Open the Assertions page with a grouped quick-reference table — all 72 anchors verified against the built HTML
- Move `outline` under `themeConfig` so `h3` headings reach the sidebar; it is read as `frontmatter.outline ?? theme.outline`, so the top-level key is silently ignored
- Fix the quickstart's `16 ms` sample output; the real format is `16ms`