### PR TITLE
fix(build): key embed markers on repo-relative paths

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -80,3 +80,12 @@ shell (or, in parallel, in per-test `.result` files aggregated at the end).
   doubles/PATH games can't hijack the framework's own plumbing.
 - **Snapshots assume 80-col non-tty width** (`tput cols` fallback); anything
   that changes rendering widths breaks `tests/acceptance/snapshots/`.
+- **The build flattens the source graph in DFS order** (`build.sh`
+  `build::process_file`): a file's body is emitted, *then* its `source` lines are
+  recursed into. That equals dev-mode order only if a module aggregator
+  (`src/<module>.sh`, e.g. `src/assertions.sh`) contains **nothing but `source`
+  lines and comments** — any other top-level statement would run before its
+  dependencies in the built artifact but after them in dev mode. Files are
+  deduped by repo-relative path, so `src/` may hold module dirs and two files may
+  share a basename. Every src file's **first line must be the shebang**:
+  `tail -n +2` strips it when embedding.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `build.sh` dedupes embedded files by repo-relative path. The previous basename key compared the top-level loop's relative paths against the recursion's absolute ones, so a file reached from two places could be bundled twice in the released binary; it also collided for same-named files in different directories (#923)
+
 ## [0.44.0](https://github.com/TypedDevs/bashunit/compare/0.43.0...0.44.0) - 2026-07-29
 
 ### Added

--- a/build.sh
+++ b/build.sh
@@ -7,9 +7,9 @@ bashunit::check_os::init
 BASHUNIT_ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export BASHUNIT_ROOT_DIR
 
-# Files already embedded by build::process_file. The source graph is a tree
-# today, but one added cross-source would otherwise silently bundle a file
-# twice (duplicate function definitions and double top-level execution).
+# Files already embedded by build::process_file, keyed by repo-relative path.
+# Without the dedupe a cross-module source would bundle a file twice (duplicate
+# function definitions and double top-level execution).
 _BUILD_EMBEDDED_FILES=""
 
 function build() {
@@ -70,13 +70,20 @@ function build::process_file() {
   local file=$1
   local temp=$2
 
+  # Key the dedupe and the marker on a repo-relative path, never a basename: the
+  # top-level loop passes `src/x.sh` while the recursion passes an absolute path,
+  # and two modules can hold the same basename (src/parallel.sh vs
+  # src/runner/parallel.sh). `$file` itself stays untouched so the `tail` and
+  # `dirname` below work on whichever form the caller passed.
+  local marker="${file#"$BASHUNIT_ROOT_DIR"/}"
+
   case " $_BUILD_EMBEDDED_FILES " in
-  *" $file "*) return ;;
+  *" $marker "*) return ;;
   esac
-  _BUILD_EMBEDDED_FILES="$_BUILD_EMBEDDED_FILES $file"
+  _BUILD_EMBEDDED_FILES="$_BUILD_EMBEDDED_FILES $marker"
 
   {
-    echo "# $(basename "$file")"
+    echo "# $marker"
     tail -n +2 "$file"
     echo ""
   } >>"$temp"
@@ -91,10 +98,12 @@ function build::process_file() {
     # Expand the literal $BASHUNIT_ROOT_DIR prefix without eval
     sourced_file="${sourced_file/\$BASHUNIT_ROOT_DIR/$BASHUNIT_ROOT_DIR}"
 
-    # Handle relative paths if necessary
+    # Handle relative paths if necessary. Strip a leading `./` first, or each
+    # recursion level appends another `/.` segment and the same file reaches the
+    # dedupe under two spellings.
     local _absolute_path_pattern='^/'
     if [[ ! "$sourced_file" =~ $_absolute_path_pattern ]]; then
-      sourced_file="$(dirname "$file")/$sourced_file"
+      sourced_file="$(dirname "$file")/${sourced_file#./}"
     fi
 
     # Recursively process the sourced file if it exists

--- a/tests/unit/build_test.sh
+++ b/tests/unit/build_test.sh
@@ -100,7 +100,48 @@ function test_build_process_file_embeds_a_file_only_once() {
   (cd "$ROOT_DIR" && bash -c 'source ./build.sh && build::process_file "$1" "$2"' _ "$dir/root.sh" "$dir/out.tmp") \
     >/dev/null 2>&1
 
-  assert_equals "1" "$(grep -c '^# common.sh$' "$dir/out.tmp")"
+  assert_equals "1" "$(grep -cFx "# $dir/common.sh" "$dir/out.tmp")"
+}
+
+# build::dependencies yields repo-relative paths while the recursion yields absolute
+# ones, so the dedupe must normalise both spellings or a cross-module source bundles
+# the same file twice (duplicate function definitions in the distributable).
+function test_build_process_file_embeds_a_file_only_once_across_relative_and_absolute_paths() {
+  local dir
+  dir=$(bashunit::temp_dir)
+  mkdir -p "$dir/src"
+  printf '#!/usr/bin/env bash\nsource "$BASHUNIT_ROOT_DIR/src/common.sh"\n' >"$dir/src/a.sh"
+  printf '#!/usr/bin/env bash\nfunction common_fn() { :; }\n' >"$dir/src/common.sh"
+
+  (cd "$ROOT_DIR" && bash -c '
+    source ./build.sh
+    BASHUNIT_ROOT_DIR="$1"
+    cd "$1" || exit 1
+    build::process_file "src/a.sh" out.tmp
+    build::process_file "src/common.sh" out.tmp
+  ' _ "$dir") >/dev/null 2>&1
+
+  assert_equals "1" "$(grep -c 'function common_fn()' "$dir/out.tmp")"
+}
+
+# A basename marker collides across directories, which both hides a genuine
+# duplicate and reports a false one for two distinct files.
+function test_build_process_file_marks_same_basename_files_in_different_dirs_distinctly() {
+  local dir
+  dir=$(bashunit::temp_dir)
+  mkdir -p "$dir/src/mod"
+  printf '#!/usr/bin/env bash\nsource "$BASHUNIT_ROOT_DIR/src/mod/parallel.sh"\n' >"$dir/src/parallel.sh"
+  printf '#!/usr/bin/env bash\nfunction mod_parallel_fn() { :; }\n' >"$dir/src/mod/parallel.sh"
+
+  (cd "$ROOT_DIR" && bash -c '
+    source ./build.sh
+    BASHUNIT_ROOT_DIR="$1"
+    cd "$1" || exit 1
+    build::process_file "src/parallel.sh" out.tmp
+  ' _ "$dir") >/dev/null 2>&1
+
+  assert_equals "1" "$(grep -cFx '# src/parallel.sh' "$dir/out.tmp")"
+  assert_equals "1" "$(grep -cFx '# src/mod/parallel.sh' "$dir/out.tmp")"
 }
 
 function test_build_assert_valid_syntax_rejects_broken_file() {
@@ -132,7 +173,23 @@ function test_built_binary_embeds_each_src_file_exactly_once() {
   (cd "$ROOT_DIR" && bash build.sh "$build_dir") >/dev/null 2>&1
 
   local duplicated
-  duplicated=$(grep -E '^# [a-z_]+\.sh$' "$build_dir/bashunit" | sort | uniq -d)
+  duplicated=$(grep -E '^# src/[a-z_0-9/]+\.sh$' "$build_dir/bashunit" | sort | uniq -d)
+
+  assert_empty "$duplicated"
+}
+
+# The marker guard above only catches a file embedded twice under the *same*
+# spelling; this one catches the symptom directly, whatever the cause.
+function test_built_binary_defines_each_bashunit_function_exactly_once() {
+  local build_dir
+  build_dir=$(bashunit::temp_dir)
+
+  (cd "$ROOT_DIR" && bash build.sh "$build_dir") >/dev/null 2>&1
+
+  # Scoped to the bashunit:: namespace on purpose: an unqualified `^function `
+  # also matches the example code inside the embedded docs/assertions.md heredoc.
+  local duplicated
+  duplicated=$(grep -oE '^function bashunit::[a-zA-Z_:]+\(\)' "$build_dir/bashunit" | sort | uniq -d)
 
   assert_empty "$duplicated"
 }


### PR DESCRIPTION
## 🤔 Background

Related #923

`build.sh` labelled every embedded file with `# <basename>`, and that label was both the dedupe key and the only thing the exactly-once guard inspected. Since the top-level embed loop passes repo-relative paths while the recursion passes absolute ones, the dedupe compared two spellings of the same file and never matched.

## 💡 Changes

- Key the dedupe and the embed marker on a repo-relative path, so a file reached from two places is bundled once and same-named files in different directories stay distinct
- Strip a leading `./` when joining relative source paths, which otherwise added a `/.` segment per recursion level and gave one file two spellings
- Retarget the exactly-once guard, which matched zero lines once markers became paths, and add a guard on the symptom itself: no framework function defined twice in the artifact
- Document the DFS embed order and the aggregator constraint it depends on