### PR TITLE
docs(adr): correct stale references across the ADR set

### DIFF
--- a/adrs/adr-002-using-booleans.md
+++ b/adrs/adr-002-using-booleans.md
@@ -32,14 +32,14 @@ When using variables, we must use `true` and `false` as commands (not strings!):
 
 When possible, extract a condition into a function. For example:
 ```bash
-function env::is_show_header_enabled() {
-    # this is a string comparison because it is coming from the .env
-    [[ "$BASHUNIT_SHOW_HEADER" == "true" ]]
+function bashunit::env::is_show_header_enabled() {
+  # this is a string comparison because it is coming from the .env
+  [ "$BASHUNIT_SHOW_HEADER" = "true" ]
 }
 ```
 Usage
 ```bash
-if env::is_show_header_enabled; then
+if bashunit::env::is_show_header_enabled; then
     # ...
 fi
 ```

--- a/adrs/adr-003-parallel-testing.md
+++ b/adrs/adr-003-parallel-testing.md
@@ -35,16 +35,29 @@ We aim to enhance testing performance by running tests in parallel processes whi
 
 ## Technical Details
 
-When the `--parallel` flag is used, each test is run in its own subprocess by calling:
+When the `--parallel` flag is used, each **test function** is spawned as its own
+background subshell from `bashunit::runner::call_test_functions`:
 
-> runner::call_test_functions "$test_file" "$filter" 2>/dev/null &
+> bashunit::runner::run_test "$script" "$fn_name" &
 
-Each test script creates a temporary directory and stores individual test results in temp files.
-After all tests finish, the results are aggregated by traversing these directories and files.
-This approach ensures isolation of test execution while improving performance by running tests concurrently.
+Each test writes its result to one file under `$TEMP_DIR_PARALLEL_TEST_SUITE`.
+After all tests finish, the results are aggregated by traversing that directory.
+This keeps test execution isolated while running tests concurrently.
 
-The aggregation (which collects all test outcomes into a final result set) is handled by the function:
+Aggregation is handled by:
 
