### PR TITLE
build(make): collect tests recursively so tests/ can mirror src/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,15 @@ TEST_SCRIPTS_DIR=tests
 EXAMPLE_TEST_SCRIPTS=./example/logic_test.sh
 PRE_COMMIT_SCRIPTS_FILE=./bin/pre-commit
 
-TEST_SCRIPTS = $(wildcard $(TEST_SCRIPTS_DIR)/*/*[tT]est.sh)
+# Collected recursively so tests/unit/ can mirror the src/ module layout. A
+# plain $(wildcard tests/*/*[tT]est.sh) matches exactly one level, so a nested
+# test would be skipped by `make test` while `./bashunit tests/` still ran it --
+# green, and quietly testing less.
+#
+# fixtures/ is excluded by path: those files are inputs to other tests, not
+# tests. Four of them end in _test.sh and a naive recursive glob collects them.
+# tests/unit/project/collection_test.sh keeps this list honest.
+TEST_SCRIPTS = $(shell find $(TEST_SCRIPTS_DIR) -name '*[tT]est.sh' -not -path '*/fixtures/*' | sort)
 
 test/list:
 	@echo "Test scripts found:"

--- a/tests/unit/project/collection_test.sh
+++ b/tests/unit/project/collection_test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Anti-drift contract for how `make test` finds tests.
+#
+# The Makefile used to collect with $(wildcard tests/*/*[tT]est.sh), which matches
+# exactly one level. Once tests/unit/ mirrors the src/ module layout (#957), a
+# nested test would be skipped by `make test` while `./bashunit tests/` still ran
+# it -- CI green, quietly testing less. This file is itself nested, so the old
+# glob would not even have collected it.
+
+ROOT_DIR=""
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+}
+
+function collection_from_make() {
+  (cd "$ROOT_DIR" && make test/list 2>/dev/null | tail -n +2 | grep -v '^$' | LC_ALL=C sort)
+}
+
+function collection_from_disk() {
+  (cd "$ROOT_DIR" && find tests -name '*[tT]est.sh' -not -path '*/fixtures/*' | LC_ALL=C sort)
+}
+
+# Every real test file must reach `make test`, however deeply it is nested.
+function test_make_test_collects_every_test_file_on_disk() {
+  assert_same "$(collection_from_disk)" "$(collection_from_make)"
+}
+
+# Fixtures are inputs to other tests, not tests. Four of them end in _test.sh, so
+# a recursive glob without the fixtures/ exclusion collects and runs them.
+function test_make_test_collects_no_fixture() {
+  assert_not_contains "fixtures/" "$(collection_from_make)"
+}
+
+# The guard above is only meaningful if fixtures that would be caught still exist.
+function test_fixtures_that_would_be_swept_in_still_exist() {
+  local trap_files
+  trap_files=$(cd "$ROOT_DIR" && find tests -path '*/fixtures/*' -name '*[tT]est.sh' | wc -l | tr -d ' ')
+
+  assert_greater_than "0" "$trap_files"
+}

--- a/tests/unit/project/collection_test.sh
+++ b/tests/unit/project/collection_test.sh
@@ -14,8 +14,14 @@ function set_up_before_script() {
   ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 }
 
+# Filtered on a `tests/` prefix rather than by stripping a fixed number of header
+# lines: run from inside `make test`, this sub-make inherits MAKEFLAGS and wraps
+# its output in `make[1]: Entering/Leaving directory`, which a positional strip
+# gets wrong. MAKEFLAGS is cleared too, so the sub-make cannot inherit -j or a
+# parent goal.
 function collection_from_make() {
-  (cd "$ROOT_DIR" && make test/list 2>/dev/null | tail -n +2 | grep -v '^$' | LC_ALL=C sort)
+  (cd "$ROOT_DIR" && MAKEFLAGS='' make --no-print-directory test/list 2>/dev/null) |
+    grep '^tests/' | LC_ALL=C sort
 }
 
 function collection_from_disk() {


### PR DESCRIPTION
## 🤔 Background

Related #957 — **prerequisite for every PR in that issue.**

`src/` is 17 modules with no loose files. `tests/unit/` is still 71 flat files with the module encoded in a filename prefix. Mirroring the layout needs `make test` to find nested tests first.

## ⚠️ The problem this prevents

`Makefile:67` collected with `$(wildcard tests/*/*[tT]est.sh)` — **exactly one level**. `./bashunit tests/` already recurses (verified). So the moment a test is nested, three of the four CI matrix entries would run it and `make test` would silently skip it — **green, and quietly testing less**.

## 💡 Why "just make it recursive" is wrong

A naive recursive glob also collects **four files under `fixtures/` that are inputs to other tests**, not tests:

```
tests/acceptance/fixtures/tests_path/{a,other}_test.sh
tests/unit/fixtures/tests/example{1,2}_test.sh
```

So `fixtures/` is excluded by path. **Collection is unchanged today** — the same 156 files, verified byte-for-byte against the old glob's output. This PR moves nothing; it only makes nesting possible.

## ✅ The guard

`tests/unit/project/collection_test.sh` — **itself nested**, so the old glob wouldn't have collected it. Three assertions:

1. every test file on disk reaches `make test`
2. no fixture does
3. fixtures that *would* be swept in still exist — so assertion 2 can't pass vacuously

Both failure modes mutation-verified: reverting to the one-level glob reddens the first, dropping the `fixtures/` exclusion reddens the second.

## ✅ Verification

Suite total **1626 → 1629** — exactly the three new tests, nothing lost.

(`make test` reports a different total from `./bashunit tests/` for pre-existing mode-dependent skips, not collection differences — which is why the guard compares *file lists* rather than totals.)

Green: sequential · `--parallel --simple --strict` · `make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅`.