### PR TITLE
fix(compat): ignore an external git differ, drop locale env prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - The `--parallel` unsupported-OS warning no longer claims Alpine is excluded
 
 ### Fixed
+- A configured external git differ (`diff.external` / `GIT_EXTERNAL_DIFF`, e.g. difftastic) no longer blanks the multiline and snapshot failure diffs, which now render with `--no-ext-diff` (#912)
+- Time reads and the JUnit report no longer set the locale with a temporary-environment prefix (`LC_ALL=C cmd`), reported to segfault inside a command substitution on Bash 5.3.9 macOS (#912)
 - Call assertions (`assert_not_called`, `assert_have_been_called*`) fail with `was never registered as a spy` instead of reporting zero calls when the name was never spied — a typo used to pass silently (#895)
 - The per-argument form a spy records was written with a literal `$'\x1f'` separator instead of the byte, so it could not be compared against (#894)
 - `--parallel` no longer discards worker stderr written outside a test body; it renders as a `Stderr from <file>` block (#864)

--- a/src/clock.sh
+++ b/src/clock.sh
@@ -182,7 +182,10 @@ function bashunit::clock::now() {
 
 function bashunit::clock::shell_time() {
   # Get time directly from the shell variable EPOCHREALTIME (Bash 5+)
-  [ -n "${EPOCHREALTIME+x}" ] && [ -n "$EPOCHREALTIME" ] && LC_ALL=C echo "$EPOCHREALTIME"
+  # No LC_ALL=C prefix: it cannot normalize the decimal separator (bash expands the
+  # value before the temp env applies, and callers accept '.' and ','), and that form
+  # was reported to segfault inside a command substitution on Bash 5.3.9 macOS (#912).
+  [ -n "${EPOCHREALTIME+x}" ] && [ -n "$EPOCHREALTIME" ] && echo "$EPOCHREALTIME"
 }
 
 function bashunit::clock::total_runtime_in_milliseconds() {

--- a/src/console_results.sh
+++ b/src/console_results.sh
@@ -312,8 +312,9 @@ function bashunit::console_results::render_diff() {
 
   # `git diff` exits non-zero when the files differ; the `|| true` keeps that
   # from tripping `set -e`/`pipefail` under --strict. `tail -n +6` drops git's
-  # header lines; `sed` indents the body.
-  git diff --no-index --word-diff "$color_flag" \
+  # header lines; `sed` indents the body. `--no-ext-diff` ignores a user's
+  # `diff.external`/`GIT_EXTERNAL_DIFF`, which would replace this word-diff.
+  git diff --no-ext-diff --no-index --word-diff "$color_flag" \
     "$expected_file" "$actual_file" 2>/dev/null |
     tail -n +6 | sed "s/^/    /" || true
 }

--- a/src/reports.sh
+++ b/src/reports.sh
@@ -102,7 +102,10 @@ function bashunit::reports::generate_junit_xml() {
   local tests_failed=$(bashunit::state::get_tests_failed)
   local time_ms=$(bashunit::clock::total_runtime_in_milliseconds)
   local time
-  time=$(LC_ALL=C awk -v ms="$time_ms" 'BEGIN {printf "%.3f", ms/1000}')
+  # `env` rather than a bare LC_ALL=C prefix (which keeps awk's radix a dot
+  # without bash changing its own locale, reported to segfault on Bash 5.3.9
+  # macOS inside a command substitution, #912).
+  time=$(env LC_ALL=C awk -v ms="$time_ms" 'BEGIN {printf "%.3f", ms/1000}')
 
   {
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
@@ -120,7 +123,7 @@ function bashunit::reports::generate_junit_xml() {
       local test_time_ms="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
       local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
       local test_time
-      test_time=$(LC_ALL=C awk -v ms="$test_time_ms" 'BEGIN {printf "%.3f", ms/1000}')
+      test_time=$(env LC_ALL=C awk -v ms="$test_time_ms" 'BEGIN {printf "%.3f", ms/1000}')
 
       echo "    <testcase file=\"$file\""
       echo "        name=\"$name\""

--- a/tests/acceptance/bashunit_syntax_error_test.sh
+++ b/tests/acceptance/bashunit_syntax_error_test.sh
@@ -10,7 +10,9 @@ function test_bashunit_when_test_file_has_syntax_error() {
 
   local actual_raw
   set +e
-  actual_raw="$(LC_ALL=C LANG=C ./bashunit \
+  # `env` rather than a bare LC_ALL=C prefix: that form was reported to segfault
+  # inside a command substitution on Bash 5.3.9 macOS (#912).
+  actual_raw="$(env LC_ALL=C LANG=C ./bashunit \
     --no-parallel --detailed --env "$TEST_ENV_FILE" "$test_file" 2>&1)"
   set -e
 
@@ -19,6 +21,6 @@ function test_bashunit_when_test_file_has_syntax_error() {
 
   assert_contains "failed" "$actual"
   assert_contains "Error" "$actual"
-  assert_general_error "$(LC_ALL=C LANG=C ./bashunit \
+  assert_general_error "$(env LC_ALL=C LANG=C ./bashunit \
     --no-parallel --env "$TEST_ENV_FILE" "$test_file" 2>&1)"
 }

--- a/tests/unit/bash_compatibility_test.sh
+++ b/tests/unit/bash_compatibility_test.sh
@@ -102,3 +102,14 @@ function test_src_has_no_coproc() {
 function test_src_has_no_parameter_transformations() {
   assert_empty "$(bashunit::compat::offenders '\$\{[A-Za-z_][A-Za-z0-9_]*@[QEPAKa]\}')"
 }
+
+# A temporary-environment locale prefix (`LC_ALL=C cmd`) makes bash change its
+# own locale for that command. Bash 5.3.9 on macOS was reported to SIGSEGV on
+# that form inside a command substitution -- `x=$(LC_ALL=C echo hi)` exits 139
+# (#912) -- and no CI job runs that build. Use `env LC_ALL=C cmd` instead, which
+# passes the locale straight to the child and never touches bash's own.
+function test_src_has_no_temporary_locale_assignment_prefix() {
+  local pattern='(^|[;&|(])[[:space:]]*((LC_[A-Z_]+|LANG)=[^[:space:]]*[[:space:]]+)+[^[:space:]=]'
+
+  assert_empty "$(bashunit::compat::offenders "$pattern")"
+}

--- a/tests/unit/console_results_diff_test.sh
+++ b/tests/unit/console_results_diff_test.sh
@@ -43,6 +43,29 @@ function test_render_diff_is_empty_for_identical_files() {
   rm -f "$a" "$b"
 }
 
+function test_render_diff_ignores_a_configured_external_diff() {
+  if ! bashunit::dependencies::has_git; then
+    bashunit::skip "git not available" && return
+  fi
+  export BASHUNIT_NO_COLOR=true
+  # An external differ (difftastic in #912) replaces git's own output, so
+  # without --no-ext-diff the rendered diff is whatever it prints — here nothing.
+  export GIT_EXTERNAL_DIFF=true
+  local a b
+  a=$(bashunit::temp_file diff_a)
+  b=$(bashunit::temp_file diff_b)
+  printf 'alpha\nbeta\ngamma\n' >"$a"
+  printf 'alpha\nDELTA\ngamma\n' >"$b"
+
+  local output
+  output=$(bashunit::console_results::render_diff "$a" "$b")
+
+  assert_contains "beta" "$output"
+  assert_contains "DELTA" "$output"
+  rm -f "$a" "$b"
+  unset BASHUNIT_NO_COLOR GIT_EXTERNAL_DIFF
+}
+
 function test_render_diff_shows_changed_tokens_without_color() {
   if ! bashunit::dependencies::has_git; then
     bashunit::skip "git not available" && return


### PR DESCRIPTION
## 🤔 Background

Related #912

Seven tests failed on macOS with Bash 5.3 under `nix-shell --pure`, and two more for anyone with an external git differ configured. CI never sees either: macOS runners ship Apple's Bash 3.2, and no runner has `diff.external` set.

## 💡 Changes

- The failure/snapshot diff renderer now passes `--no-ext-diff`, so a configured `diff.external` (difftastic) no longer replaces the word-diff with empty output.
- Time reads and the JUnit report no longer set the locale with a temporary-environment prefix (`LC_ALL=C cmd`), reported to segfault inside a command substitution on Bash 5.3.9 macOS. `env LC_ALL=C cmd` keeps the C radix; the clock never needed the prefix, since the value is expanded before the temporary environment applies.
- The syntax-error acceptance test drops the same prefix form.
- A source-level gate keeps the prefix out of `src/`, since no CI job runs that bash.