-> parallel::aggregate_test_results "$TEMP_DIR_PARALLEL_TEST_SUITE"
+> bashunit::state::aggregate_parallel_results "$TEMP_DIR_PARALLEL_TEST_SUITE"
+
+> **Updated since this ADR was written.** The original text described spawning
+> one subprocess *per file* via `runner::call_test_functions … &` and aggregating
+> via `parallel::aggregate_test_results`. Both are out of date: the unit of
+> parallelism is the individual test, the functions gained the `bashunit::`
+> namespace (#538), aggregation moved to `state.sh`, and the runner now lives in
+> the `src/runner/` module (ADR-010) with the spawn in `src/runner/exec.sh`.
+> The result file is named from a per-suite ordinal assigned just before each
+> `&` rather than from a `mktemp` per test (#851) — Bash 3 subshells inherit
+> `$$` and the `RANDOM` state and `BASHPID` is 4.0+, so an ordinal is the only
+> fork-free way to get a unique name. Job-slot limiting is in
+> `src/runner/parallel.sh`.
 
 

--- a/adrs/adr-004-metadata-prefix.md
+++ b/adrs/adr-004-metadata-prefix.md
@@ -33,5 +33,5 @@ eg: using `# @data_provider provider_name`.
 
 ## Technical Details
 
-`helper::get_provider_data` now matches both `# @data_provider` and the old
+`bashunit::helper::get_provider_data` now matches both `# @data_provider` and the old
 `# data_provider` when locating provider functions.

--- a/adrs/adr-006-tput-vs-ansi-escapes.md
+++ b/adrs/adr-006-tput-vs-ansi-escapes.md
@@ -32,7 +32,7 @@ Reasoning:
 
 What this PR does:
 
-1. All color escapes go through `bashunit::sgr` and the `_BASHUNIT_COLOR_*` constants. No more raw `\033[...m` literals in `src/coverage.sh` or `src/main.sh`.
+1. All color escapes go through `bashunit::sgr` and the `_BASHUNIT_COLOR_*` constants. No more raw `\033[...m` literals in the coverage code (since ADR-010, `src/coverage/`) or `src/main.sh`.
 2. New `bashunit::env::supports_color` (false on `TERM=dumb` or `tput colors < 8`). Exposed but not wired into `colors.sh` init yet. The same auto-disable broke CI in PR #245 and again on the first push of this branch, so it waits until we add a `CI` / `FORCE_COLOR` override.
 3. New `bashunit::io::clear_screen` runs `tput clear` and falls back to `\033[2J\033[H` if tput is missing or returns nothing. Replaces the hardcoded clear in `--watch` mode.
 

--- a/adrs/adr-007-branch-coverage-mvp.md
+++ b/adrs/adr-007-branch-coverage-mvp.md
@@ -18,7 +18,7 @@ We need a path that yields useful, mostly-correct branch metrics in LCOV reports
 * Bash 3.0+ compatibility (no associative arrays, no `[[`, no Bash 4-only features).
 * Reuse existing line-hit data; do not double the runtime cost of coverage.
 * LCOV output must be consumable by genhtml, Codecov and Coveralls without custom processing.
-* Implementation must fit in `src/coverage.sh` and remain testable with the existing unit-test patterns.
+* Implementation must fit in the coverage module and remain testable with the existing unit-test patterns.
 * Behavior must be predictable enough to pin in tests; "best-effort heuristic" outputs are not acceptable.
 
 ## Considered Options
@@ -101,5 +101,5 @@ than the line-range model.
 
 ## Links
 
-* Builds on the function extractor introduced in `src/coverage.sh` (see `bashunit::coverage::extract_functions`).
+* Builds on the function extractor `bashunit::coverage::extract_functions` (now `src/coverage/functions.sh`; branch code lives in `src/coverage/branches.sh` since ADR-010).
 * LCOV format reference: <https://manpages.debian.org/unstable/lcov/geninfo.1.en.html>

--- a/adrs/adr-009-coverage-tracing-engine.md
+++ b/adrs/adr-009-coverage-tracing-engine.md
@@ -1,13 +1,13 @@
 # Coverage Tracing Engine: xtrace fast path with DEBUG-trap fallback
 
-* Status: accepted (direction); implementation deferred to a follow-up
+* Status: accepted; implemented in #860 (see Implementation notes below)
 * Date: 2026-07-24
 * Spike: #854 · builds on #853 (shelved dedup) and ADR-007/ADR-008
 
 ## Context and Problem Statement
 
 Line/branch coverage is driven by a `DEBUG` trap that invokes
-`bashunit::coverage::record_line` for **every executed command** (`src/coverage.sh`).
+`bashunit::coverage::record_line` for **every executed command** (now `src/coverage/engine.sh`).
 That per-line callback is a full shell-function dispatch, and it dominates the
 cost of `--coverage`: on a loop-heavy fixture the whole run takes ~35s, and the
 #853 experiment (dedup line hits at source) moved that by ~0s — collapsing ~1500


### PR DESCRIPTION
## 🤔 Background

ADR-010 was recently amended because its reasoning didn't hold up. That prompted an audit of the whole set: every factual claim in all ten ADRs — file paths, function names, env vars, behaviours — checked against the current codebase.

Six had drifted. Two have problems an edit can't fix; those are flagged below rather than changed here.

## 💡 Changes

- **ADR-002** — the example called `env::is_show_header_enabled` (namespaced in #538) and used `[[ ]]`, which this project's own house style prohibits. An ADR was modelling a banned construct.
- **ADR-003** — Technical Details described the pre-#538, pre-#851, pre-ADR-010 design: one subprocess per *file*, and aggregation via `parallel::aggregate_test_results`, which doesn't exist. Parallelism is per-test, aggregation is `bashunit::state::aggregate_parallel_results`, spawn is in `src/runner/exec.sh`. Rewritten with a note recording what changed rather than silently overwriting.
- **ADR-004** — `helper::get_provider_data` → `bashunit::helper::get_provider_data`.
- **ADR-006** — pointed at `src/coverage.sh`, gone since ADR-010.
- **ADR-007** — a decision driver and a link required the implementation to "fit in `src/coverage.sh`".
- **ADR-009** — Status read "implementation deferred to a follow-up" while the same document carries an "Implementation notes (#860)" section describing the shipped engine.

Verified as still accurate and left alone: ADR-006's `bashunit::sgr` / `supports_color` / `clear_screen` claims (including that `supports_color` is still deliberately unwired), ADR-007's function references, ADR-008's `clock::is_expensive` and `needs_test_duration`, and ADR-010.

## ⚠️ Flagged, not changed

Two ADRs describe decisions that no longer match the project. Superseding a decision isn't a docs edit, so they need your call — see the PR discussion.

- **ADR-001** — its core outcome ("if any execution writes to stderr it is considered failed") is **false today**, verified empirically: a test writing to stderr passes.
- **ADR-005** — status "proposed" since 2025-09-17; chose Copilot custom instructions at `.github/copilot-instructions.md`, which was never created. The project adopted Claude Code (`.claude/`) instead, with no ADR recording it.