### PR TITLE
feat(assert): a supported way to test that an assertion fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `assert_assertion_passes`, `assert_assertion_fails` and `assert_assertion_fails_with <message>` test a custom assertion for the verdict it reports. The inner assertion runs isolated — its counters, output and stop-on-failure guard are restored — so testing a failing assertion no longer means rebuilding the expected string from `bashunit::console_results::print_failed_test` (#916)
 - `bashunit::assert_that <expected> <actual> <cmd> [args...]` writes a custom assertion in one call: it runs the command and marks the assertion passed or failed, so the two counters can no longer drift apart by a forgotten `return` or a missing `bashunit::assertion_passed` (#915)
 - `bashunit::assertion_failed` takes an optional 4th argument labelling the failure block, so a custom assertion can name itself instead of showing the test name (#915)
 - `--snapshot-report-unused` lists snapshot files no test resolved — the ones a rename or deletion leaves behind. Reports only, never deletes; refused on partial runs (#902)

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -15,7 +15,8 @@ _bashunit() {
     local -a assert_fns
     assert_fns=(
       assert_array_contains assert_array_length assert_array_not_contains
-      assert_arrays_equal assert_command_not_found assert_contains
+      assert_arrays_equal assert_assertion_fails assert_assertion_fails_with
+      assert_assertion_passes assert_command_not_found assert_contains
       assert_contains_ignore_case assert_date_after assert_date_before
       assert_date_equals assert_date_within_delta assert_date_within_range
       assert_directory_exists assert_directory_not_exists assert_duration

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -25,7 +25,8 @@ _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --coverage --coverage-exclude \
 --watch -R -S -a -e -f -h -j -l -p -r -s -vvv -w"
 
 _BASHUNIT_COMPLETIONS_ASSERT_FNS="assert_array_contains assert_array_length \
-assert_array_not_contains assert_arrays_equal assert_command_not_found \
+assert_array_not_contains assert_arrays_equal assert_assertion_fails \
+assert_assertion_fails_with assert_assertion_passes assert_command_not_found \
 assert_contains assert_contains_ignore_case assert_date_after \
 assert_date_before assert_date_equals assert_date_within_delta \
 assert_date_within_range assert_directory_exists assert_directory_not_exists \

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -30,6 +30,7 @@ to narrow it (`bashunit doc json`).
 | **Duration** | [assert_duration](#assert-duration) · [assert_duration_less_than](#assert-duration-less-than) · [assert_duration_greater_than](#assert-duration-greater-than) |
 | **Snapshots** | [assert_match_snapshot](#assert-match-snapshot) · [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors) |
 | **Spies** | [assert_have_been_called](#assert-have-been-called) · [assert_not_called](#assert-not-called) · [assert_have_been_called_with](#assert-have-been-called-with) · [assert_have_been_called_with_any](#assert-have-been-called-with-any) · [assert_have_been_called_with_args](#assert-have-been-called-with-args) · [assert_have_been_called_nth_with](#assert-have-been-called-nth-with) · [assert_have_been_called_times](#assert-have-been-called-times) |
+| **Assertions** | [assert_assertion_passes](#assert-assertion-passes) · [assert_assertion_fails](#assert-assertion-fails) · [assert_assertion_fails_with](#assert-assertion-fails-with) |
 | **Manual failure** | [bashunit::fail](#bashunit-fail) |
 
 ## assert_true
@@ -1813,6 +1814,67 @@ function test_failure() {
   if [ "$(date +%-H)" -lt 25 ]; then
     bashunit::fail "This test will always fail"
   fi
+}
+```
+:::
+
+## assert_assertion_passes
+> `assert_assertion_passes <assertion> [args...]`
+
+Reports an error unless the given assertion reports a success. Use it to test
+your own [custom assertions](/custom-asserts).
+
+The inner assertion runs isolated: its verdict is never added to the run totals,
+its failure output never reaches the console, and it cannot trip the
+stop-on-failure guard for the rest of your test. Exactly one assertion is
+counted — this one.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_assertion_passes assert_positive_number 1
+}
+function test_failure() {
+  assert_assertion_passes assert_positive_number 0
+}
+```
+:::
+
+## assert_assertion_fails
+> `assert_assertion_fails <assertion> [args...]`
+
+Reports an error unless the given assertion reports a failure. An assertion that
+counts nothing at all also fails this check.
+
+The message the inner assertion produced is left in
+`$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT`, colour-stripped and flattened to one line,
+so you can also assert on what it did *not* say.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_assertion_fails assert_positive_number 0
+}
+function test_failure() {
+  assert_assertion_fails assert_positive_number 1
+}
+```
+:::
+
+## assert_assertion_fails_with
+> `assert_assertion_fails_with <expected_message> <assertion> [args...]`
+
+Reports an error unless the given assertion fails **and** its failure message
+contains `expected_message`. This is how a custom assertion's output contract
+gets tested without rebuilding the expected string from `console_results`.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_assertion_fails_with "positive number" assert_positive_number 0
+}
+function test_failure() {
+  assert_assertion_fails_with "negative number" assert_positive_number 0
 }
 ```
 :::

--- a/docs/custom-asserts.md
+++ b/docs/custom-asserts.md
@@ -183,6 +183,47 @@ function assert_positive_number() {
 }
 ```
 
+## Testing your custom assertions
+
+A custom assertion is code, so it deserves tests of its own — including for the
+case it is meant to reject. Three [assertions](/assertions) assert about
+assertions:
+
+```bash
+function test_positive_number_accepts_one() {
+  assert_assertion_passes assert_positive_number 1
+}
+
+function test_positive_number_rejects_zero() {
+  assert_assertion_fails assert_positive_number 0
+}
+
+function test_positive_number_says_what_it_wanted() {
+  assert_assertion_fails_with "positive number" assert_positive_number 0
+}
+```
+
+The inner assertion runs isolated. Its verdict never lands in the run totals,
+its failure block never reaches the console, and it cannot trip the
+stop-on-failure guard for the rest of your test — only the outer
+`assert_assertion_*` is counted.
+
+An assertion that counts *nothing* fails both `assert_assertion_passes` and
+`assert_assertion_fails`, which is what catches a custom assertion that forgot
+to mark its outcome at all.
+
+To assert on what a failure did **not** say, read the captured message from
+`$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT` — colour-stripped and flattened to a single
+line:
+
+```bash
+function test_failure_is_labelled_with_the_test_not_the_assertion() {
+  assert_assertion_fails assert_positive_number 0
+
+  assert_not_contains "Assert positive number" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
+}
+```
+
 ## Loading your assertions once
 
 Sourcing a shared assertions file from `set_up` re-runs it for every test, and

--- a/src/assert_assertions.sh
+++ b/src/assert_assertions.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+# Assertions about assertions: they let a custom assertion be tested for the
+# verdict it reports, without reconstructing the expected string from
+# bashunit::console_results::print_failed_test.
+
+_BASHUNIT_ASSERT_INNER_FAILED_OUT=0
+_BASHUNIT_ASSERT_INNER_PASSED_OUT=0
+
+# Public: the message the last captured assertion reported, colour-stripped and
+# flattened to a single line. Set by every assert_assertion_* call, so a test can
+# assert on what an assertion did *not* say, which no assertion can express.
+_BASHUNIT_ASSERT_INNER_OUTPUT_OUT=""
+
+##
+# Runs an assertion in isolation and reports what it did, without letting it
+# touch the calling test.
+#
+# Everything the inner assertion reports is snapshotted and restored: the two
+# counters, the stop-on-assertion-failure guard (src/assert.sh:10) — which
+# would otherwise make every later assertion in the same test skip — plus the
+# per-test output accumulator and the TAP line counter that
+# console_results::print_line feeds. Console output is redirected away.
+#
+# The captured message is read back from that accumulator rather than from
+# stdout, because in --simple mode print_line only emits a one-char marker.
+#
+# Every slot is written *after* the call returns, which is what makes this
+# reentrant: a nested capture clobbers the slots while it runs, and the outer
+# frame overwrites them again on the way out.
+#
+# Writes: _BASHUNIT_ASSERT_INNER_FAILED_OUT (1 when it reported a failure),
+#         _BASHUNIT_ASSERT_INNER_PASSED_OUT (1 when it reported a success),
+#         _BASHUNIT_ASSERT_INNER_OUTPUT_OUT (what it reported).
+# Arguments: $1.. - the assertion and its arguments
+##
+function bashunit::assert::_capture() {
+  local before_passed=$_BASHUNIT_ASSERTIONS_PASSED
+  local before_failed=$_BASHUNIT_ASSERTIONS_FAILED
+  local before_guard=$_BASHUNIT_ASSERTION_FAILED_IN_TEST
+  local before_output=$_BASHUNIT_TEST_OUTPUT
+  local before_count=$_BASHUNIT_TOTAL_TESTS_COUNT
+
+  # Run the inner assertion unguarded: had an earlier assertion in this test
+  # failed, it would otherwise skip and report no verdict at all.
+  _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
+
+  "$@" >/dev/null 2>&1 || true
+
+  bashunit::str::strip_ansi_to_slot "${_BASHUNIT_TEST_OUTPUT#"$before_output"}"
+  local output=$_BASHUNIT_STR_STRIPPED_OUT
+
+  if [ "$_BASHUNIT_ASSERTIONS_FAILED" -gt "$before_failed" ]; then
+    _BASHUNIT_ASSERT_INNER_FAILED_OUT=1
+  else
+    _BASHUNIT_ASSERT_INNER_FAILED_OUT=0
+  fi
+
+  if [ "$_BASHUNIT_ASSERTIONS_PASSED" -gt "$before_passed" ]; then
+    _BASHUNIT_ASSERT_INNER_PASSED_OUT=1
+  else
+    _BASHUNIT_ASSERT_INNER_PASSED_OUT=0
+  fi
+
+  _BASHUNIT_ASSERT_INNER_OUTPUT_OUT=$output
+
+  _BASHUNIT_ASSERTIONS_PASSED=$before_passed
+  _BASHUNIT_ASSERTIONS_FAILED=$before_failed
+  _BASHUNIT_ASSERTION_FAILED_IN_TEST=$before_guard
+  _BASHUNIT_TEST_OUTPUT=$before_output
+  _BASHUNIT_TOTAL_TESTS_COUNT=$before_count
+}
+
+_BASHUNIT_ASSERT_INNER_OUTCOME_OUT=""
+
+# Describes what the captured assertion actually reported, so the failure block
+# distinguishes "it passed" from "it never counted an assertion at all".
+function bashunit::assert::_inner_outcome_to_slot() {
+  if [ "$_BASHUNIT_ASSERT_INNER_FAILED_OUT" -eq 1 ]; then
+    _BASHUNIT_ASSERT_INNER_OUTCOME_OUT="a failing assertion"
+  elif [ "$_BASHUNIT_ASSERT_INNER_PASSED_OUT" -eq 1 ]; then
+    _BASHUNIT_ASSERT_INNER_OUTCOME_OUT="a passing assertion"
+  else
+    _BASHUNIT_ASSERT_INNER_OUTCOME_OUT="no assertion at all"
+  fi
+}
+
+##
+# Asserts that the given assertion reports a failure.
+# Arguments: $1.. - the assertion and its arguments
+# Returns: 0 when it failed, 1 otherwise
+##
+function assert_assertion_fails() {
+  bashunit::assert::should_skip && return 0
+
+  bashunit::assert::_capture "$@"
+
+  if [ "$_BASHUNIT_ASSERT_INNER_FAILED_OUT" -eq 1 ]; then
+    bashunit::state::add_assertions_passed
+    return 0
+  fi
+
+  bashunit::assert::_inner_outcome_to_slot
+  bashunit::assert::fail_with "" "${1-}" \
+    "to be a failing assertion, but got " "$_BASHUNIT_ASSERT_INNER_OUTCOME_OUT"
+  return 1
+}
+
+##
+# Asserts that the given assertion reports a success.
+# Arguments: $1.. - the assertion and its arguments
+# Returns: 0 when it passed, 1 otherwise
+##
+function assert_assertion_passes() {
+  bashunit::assert::should_skip && return 0
+
+  bashunit::assert::_capture "$@"
+
+  if [ "$_BASHUNIT_ASSERT_INNER_PASSED_OUT" -eq 1 ] &&
+    [ "$_BASHUNIT_ASSERT_INNER_FAILED_OUT" -eq 0 ]; then
+    bashunit::state::add_assertions_passed
+    return 0
+  fi
+
+  bashunit::assert::_inner_outcome_to_slot
+  bashunit::assert::fail_with "" "${1-}" \
+    "to be a passing assertion, but got " "$_BASHUNIT_ASSERT_INNER_OUTCOME_OUT"
+  return 1
+}
+
+##
+# Asserts that the given assertion fails *and* that its failure output contains
+# the expected message, so the output contract is testable without reaching into
+# bashunit::console_results.
+# Arguments: $1 - expected substring of the failure output,
+#            $2.. - the assertion and its arguments
+# Returns: 0 when it failed with that message, 1 otherwise
+##
+function assert_assertion_fails_with() {
+  bashunit::assert::should_skip && return 0
+
+  local expected_message=$1
+  shift
+
+  bashunit::assert::_capture "$@"
+
+  if [ "$_BASHUNIT_ASSERT_INNER_FAILED_OUT" -ne 1 ]; then
+    bashunit::assert::_inner_outcome_to_slot
+    bashunit::assert::fail_with "" "${1-}" \
+      "to be a failing assertion, but got " "$_BASHUNIT_ASSERT_INNER_OUTCOME_OUT"
+    return 1
+  fi
+
+  case "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT" in
+  *"$expected_message"*)
+    bashunit::state::add_assertions_passed
+    return 0
+    ;;
+  esac
+
+  bashunit::assert::fail_with "" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT" \
+    "to contain" "$expected_message"
+  return 1
+}

--- a/src/assertions.sh
+++ b/src/assertions.sh
@@ -2,6 +2,7 @@
 
 source "$BASHUNIT_ROOT_DIR/src/assert.sh"
 source "$BASHUNIT_ROOT_DIR/src/assert_arrays.sh"
+source "$BASHUNIT_ROOT_DIR/src/assert_assertions.sh"
 source "$BASHUNIT_ROOT_DIR/src/assert_dates.sh"
 source "$BASHUNIT_ROOT_DIR/src/assert_duration.sh"
 source "$BASHUNIT_ROOT_DIR/src/assert_files.sh"

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -694,3 +694,37 @@ Reports an error if the spied `command` was called at all. The inverse of assert
 
 Unambiguously reports an error message. Useful for reporting specific message
 when testing situations not covered by any `assert_*` functions.
+
+
+## assert_assertion_passes
+--------------
+> `assert_assertion_passes <assertion> args...`
+
+Reports an error unless the given assertion reports a success. Use it to test
+your own custom assertions(/custom-asserts).
+
+The inner assertion runs isolated: its verdict is never added to the run totals,
+its failure output never reaches the console, and it cannot trip the
+stop-on-failure guard for the rest of your test. Exactly one assertion is
+counted — this one.
+
+
+## assert_assertion_fails
+--------------
+> `assert_assertion_fails <assertion> args...`
+
+Reports an error unless the given assertion reports a failure. An assertion that
+counts nothing at all also fails this check.
+
+The message the inner assertion produced is left in
+`$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT`, colour-stripped and flattened to one line,
+so you can also assert on what it did *not* say.
+
+
+## assert_assertion_fails_with
+--------------
+> `assert_assertion_fails_with <expected_message> <assertion> args...`
+
+Reports an error unless the given assertion fails **and** its failure message
+contains `expected_message`. This is how a custom assertion's output contract
+gets tested without rebuilding the expected string from `console_results`.

--- a/tests/functional/custom_asserts_test.sh
+++ b/tests/functional/custom_asserts_test.sh
@@ -7,41 +7,51 @@ function set_up() {
 }
 
 function test_assert_foo_passed() {
-  assert_foo "foo"
+  assert_assertion_passes assert_foo "foo"
 }
 
 function test_assert_foo_failed() {
-  assert_same "$(bashunit::console_results::print_failed_test "Assert foo failed" "foo" "but got " "bar")" \
-    "$(assert_foo "bar")"
+  assert_assertion_fails assert_foo "bar"
+}
+
+function test_assert_foo_failure_reports_the_expected_and_actual_values() {
+  assert_assertion_fails_with "Expected 'foo'" assert_foo "bar"
+  assert_assertion_fails_with "'bar'" assert_foo "bar"
+}
+
+function test_assert_foo_failure_is_labelled_with_the_test_name() {
+  assert_assertion_fails_with \
+    "Assert foo failure is labelled with the test name" assert_foo "bar"
 }
 
 function test_assert_positive_number_passed() {
-  assert_positive_number "1"
+  assert_assertion_passes assert_positive_number "1"
 }
 
 function test_assert_positive_number_failed() {
-  assert_same \
-    "$(bashunit::console_results::print_failed_test "Assert positive number failed" "positive number" "got" "0")" \
-    "$(assert_positive_number "0")"
+  assert_assertion_fails assert_positive_number "0"
+}
+
+function test_assert_positive_number_uses_its_own_failure_condition_message() {
+  assert_assertion_fails_with "got '0'" assert_positive_number "0"
 }
 
 function test_assert_that_positive_number_passed() {
-  assert_that_positive_number "1"
+  assert_assertion_passes assert_that_positive_number "1"
 }
 
 function test_assert_that_positive_number_failed() {
-  assert_same \
-    "$(bashunit::console_results::print_failed_test \
-      "Assert that positive number failed" "positive number" "but got " "0")" \
-    "$(assert_that_positive_number "0" || true)"
+  assert_assertion_fails_with "Expected 'positive number'" assert_that_positive_number "0"
 }
 
 function test_assert_labelled_foo_passed() {
-  assert_labelled_foo "foo"
+  assert_assertion_passes assert_labelled_foo "foo"
 }
 
-function test_assert_labelled_foo_failed() {
-  assert_same \
-    "$(bashunit::console_results::print_failed_test "Assert labelled foo" "foo" "but got " "bar")" \
-    "$(assert_labelled_foo "bar")"
+function test_assert_labelled_foo_names_itself_instead_of_the_test() {
+  assert_assertion_fails_with "Assert labelled foo" assert_labelled_foo "bar"
+
+  assert_not_contains \
+    "Assert labelled foo names itself instead of the test" \
+    "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
 }

--- a/tests/unit/assert_assertions_test.sh
+++ b/tests/unit/assert_assertions_test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+
+# A custom assertion routed through bashunit::fail rather than the counters
+# directly, to prove the capture notices that flavour of failure too.
+function _assert_never_valid() {
+  bashunit::fail "always invalid"
+}
+
+function test_assert_assertion_fails_when_the_inner_assertion_fails() {
+  assert_assertion_fails assert_same "a" "b"
+}
+
+function test_assert_assertion_fails_detects_a_failure_raised_through_bashunit_fail() {
+  assert_assertion_fails _assert_never_valid
+}
+
+function test_assert_assertion_fails_fails_when_the_inner_assertion_passes() {
+  assert_assertion_fails assert_assertion_fails assert_same "a" "a"
+}
+
+function test_assert_assertion_fails_fails_when_nothing_is_asserted() {
+  assert_assertion_fails assert_assertion_fails true
+}
+
+function test_assert_assertion_passes_when_the_inner_assertion_passes() {
+  assert_assertion_passes assert_same "a" "a"
+}
+
+function test_assert_assertion_passes_fails_when_the_inner_assertion_fails() {
+  assert_assertion_fails assert_assertion_passes assert_same "a" "b"
+}
+
+function test_assert_assertion_passes_fails_when_nothing_is_asserted() {
+  assert_assertion_fails assert_assertion_passes true
+}
+
+function test_assert_assertion_fails_with_matches_the_failure_message() {
+  assert_assertion_fails_with "but got" assert_same "a" "b"
+}
+
+function test_assert_assertion_fails_with_rejects_a_different_message() {
+  assert_assertion_fails assert_assertion_fails_with "unrelated text" assert_same "a" "b"
+}
+
+function test_assert_assertion_fails_with_fails_when_the_inner_assertion_passes() {
+  assert_assertion_fails assert_assertion_fails_with "but got" assert_same "a" "a"
+}
+
+function test_assert_assertion_fails_restores_the_assertion_counters() {
+  local before_passed=$_BASHUNIT_ASSERTIONS_PASSED
+  local before_failed=$_BASHUNIT_ASSERTIONS_FAILED
+
+  assert_assertion_fails assert_same "a" "b"
+
+  # Exactly one assertion is reported: the outer one. The inner failure leaves
+  # neither counter behind.
+  assert_same "$((before_passed + 1))" "$_BASHUNIT_ASSERTIONS_PASSED"
+  assert_same "$before_failed" "$_BASHUNIT_ASSERTIONS_FAILED"
+}
+
+function test_assert_assertion_passes_restores_the_assertion_counters() {
+  local before_passed=$_BASHUNIT_ASSERTIONS_PASSED
+  local before_failed=$_BASHUNIT_ASSERTIONS_FAILED
+
+  assert_assertion_passes assert_same "a" "a"
+
+  assert_same "$((before_passed + 1))" "$_BASHUNIT_ASSERTIONS_PASSED"
+  assert_same "$before_failed" "$_BASHUNIT_ASSERTIONS_FAILED"
+}
+
+function test_assert_assertion_fails_leaves_the_stop_on_failure_guard_untouched() {
+  # Without the restore, the inner failure would set the guard and every later
+  # assertion in this test would be silently skipped under
+  # BASHUNIT_STOP_ON_FAILURE.
+  local before=$_BASHUNIT_ASSERTION_FAILED_IN_TEST
+
+  assert_assertion_fails assert_same "a" "b"
+
+  assert_same "$before" "$_BASHUNIT_ASSERTION_FAILED_IN_TEST"
+}
+
+function test_assert_assertion_fails_does_not_print_the_inner_failure() {
+  local output
+  output="$(assert_assertion_fails assert_same "a" "b")"
+
+  assert_empty "$output"
+}
+
+function test_assert_assertion_fails_leaves_the_test_output_accumulator_untouched() {
+  # print_line also appends to _BASHUNIT_TEST_OUTPUT, which the runner renders
+  # as this test's "Output:" block. Redirecting stdout alone would still leak
+  # the inner failure there.
+  local before=$_BASHUNIT_TEST_OUTPUT
+
+  assert_assertion_fails assert_same "a" "b"
+
+  assert_same "$before" "$_BASHUNIT_TEST_OUTPUT"
+}
+
+function test_assert_assertion_fails_with_reads_the_message_not_the_console_output() {
+  # In --simple mode the console only receives a one-char marker, so matching
+  # on stdout would make this pass sequentially and fail in CI.
+  assert_assertion_fails_with "Expected" assert_same "a" "b"
+}
+
+function test_assert_assertion_fails_forwards_every_argument_to_the_assertion() {
+  # A boundary-exact assertion proves the arguments are not re-split or eval'd.
+  assert_assertion_passes assert_same "one two" "one two"
+  assert_assertion_fails assert_same "one two" "one  two"
+}

--- a/tests/unit/custom_assertions_test.sh
+++ b/tests/unit/custom_assertions_test.sh
@@ -42,72 +42,32 @@ function _assert_length_equals() {
 function test_custom_assertion_with_fail_shows_correct_test_name() {
   # This test verifies that when a custom assertion uses fail(),
   # the failure message shows the test function name, not the custom assertion name
-  local output
-  output="$(
-    # Temporarily override bashunit::console_results::print_line to capture output
-    _captured_output=""
-    # shellcheck disable=SC2317,SC2329
-    bashunit::console_results::print_line() {
-      _captured_output="$2"
-      echo "$_captured_output"
-    }
-
-    # Force a failure using our custom assertion with invalid JSON
-    _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
+  assert_assertion_fails_with \
+    "Custom assertion with fail shows correct test name" \
     _assert_valid_json "invalid json"
 
-    echo "$_captured_output"
-  )"
-
-  # The output should contain the test function name (normalized from the test function)
-  assert_contains "Custom assertion with fail shows correct test name" "$output"
-  assert_not_contains "Assert valid json" "$output"
+  assert_not_contains "Assert valid json" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
 }
 
 function test_custom_assertion_with_bashunit_assertion_failed_shows_correct_test_name() {
   # This test verifies that when a custom assertion uses bashunit::assertion_failed(),
   # the failure message shows the test function name, not the custom assertion name
-  local output
-  output="$(
-    _captured_output=""
-    # shellcheck disable=SC2317,SC2329
-    bashunit::console_results::print_line() {
-      _captured_output="$2"
-      echo "$_captured_output"
-    }
-
-    _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
+  assert_assertion_fails_with \
+    "Custom assertion with bashunit assertion failed shows correct test name" \
     _assert_positive_number "-5"
 
-    echo "$_captured_output"
-  )"
-
-  assert_contains \
-    "Custom assertion with bashunit assertion failed shows correct test name" "$output"
-  assert_not_contains "Assert positive number" "$output"
+  assert_not_contains "Assert positive number" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
 }
 
 function test_custom_assertion_calling_assert_same_shows_correct_test_name() {
   # This test verifies that when a custom assertion calls another assertion like assert_same,
   # the failure message shows the test function name, not the intermediate assertion name
-  local output
-  output="$(
-    _captured_output=""
-    # shellcheck disable=SC2317,SC2329
-    bashunit::console_results::print_line() {
-      _captured_output="$2"
-      echo "$_captured_output"
-    }
-
-    _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
+  assert_assertion_fails_with \
+    "Custom assertion calling assert same shows correct test name" \
     _assert_length_equals "5" "abc" # length is 3, not 5
 
-    echo "$_captured_output"
-  )"
-
-  assert_contains "Custom assertion calling assert same shows correct test name" "$output"
-  assert_not_contains "Assert length equals" "$output"
-  assert_not_contains "Assert same" "$output"
+  assert_not_contains "Assert length equals" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
+  assert_not_contains "Assert same" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
 }
 
 function test_assert_that_counts_exactly_one_passed_assertion() {
@@ -160,23 +120,11 @@ function test_assert_that_returns_one_when_the_command_fails() {
 }
 
 function test_assertion_failed_uses_the_optional_label_over_the_test_name() {
-  local output
-  output="$(
-    _captured_output=""
-    # shellcheck disable=SC2317,SC2329
-    bashunit::console_results::print_line() {
-      _captured_output="$2"
-      echo "$_captured_output"
-    }
-
-    _BASHUNIT_ASSERTION_FAILED_IN_TEST=0
+  assert_assertion_fails_with "My own label" \
     bashunit::assertion_failed "positive number" "-5" "but got " "My own label"
 
-    echo "$_captured_output"
-  )"
-
-  assert_contains "My own label" "$output"
-  assert_not_contains "Assertion failed uses the optional label" "$output"
+  assert_not_contains \
+    "Assertion failed uses the optional label" "$_BASHUNIT_ASSERT_INNER_OUTPUT_OUT"
 }
 
 function test_helper_find_test_function_name_finds_test() {


### PR DESCRIPTION
## 🤔 Background

Related #916

There was no supported way to test that a custom assertion fails the way you intended. bashunit's own suite reconstructed the expected string from `bashunit::console_results::print_failed_test`, and its unit tests monkey-patched `print_line` inside a subshell — if the framework has to break its own encapsulation, a user has no chance, and a change to the failure renderer breaks those tests for unrelated reasons.

## 💡 Changes

- Add `assert_assertion_passes`, `assert_assertion_fails` and `assert_assertion_fails_with <message>`, which assert about the verdict an assertion reports.
- The inner assertion runs isolated: counters, stop-on-failure guard, output accumulator and TAP counter are all snapshotted and restored, so exactly one assertion is counted and a failing inner assertion never pollutes the test. Reentrant, so these compose with each other.
- The captured message is read from the output accumulator, not stdout — `--simple` only prints a one-char marker — and exposed colour-stripped so a test can assert on what a failure did *not* say.
- Rewrites `tests/functional/custom_asserts_test.sh` and `tests/unit/custom_assertions_test.sh` on top of the new API, which is the real proof it is good enough.