### PR TITLE
fix(coverage): stop counting variable assignments as functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Internal: `src/runner.sh` and `src/coverage.sh` are split into `src/runner/` and `src/coverage/` modules of single-responsibility files, each behind a `source`-only `index.sh` aggregator. A pure relocation, no behavior change; see [ADR-010](adrs/adr-010-src-module-directories.md) (#924, #925)
 
 ### Fixed
+- Coverage no longer counts variable assignments as functions. A line like `URL="https://${host}/api"` was reported as a function, inflating `FNF`/`FNH` in the LCOV report (17 phantom entries in bashunit's own run); when the value also contained a `|`, the malformed record aborted the LCOV writer with a raw bash arithmetic error (#936)
 - `build.sh` dedupes embedded files by repo-relative path. The previous basename key compared the top-level loop's relative paths against the recursion's absolute ones, so a file reached from two places could be bundled twice in the released binary; it also collided for same-named files in different directories (#923)
 - `bashunit doc` no longer errors when the default bootstrap file is missing (#929)
 

--- a/src/coverage/functions.sh
+++ b/src/coverage/functions.sh
@@ -37,9 +37,17 @@ function bashunit::coverage::extract_functions() {
       # Extract first word as candidate function name
       fn_name="${stripped%%[[:space:]\(\{]*}"
 
-      # Validate: must start with valid identifier char, and rest must have () or {
+      # Validate: must BE an identifier, and rest must have () or {
       if [ -n "$fn_name" ]; then
         case "$fn_name" in
+        # A candidate holding anything outside the identifier alphabet is not a
+        # function name. Cutting at the first `{` means `VAR="x${Y}"` yields
+        # `VAR="x$`, whose trailing `{Y}"` then looks like a body opener — every
+        # such assignment became a phantom FN record, and one containing the
+        # record separator `|` shifted the fields and crashed report_lcov's
+        # arithmetic (#936). Checking only the first character let all of that
+        # through.
+        *[!a-zA-Z0-9_:]*) fn_name="" ;;
         [a-zA-Z_]*)
           local after_name="${stripped#"$fn_name"}"
           after_name="${after_name#"${after_name%%[![:space:]]*}"}"

--- a/src/coverage/report_lcov.sh
+++ b/src/coverage/report_lcov.sh
@@ -31,6 +31,10 @@ function bashunit::coverage::report_lcov() {
       local _fdi=0
       while IFS='|' read -r fn_name fn_start fn_end; do
         [ -z "$fn_name" ] && continue
+        # Belt and braces alongside the extract_functions fix (#936): a record
+        # whose span is not numeric must never reach the `for ((...))` below,
+        # where it aborts the report with a raw bash arithmetic error.
+        case "$fn_start$fn_end" in '' | *[!0-9]*) continue ;; esac
         echo "FN:${fn_start},${fn_name}"
         fn_total=$((fn_total + 1))
 

--- a/tests/unit/coverage_helpers_test.sh
+++ b/tests/unit/coverage_helpers_test.sh
@@ -287,3 +287,77 @@ function test_coverage_get_all_line_hits_counts_per_line() {
 
   assert_equals "5:3" "$result"
 }
+
+# A variable assignment is not a function definition. extract_functions cut the
+# candidate name at the first space, `(` or `{`, so in `VAR="x${Y}"` the `{` of
+# the expansion ended the name and the remaining `{Y}"` looked like a function
+# body opener. Every such assignment became a phantom FN record, corrupting
+# FNF/FNH in the LCOV report (#936).
+function test_coverage_extract_functions_ignores_assignment_with_expansion() {
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'FIXTURE'
+#!/usr/bin/env bash
+URL="https://${host}/api"
+PATH_="$HOME/${sub}"
+function real_fn() {
+  echo "hello"
+}
+FIXTURE
+
+  local result
+  result=$(bashunit::coverage::extract_functions "$temp_file")
+
+  assert_not_contains "URL" "$result"
+  assert_not_contains "PATH_" "$result"
+  assert_contains "real_fn" "$result"
+
+  rm -f "$temp_file"
+}
+
+# Same misdetection, but the value also contains the `|` used as the record
+# separator, so the emitted record gained a fourth field. report_lcov reads it
+# with `IFS='|' read -r fn_name fn_start fn_end`, landing a literal `$` in
+# fn_start and aborting its `for ((...))` with a bash arithmetic error (#936).
+function test_coverage_extract_functions_ignores_assignment_containing_a_pipe() {
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'FIXTURE'
+#!/usr/bin/env bash
+PS4_LIKE="x|${LINENO}"
+function real_fn() {
+  echo "hello"
+}
+FIXTURE
+
+  local result
+  result=$(bashunit::coverage::extract_functions "$temp_file")
+
+  assert_not_contains "PS4_LIKE" "$result"
+  assert_contains "real_fn" "$result"
+
+  rm -f "$temp_file"
+}
+
+# Every emitted record must be exactly name|start|end, so a malformed one can
+# never reach the arithmetic in report_lcov.
+function test_coverage_extract_functions_emits_three_fields_per_record() {
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'FIXTURE'
+#!/usr/bin/env bash
+PS4_LIKE="x|${LINENO}"
+function real_fn() { echo "hi"; }
+function bashunit::ns::other() {
+  echo "there"
+}
+FIXTURE
+
+  local malformed
+  malformed=$(bashunit::coverage::extract_functions "$temp_file" |
+    awk -F'|' 'NF != 3 || $2 !~ /^[0-9]+$/ || $3 !~ /^[0-9]+$/')
+
+  assert_empty "$malformed"
+
+  rm -f "$temp_file"
+}


### PR DESCRIPTION
## 🤔 Background

Related #936

`extract_functions` derived a candidate name by cutting at the first space, `(` or `{`, then accepted it if its **first character** looked like an identifier. For `URL="https://${host}/api"` the first such character is the `{` of the expansion, so the candidate became `URL="https://$` and the remainder `{host}/api"` read as a function-body opener. Braces balance on the line, so it was emitted as a single-line function.

## 💡 Changes

- The candidate must now **be** an identifier, not merely start like one — one `case` arm rejecting anything outside `[a-zA-Z0-9_:]`. No fork, Bash 3.0 safe, `::`-namespaced names still pass.
- `report_lcov` additionally skips any record whose span is not numeric, so a malformed record can never reach the arithmetic again whatever produces it.

## ✅ Impact, measured

Two consequences, and the quiet one is worse:

| | Symptom | Before | After |
|---|---|---|---|
| **Silent, wide** | phantom `FN` records inflate `FNF`/`FNH` in LCOV consumed by genhtml/Codecov/Coveralls — **affects user projects** | 17 phantom entries, `FNF` 465 | 0 phantom, `FNF` 448 |
| **Loud, narrow** | value containing `\|` shifts the record → `((: $: syntax error: operand expected` | reproduces every run | gone |

## ✅ Verification

TDD: three tests added to `tests/unit/coverage_helpers_test.sh` — assignments with expansions yield no record, assignments containing `|` yield no record, and every emitted record is exactly `name|start|end` with numeric span. All three verified failing before the fix.

Green: sequential (1604 passed, 0 failed) · `--parallel --simple --strict` · `--coverage --parallel` with no arithmetic error · `make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅`.

Not caught before because `--coverage` is a nightly non-gating workflow and the error went to stderr without failing the run.