### PR TITLE
feat(snapshot): add --snapshot-update to re-record snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `--snapshot-update` / `BASHUNIT_SNAPSHOT_UPDATE=true` re-records existing snapshots (combine with `--filter`); snapshots holding a placeholder are left alone (#900)
 - `bashunit::mock <cmd> <code>`: a lone all-digits argument is an exit code, matching `bashunit::spy`; no throwaway `return 1` helper needed (#898)
 - `assert_have_been_called_with_any <spy> <expected>`: passes when *any* recorded call matches, instead of only the last one (#897)
 - A failed call assertion now prints the calls recorded for that spy, capped at 10 with an explicit `… and N more` (#896)

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -83,6 +83,7 @@ _bashunit() {
     '--seed[Seed for random order]:seed:' \
     '--shard[Run shard i of n]:shard:' \
     '--rerun-failed[Replay only the tests that failed on the last run]' \
+    '--snapshot-update[Rewrite existing snapshots from the actual value]' \
     '(-vvv --verbose)'{-vvv,--verbose}'[Show execution details]' \
     '--debug[Enable shell debug mode]::file:_files' \
     '--no-output[Suppress all output]' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -18,7 +18,8 @@ _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --coverage --coverage-exclude \
 --no-progress --output --parallel --profile --random-order --report-html \
 --report-json --report-junit --report-tap --rerun-failed --retry --run-all \
 --seed --shard --show-incomplete --show-output --show-skipped --simple \
---skip-env-file --stop-on-failure --strict --tag --test-timeout --verbose \
+--skip-env-file --snapshot-update --stop-on-failure --strict --tag \
+--test-timeout --verbose \
 --watch -R -S -a -e -f -h -j -l -p -r -s -vvv -w"
 
 _BASHUNIT_COMPLETIONS_ASSERT_FNS="assert_array_contains assert_array_length \

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -132,9 +132,10 @@ actually make against this API:
   argument by argument whenever an argument may contain a space.
 - Do not delete a shared fixture in `tear_down_after_script`: under `--parallel` the
   file's tests may still be running, and they will vanish from the totals silently.
-- There is no `--update-snapshots` flag. Re-record a snapshot by deleting the file and
-  re-running; the assertion writes it when missing. A missing snapshot therefore never
-  fails, so delete one only after reading the diff.
+- Re-record snapshots with `--snapshot-update`, scoped by `--filter`; do not delete
+  snapshot files. A missing snapshot is written silently and never fails, so a wrong
+  `rm` turns a real assertion into a rubber stamp. Read `git diff` afterwards either way.
+  Snapshots containing the placeholder are not rewritten — bashunit says so on stderr.
 - Assertions are listed at https://bashunit.com/assertions — do not invent names.
   `bashunit doc <filter>` prints them locally.
 ```

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -83,6 +83,7 @@ bashunit test tests/ --parallel --simple
 | `--seed <n>`                   | Seed for `--random-order` (reproducible shuffle) |
 | `--shard <i>/<n>`              | Run shard i of n (split suite across runners)    |
 | `--rerun-failed`               | Replay only the tests that failed on the last run |
+| `--snapshot-update`            | Rewrite existing snapshots from the actual value |
 | `--show-skipped`               | Show skipped tests summary at end                |
 | `--show-incomplete`            | Show incomplete tests summary at end             |
 | `-vvv, --verbose`              | Show execution details                           |
@@ -567,6 +568,35 @@ steps:
   - run: ./bashunit tests/ --shard ${{ matrix.shard }}/4
 ```
 :::
+
+### Snapshot update
+
+> `bashunit test --snapshot-update`
+
+Re-record snapshots: every `assert_match_snapshot` /
+`assert_match_snapshot_ignore_colors` whose snapshot already exists is
+overwritten with the value this run produced, and reported as a recorded
+snapshot instead of a pass. A missing snapshot is written as usual.
+
+Use it when an output change is deliberate. It replaces deleting snapshot files
+by hand — the path is derived from the test file and function name, so a wrong
+`rm` is easy and silent: a deleted snapshot is re-recorded on the next run and
+never fails.
+
+Scope it with `--filter` to re-record a single test:
+
+```bash
+./bashunit --snapshot-update --filter "renders the header" tests/
+```
+
+Notes:
+
+- A snapshot containing the placeholder (`::ignore::`, or
+  `BASHUNIT_SNAPSHOT_PLACEHOLDER`) is **not** overwritten — the placeholder
+  marks output the author chose not to pin, and rewriting would silently drop
+  it. bashunit says so on stderr and compares as usual.
+- Review the diff afterwards: this rewrites files, so `git diff` is what tells
+  you the new output is the output you meant.
 
 ### Rerun failed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,27 @@ BASHUNIT_RANDOM_ORDER=false
 ```
 :::
 
+## Snapshot update
+
+> `BASHUNIT_SNAPSHOT_UPDATE=true|false`
+
+Rewrite existing snapshots with the value each run produces instead of comparing
+against them. Disabled by default. Snapshots holding the placeholder are left
+alone. Because it writes to disk, prefer the flag for a one-off re-record and
+keep this off in a committed `.env`.
+
+Similar as using `--snapshot-update` option on the
+[command line](/command-line#snapshot-update).
+
+::: code-group
+```bash [Re-record snapshots]
+BASHUNIT_SNAPSHOT_UPDATE=true
+```
+```bash [Disabled (default)]
+BASHUNIT_SNAPSHOT_UPDATE=false
+```
+:::
+
 ## Rerun failed
 
 > `BASHUNIT_RERUN_FAILED=true|false`

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -186,10 +186,11 @@ file's tests may still be running; they crash and vanish from the totals without
 reporting a failure. Create per-test fixtures with `bashunit::temp_dir` instead and add
 no teardown.
 
-**There is no `--update-snapshots` flag.** To re-record a snapshot, delete the file and
-run the test again — the assertion writes the snapshot when it is missing and passes.
-Which also means a *deleted* snapshot never fails: delete only when you have read the
-diff and decided the new output is correct.
+**Re-record snapshots with `--snapshot-update`** (scope it: `--snapshot-update --filter
+"my test"`), never by deleting snapshot files. A missing snapshot is written silently and
+passes, so a wrong `rm` converts a real assertion into a rubber stamp with no error. Read
+`git diff` after re-recording. A snapshot containing the placeholder is left alone and
+reported on stderr, because rewriting it would drop the part the author chose not to pin.
 
 **No network calls.** Mock the command.
 

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -91,6 +91,26 @@ echo 'Run at ::ignore::' > snapshots/example.snapshot
 assert_match_snapshot "Run at $(date)"
 ```
 
+## Re-recording snapshots
+
+When an output change is intentional, run with `--snapshot-update` (or
+`BASHUNIT_SNAPSHOT_UPDATE=true`) and the existing snapshots are rewritten with the value
+of that run, reported as recorded snapshots rather than passes:
+
+```bash
+./bashunit --snapshot-update tests/                            # all of them
+./bashunit --snapshot-update --filter "renders header" tests/  # just one test
+```
+
+Snapshots holding a [placeholder](#placeholders) are **not** rewritten: the placeholder
+marks output that was deliberately left unpinned, and overwriting it would replace that
+with one run's concrete value. bashunit reports those on stderr and compares as usual.
+
+Prefer this to deleting snapshot files. The snapshot path is derived from the test file
+and function name, and a missing snapshot is silently re-recorded and passes — so a `rm`
+of the wrong file turns a real assertion into one that asserts nothing. Either way, read
+`git diff` before committing the re-recorded files.
+
 ## Related
 
 - [Assertions](/assertions) — the built-in assertion reference

--- a/src/assert_snapshot.sh
+++ b/src/assert_snapshot.sh
@@ -26,6 +26,10 @@ function assert_match_snapshot() {
     return
   fi
 
+  if bashunit::snapshot::update "$snapshot_file" "$actual"; then
+    return
+  fi
+
   bashunit::snapshot::compare "$actual" "$snapshot_file" "$test_fn"
 }
 
@@ -48,6 +52,10 @@ function assert_match_snapshot_ignore_colors() {
 
   if [ ! -f "$snapshot_file" ]; then
     bashunit::snapshot::initialize "$snapshot_file" "$actual"
+    return
+  fi
+
+  if bashunit::snapshot::update "$snapshot_file" "$actual"; then
     return
   fi
 
@@ -121,6 +129,36 @@ function bashunit::snapshot::initialize() {
   mkdir -p "$(dirname "$path")"
   echo "$content" >"$path"
   bashunit::state::add_assertions_snapshot
+}
+
+# Under --snapshot-update, rewrites $1 with the actual value $2 and counts it as
+# a recorded snapshot. Returns 1 when the caller must fall back to a normal
+# comparison: either the mode is off, or the snapshot carries a placeholder.
+#
+# A placeholder is deliberate: it marks a part of the output the author decided
+# not to pin. Overwriting would silently replace it with whatever this run
+# produced, turning a tolerant snapshot into a brittle one with no way back, so
+# such a file is left alone and the run says so on stderr.
+function bashunit::snapshot::update() {
+  local path="$1"
+  local actual="$2"
+
+  bashunit::env::is_snapshot_update_enabled || return 1
+
+  local placeholder="${BASHUNIT_SNAPSHOT_PLACEHOLDER:-::ignore::}"
+  local snapshot
+  snapshot=$(<"$path")
+  case "$snapshot" in
+  *"$placeholder"*)
+    printf "%sNot updating %s: it contains the placeholder '%s'.%s\n" \
+      "${_BASHUNIT_COLOR_SKIPPED:-}" "$path" "$placeholder" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+    return 1
+    ;;
+  esac
+
+  echo "$actual" >"$path"
+  bashunit::state::add_assertions_snapshot
+  return 0
 }
 
 function bashunit::snapshot::compare() {

--- a/src/console_header.sh
+++ b/src/console_header.sh
@@ -140,6 +140,7 @@ Options:
   --seed <n>                  Seed for --random-order (reproducible shuffle)
   --shard <i>/<n>             Run shard i of n (split the suite across runners)
   --rerun-failed              Replay only the tests that failed on the last run (.bashunit/last-failed)
+  --snapshot-update           Rewrite existing snapshots from the actual value (combine with --filter)
   -vvv, --verbose             Show execution details
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -116,7 +116,11 @@ function bashunit::console_results::render_result() {
   fi
 
   if [ "$tests_snapshot" -gt 0 ]; then
-    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_RETURN_SNAPSHOT" " Some snapshots created " "$_BASHUNIT_COLOR_DEFAULT"
+    local snapshot_notice=" Some snapshots created "
+    if bashunit::env::is_snapshot_update_enabled; then
+      snapshot_notice=" Some snapshots updated "
+    fi
+    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_RETURN_SNAPSHOT" "$snapshot_notice" "$_BASHUNIT_COLOR_DEFAULT"
     bashunit::console_results::print_execution_time
     return 0
   fi

--- a/src/env.sh
+++ b/src/env.sh
@@ -255,6 +255,8 @@ _BASHUNIT_DEFAULT_SHARD_INDEX=""
 _BASHUNIT_DEFAULT_SHARD_TOTAL=""
 # Replay only the tests recorded as failing by the previous run
 _BASHUNIT_DEFAULT_RERUN_FAILED="false"
+# Rewrite existing snapshots from the actual value instead of comparing
+_BASHUNIT_DEFAULT_SNAPSHOT_UPDATE="false"
 
 : "${BASHUNIT_PARALLEL_RUN:=${PARALLEL_RUN:=$_BASHUNIT_DEFAULT_PARALLEL_RUN}}"
 : "${BASHUNIT_PARALLEL_JOBS:=$_BASHUNIT_DEFAULT_PARALLEL_JOBS}"
@@ -295,6 +297,9 @@ _BASHUNIT_DEFAULT_RERUN_FAILED="false"
 # lives here rather than inline in rerun.sh so every BASHUNIT_* default has one
 # home; bashunit::rerun::is_enabled keeps its :- guard for callers that unset it.
 : "${BASHUNIT_RERUN_FAILED:=$_BASHUNIT_DEFAULT_RERUN_FAILED}"
+# No bare SNAPSHOT_UPDATE alias either: rewriting files on disk is the last
+# setting that should be reachable by a generic name from the environment.
+: "${BASHUNIT_SNAPSHOT_UPDATE:=$_BASHUNIT_DEFAULT_SNAPSHOT_UPDATE}"
 # Support NO_COLOR standard (https://no-color.org)
 if [ -n "${NO_COLOR:-}" ]; then
   BASHUNIT_NO_COLOR="true"
@@ -540,6 +545,10 @@ function bashunit::env::is_coverage_enabled() {
 
 function bashunit::env::is_tap_output_enabled() {
   [ "$BASHUNIT_OUTPUT_FORMAT" = "tap" ]
+}
+
+function bashunit::env::is_snapshot_update_enabled() {
+  [ "$BASHUNIT_SNAPSHOT_UPDATE" = "true" ]
 }
 
 function bashunit::env::is_fail_on_risky_enabled() {

--- a/src/main.sh
+++ b/src/main.sh
@@ -277,6 +277,10 @@ function bashunit::main::cmd_test() {
       BASHUNIT_RERUN_FAILED=true
       export -n BASHUNIT_RERUN_FAILED
       ;;
+    --snapshot-update)
+      BASHUNIT_SNAPSHOT_UPDATE=true
+      export -n BASHUNIT_SNAPSHOT_UPDATE
+      ;;
     -w | --watch)
       BASHUNIT_WATCH_MODE=true
       export -n BASHUNIT_WATCH_MODE

--- a/tests/acceptance/bashunit_snapshot_update_test.sh
+++ b/tests/acceptance/bashunit_snapshot_update_test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  BASHUNIT_BIN="$(pwd)/bashunit"
+  FIXTURES_DIR="$(pwd)/tests/acceptance/fixtures/snapshot_update"
+}
+
+function set_up() {
+  WORKDIR="$(mktemp -d)"
+  cp "$FIXTURES_DIR/snap.sh" "$WORKDIR/snap.sh"
+  cp "$FIXTURES_DIR/placeholder.sh" "$WORKDIR/placeholder.sh"
+  mkdir -p "$WORKDIR/snapshots"
+  SNAPSHOT_ALPHA="$WORKDIR/snapshots/snap_sh.test_snapshot_alpha.snapshot"
+  SNAPSHOT_BETA="$WORKDIR/snapshots/snap_sh.test_snapshot_beta.snapshot"
+  echo "stale alpha" >"$SNAPSHOT_ALPHA"
+  echo "stale beta" >"$SNAPSHOT_BETA"
+}
+
+function tear_down() {
+  rm -rf "$WORKDIR"
+}
+
+function test_snapshot_update_rewrites_the_existing_snapshot() {
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update snap.sh) >/dev/null 2>&1 || true
+
+  assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
+  assert_same "beta value" "$(cat "$SNAPSHOT_BETA")"
+}
+
+function test_snapshot_update_composes_with_filter() {
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update --filter alpha snap.sh) >/dev/null 2>&1 || true
+
+  assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
+  assert_same "stale beta" "$(cat "$SNAPSHOT_BETA")"
+}
+
+function test_snapshot_update_reports_the_rewrite_instead_of_a_pass() {
+  local output
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update snap.sh 2>&1) || true
+
+  assert_contains "Some snapshots updated" "$output"
+  assert_contains "2 snapshot" "$output"
+  assert_not_contains "2 passed" "$output"
+}
+
+function test_env_variable_updates_snapshots_too() {
+  (cd "$WORKDIR" && BASHUNIT_SNAPSHOT_UPDATE=true "$BASHUNIT_BIN" \
+    --no-parallel --skip-env-file snap.sh) >/dev/null 2>&1 || true
+
+  assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
+}
+
+function test_without_the_flag_a_stale_snapshot_still_fails() {
+  local output
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file snap.sh 2>&1) || true
+
+  assert_contains "failed" "$output"
+  assert_same "stale alpha" "$(cat "$SNAPSHOT_ALPHA")"
+}
+
+function test_a_snapshot_holding_a_placeholder_is_not_overwritten() {
+  local snapshot="$WORKDIR/snapshots/placeholder_sh.test_snapshot_with_placeholder.snapshot"
+  echo "run at ::ignore::" >"$snapshot"
+
+  local output
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update placeholder.sh 2>&1) || true
+
+  assert_same "run at ::ignore::" "$(cat "$snapshot")"
+  assert_contains "placeholder" "$output"
+}
+
+function test_snapshot_update_still_records_a_missing_snapshot() {
+  rm -f "$SNAPSHOT_ALPHA"
+
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update --filter alpha snap.sh) >/dev/null 2>&1 || true
+
+  assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
+}

--- a/tests/acceptance/fixtures/snapshot_update/placeholder.sh
+++ b/tests/acceptance/fixtures/snapshot_update/placeholder.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+function test_snapshot_with_placeholder() {
+  assert_match_snapshot "run at 12:00:00"
+}

--- a/tests/acceptance/fixtures/snapshot_update/snap.sh
+++ b/tests/acceptance/fixtures/snapshot_update/snap.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+function test_snapshot_alpha() {
+  assert_match_snapshot "alpha value"
+}
+
+function test_snapshot_beta() {
+  assert_match_snapshot "beta value"
+}


### PR DESCRIPTION
## 🤔 Background

Related #900

Re-recording a snapshot meant deleting the file and re-running, with the path derived from the test file and function name — so it had to be reconstructed by hand. A missing snapshot is silently re-recorded and passes, which makes a wrong `rm` a real assertion turned into a rubber stamp, with nothing in the output to notice.

## 💡 Changes

- Add `--snapshot-update` and `BASHUNIT_SNAPSHOT_UPDATE`: existing snapshots are rewritten from the actual value and counted as recorded snapshots, not passes; the summary reads `Some snapshots updated`.
- Composes with `--filter` to re-record a single test.
- Snapshots holding a placeholder are protected, not overwritten — rewriting would replace the deliberately-unpinned part with one run's value; those are reported on stderr and compared as usual.
- Docs (snapshots, command-line, configuration) updated, and the "there is no such flag" notes in the agentic-coding page and the agent skill now point at the flag.