### PR TITLE
fix(doc): don't error on missing default bootstrap file (#929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - `build.sh` dedupes embedded files by repo-relative path. The previous basename key compared the top-level loop's relative paths against the recursion's absolute ones, so a file reached from two places could be bundled twice in the released binary; it also collided for same-named files in different directories (#923)
+- `bashunit doc` no longer errors when the default bootstrap file is missing (#929)
 
 ## [0.44.0](https://github.com/TypedDevs/bashunit/compare/0.43.0...0.44.0) - 2026-07-29
 

--- a/src/main.sh
+++ b/src/main.sh
@@ -736,6 +736,7 @@ function bashunit::main::cmd_doc() {
   local filter=""
   local custom_only=false
   local boot_file="${BASHUNIT_BOOTSTRAP:-}"
+  local boot_provided=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -749,6 +750,7 @@ function bashunit::main::cmd_doc() {
       ;;
     -e | --env | --boot)
       boot_file="${2:-}"
+      boot_provided=true
       shift 2
       ;;
     *)
@@ -765,12 +767,15 @@ function bashunit::main::cmd_doc() {
 
   if [ -n "$boot_file" ]; then
     if [ ! -r "$boot_file" ]; then
-      printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
-        "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
-      exit 1
+      if [ "$boot_provided" = true ]; then
+        printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
+          "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+        exit 1
+      fi
+    else
+      # shellcheck disable=SC1090,SC2086
+      source "$boot_file" ${BASHUNIT_BOOTSTRAP_ARGS:-}
     fi
-    # shellcheck disable=SC1090,SC2086
-    source "$boot_file" ${BASHUNIT_BOOTSTRAP_ARGS:-}
   fi
 
   bashunit::doc::custom_fns_to_slot "$known"

--- a/tests/acceptance/bashunit_doc_custom_test.sh
+++ b/tests/acceptance/bashunit_doc_custom_test.sh
@@ -80,3 +80,24 @@ function test_doc_custom_reports_an_unreadable_bootstrap() {
 
   assert_contains "cannot read the bootstrap file" "$output"
 }
+
+# A bootstrap named explicitly must still fail loudly (above), but the *default*
+# one is optional: BASHUNIT_BOOTSTRAP carries a default of tests/bootstrap.sh, so
+# treating it as mandatory made plain `bashunit doc` abort before printing
+# anything in any project without that file (#929). This mirrors what cmd_test
+# already does -- explicit --env errors, the default is `[ -f ] && source`.
+function test_doc_does_not_error_when_the_default_bootstrap_is_missing() {
+  local output
+  output=$(BASHUNIT_BOOTSTRAP="does/not/exist.sh" ./bashunit doc 2>&1) || true
+
+  assert_contains "## assert_same" "$output"
+  assert_not_contains "cannot read the bootstrap file" "$output"
+}
+
+function test_doc_exits_zero_when_the_default_bootstrap_is_missing() {
+  local exit_code=0
+
+  BASHUNIT_BOOTSTRAP="does/not/exist.sh" ./bashunit doc >/dev/null 2>&1 || exit_code=$?
+
+  assert_same "0" "$exit_code"
+}


### PR DESCRIPTION
Plain 'bashunit doc' now lists all assertions without requiring a bootstrap; only an explicitly named --boot/-e/--env file still errors when unreadable.

## Background

Related #929

`bashunit doc` treated the default `BASHUNIT_BOOTSTRAP` (`tests/bootstrap.sh`) as mandatory and aborted with `Error: cannot read the bootstrap file: 'tests/bootstrap.sh'.` before printing anything. This contradicts the documented behaviour, where plain `bashunit doc` lists all assertions without requiring a bootstrap file.

## Changes

- Make the default bootstrap optional in `bashunit::main::cmd_doc`: a missing *default* bootstrap no longer errors. Plain `bashunit doc` prints all assertions, and `bashunit doc --custom` prints "No custom assertions found." when none exist.
- An explicitly named bootstrap (`--boot` / `-e` / `--env`) still errors when unreadable, preserving intended behaviour.
- Added a `CHANGELOG.md` entry under Unreleased → Fixed.

## Checklist

- [x] I updated the `CHANGELOG.md` to reflect the new feature or fix
- [ ] I updated the documentation to reflect the changes (no change needed — behaviour now matches the existing `doc` docs)