### PR TITLE
docs(src): tighten comments, drop duplicated boilerplate, fix stale refs

### DIFF
--- a/src/api/index.sh
+++ b/src/api/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/api/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/api/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # The surface a user's test file calls: temp_file/temp_dir/current_dir/data_set,
 # skip/todo, set_test_title, and the custom-assert facade (assert_that,

--- a/src/assert/assertions.sh
+++ b/src/assert/assertions.sh
@@ -16,18 +16,16 @@ _BASHUNIT_ASSERT_INNER_OUTPUT_OUT=""
 # Runs an assertion in isolation and reports what it did, without letting it
 # touch the calling test.
 #
-# Everything the inner assertion reports is snapshotted and restored: the two
-# counters, the stop-on-assertion-failure guard (src/assert.sh:10) — which
-# would otherwise make every later assertion in the same test skip — plus the
-# per-test output accumulator and the TAP line counter that
-# console_results::print_line feeds. Console output is redirected away.
+# Snapshotted and restored: both counters, the stop-on-assertion-failure guard
+# (assert/core.sh, which would otherwise skip every later assertion in the test),
+# the per-test output accumulator and the TAP line counter. Console output is
+# redirected away.
 #
-# The captured message is read back from that accumulator rather than from
-# stdout, because in --simple mode print_line only emits a one-char marker.
+# The message is read back from the accumulator, not stdout: --simple mode only
+# prints a one-char marker.
 #
-# Every slot is written *after* the call returns, which is what makes this
-# reentrant: a nested capture clobbers the slots while it runs, and the outer
-# frame overwrites them again on the way out.
+# Slots are written *after* the call returns, which makes this reentrant -- a
+# nested capture clobbers them, the outer frame overwrites them on the way out.
 #
 # Writes: _BASHUNIT_ASSERT_INNER_FAILED_OUT (1 when it reported a failure),
 #         _BASHUNIT_ASSERT_INNER_PASSED_OUT (1 when it reported a success),

--- a/src/assert/index.sh
+++ b/src/assert/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/assert/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/assert/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # core.sh first: the other files call its shared helpers (assert::should_skip,
 # assert::fail_with, assert::join_to_slot).

--- a/src/assert/once.sh
+++ b/src/assert/once.sh
@@ -1,27 +1,21 @@
 #!/usr/bin/env bash
 
-# Opt-in marker letting a composed custom assertion count and report once.
+# Opt-in marker: a custom assertion built from built-in assertions otherwise
+# reports one assertion per inner step, and its failure names the step rather
+# than itself. Declaring bashunit::assert_once absorbs them all into one.
 #
-# A custom assertion built out of built-in assertions otherwise reports one
-# assertion per inner step, and its failure names the inner step rather than
-# itself. Declaring bashunit::assert_once at the top of such a function absorbs
-# every assertion it makes into a single reported one.
+# Opt-in because bash has no cheap hook on a user function's return, and the
+# inner assertions are siblings, not nested frames -- nothing to detect without
+# a functrace RETURN trap on the per-test hot path. It also leaves existing
+# suites' totals untouched.
 #
-# Why opt-in: bash gives no cheap hook on a user function's *return*, and the
-# inner assertions are siblings rather than nested frames, so there is nothing
-# to detect implicitly without a functrace RETURN trap on the per-test hot path.
-# An explicit marker also keeps existing suites' totals unchanged.
+# With no return hook, the marker counts one pass immediately and the flush
+# converts it to a failure if anything it absorbed failed, so the totals are
+# correct at every point in time.
 #
-# How the absence of a return hook is worked around: the marker counts one
-# passing assertion immediately, and the flush converts that into a failure if
-# any absorbed assertion failed. The totals are therefore correct at every point
-# in time, without ever needing to observe the declaring function returning.
-#
-# The marker is closed (flushed) by whichever of these happens first:
-#   - another bashunit::assert_once call, which is what makes a loop over the
-#     same custom assertion count once per iteration,
-#   - an assertion reached after the declaring frame has returned,
-#   - the end of the test, via bashunit::runner::cleanup_on_exit.
+# Flushed by whichever comes first: the next assert_once call (which is what
+# makes a loop count once per iteration), an assertion after the declaring frame
+# returned, or runner::cleanup_on_exit at end of test.
 
 _BASHUNIT_ASSERT_ONCE_ACTIVE=0
 _BASHUNIT_ASSERT_ONCE_FRAME=""

--- a/src/benchmark/index.sh
+++ b/src/benchmark/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/benchmark/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/benchmark/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # The bench implementation. src/runner/bench.sh is the file and function loop
 # that drives it; this is what each bench function actually does.

--- a/src/cli/index.sh
+++ b/src/cli/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/cli/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/cli/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # The `bashunit <subcommand>` implementations. main.sh is their only caller; it
 # stays flat as the dispatcher. benchmark.sh is deliberately not here: the runner

--- a/src/config/index.sh
+++ b/src/config/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/config/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/config/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Run-scoped configuration and the state a run persists: every BASHUNIT_* default
 # and its scratch dirs (env), whether this run is parallel and its stop flag

--- a/src/console/index.sh
+++ b/src/console/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/console/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/console/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # colors.sh first: it defines the _BASHUNIT_COLOR_* palette everything else
 # renders with. The former results.sh is now six files, sourced leaves first:

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -22,7 +22,7 @@ _BASHUNIT_COVERAGE_IS_PARALLEL=""
 
 # Auto-discover coverage paths from test file names
 # When no explicit coverage paths are set, find source files matching test file base names
-# Example: tests/unit/assert_test.sh -> finds src/assert.sh, src/assert_*.sh
+# Example: tests/unit/assert/basic_test.sh -> finds src/assert/*.sh
 function bashunit::coverage::auto_discover_paths() {
   local project_root
   project_root="$(pwd)"

--- a/src/coverage/index.sh
+++ b/src/coverage/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/coverage/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/coverage/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Sourced in dependency layers, leaves first:
 #   config · paths · lines · functions → engine · stats · branches

--- a/src/doubles/index.sh
+++ b/src/doubles/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/doubles/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/doubles/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # mock.sh first: it declares _BASHUNIT_MOCKED_FUNCTIONS, the registry that
 # bashunit::spy also registers into and that runner/hooks.sh unwinds per test.

--- a/src/helper/discovery.sh
+++ b/src/helper/discovery.sh
@@ -56,12 +56,8 @@ function bashunit::helper::check_duplicate_functions() {
 }
 
 
-#
-# @param $1 string Eg: "prefix"
-# @param $2 string Eg: "filter"
-# @param $3 array Eg: "[fn1, fn2, prefix_filter_fn3, fn4, ...]"
-#
-# @return array Eg: "[prefix_filter_fn3, ...]" The filtered functions with prefix
+# Arguments: $1 - eg: "prefix", $2 - eg: "filter", $3 - eg: "[fn1, fn2, prefix_filter_fn3, fn4, ...]"
+# Returns: eg: "[prefix_filter_fn3, ...]" The filtered functions with prefix
 #
 function bashunit::helper::get_functions_to_run() {
   local prefix=$1
@@ -241,9 +237,8 @@ function bashunit::helper::load_bench_files() {
 }
 
 
-#
-# @param $1 string function name
-# @return number line number of the function in the source file
+# Arguments: $1 - function name
+# Returns: line number of the function in the source file
 #
 function bashunit::helper::get_function_line_number() {
   local fn_name=$1
@@ -266,10 +261,8 @@ function bashunit::helper::get_function_line_number() {
 # Supports two syntaxes:
 #   - path::function_name (filter by function name)
 #   - path:line_number (filter by line number)
-#
-# @param $1 string Eg: "tests/test.sh::test_foo" or "tests/test.sh:123"
-#
-# @return string Two lines: first is file path, second is filter (or empty)
+# Arguments: $1 - eg: "tests/test.sh::test_foo" or "tests/test.sh:123"
+# Returns: two lines: first is file path, second is filter (or empty)
 #
 function bashunit::helper::parse_file_path_filter() {
   local input="$1"
@@ -311,11 +304,8 @@ function bashunit::helper::parse_file_path_filter() {
 
 #
 # Finds the test function that contains a given line number in a file.
-#
-# @param $1 string File path
-# @param $2 number Line number
-#
-# @return string The function name, or empty if not found
+# Arguments: $1 - file path, $2 - line number
+# Returns: the function name, or empty if not found
 #
 function bashunit::helper::find_function_at_line() {
   local file="$1"

--- a/src/helper/functions.sh
+++ b/src/helper/functions.sh
@@ -2,8 +2,7 @@
 
 # Generic shell-function utilities.
 
-#
-# @param $1 string Eg: "do_something"
+# Arguments: $1 - eg: "do_something"
 #
 function bashunit::helper::execute_function_if_exists() {
   local fn_name="$1"
@@ -17,8 +16,7 @@ function bashunit::helper::execute_function_if_exists() {
 }
 
 
-#
-# @param $1 string Eg: "do_something"
+# Arguments: $1 - eg: "do_something"
 #
 function bashunit::helper::unset_if_exists() {
   unset "$1" 2>/dev/null

--- a/src/helper/index.sh
+++ b/src/helper/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/helper/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/helper/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Sourced leaves first; only discovery.sh has cross-file callees (provider.sh
 # and functions.sh).

--- a/src/helper/naming.sh
+++ b/src/helper/naming.sh
@@ -7,10 +7,8 @@
 # Walks up the call stack to find the first function that looks like a test function.
 # A test function is one that starts with "test_" or "test" (camelCase).
 # If no test function is found, falls back to the caller of the assertion function.
-#
-# @param $1 number Optional fallback depth (default: 2, i.e., the caller of the assertion)
-#
-# @return string The test function name, or fallback function name
+# Arguments: $1 - optional fallback depth (default: 2, i.e., the caller of the assertion)
+# Returns: the test function name, or fallback function name
 #
 _BASHUNIT_HELPER_TESTFN_OUT=""
 
@@ -58,10 +56,8 @@ function bashunit::helper::find_test_function_name() {
   echo "${FUNCNAME[$fallback_depth]:-}"
 }
 
-#
-# @param $1 string Eg: "test_some_logic_camelCase"
-#
-# @return string Eg: "Some logic camelCase"
+# Arguments: $1 - eg: "test_some_logic_camelCase"
+# Returns: eg: "Some logic camelCase"
 #
 _BASHUNIT_HELPER_NORMALIZED_OUT=""
 
@@ -70,9 +66,7 @@ _BASHUNIT_HELPER_NORMALIZED_OUT=""
 # Return-slot variant of normalize_test_function_name: writes the result into
 # _BASHUNIT_HELPER_NORMALIZED_OUT with no fork, removing the command-substitution
 # fork at the (failure-path) call sites in the assertion layer.
-#
-# @param $1 string Eg: "test_some_logic_camelCase"
-# @param $2 string Optional interpolated name
+# Arguments: $1 - eg: "test_some_logic_camelCase", $2 - optional interpolated name
 #
 function bashunit::helper::normalize_test_function_name_to_slot() {
   local original_fn_name="${1-}"
@@ -129,10 +123,8 @@ function bashunit::helper::normalize_test_function_name_to_slot() {
 }
 
 
-#
-# @param $1 string Eg: "test_some_logic_camelCase"
-#
-# @return string Eg: "Some logic camelCase"
+# Arguments: $1 - eg: "test_some_logic_camelCase"
+# Returns: eg: "Some logic camelCase"
 #
 function bashunit::helper::normalize_test_function_name() {
   bashunit::helper::normalize_test_function_name_to_slot "${1-}" "${2-}"

--- a/src/helper/provider.sh
+++ b/src/helper/provider.sh
@@ -24,8 +24,7 @@ function bashunit::helper::_resolve_provider_script() {
 #
 # Scans a script once and caches its test-function -> provider-function pairs.
 # Memoized by resolved path, so repeated calls for the same file do not rescan.
-#
-# @param $1 string Path to the test script
+# Arguments: $1 - path to the test script
 #
 function bashunit::helper::build_provider_map() {
   bashunit::helper::_resolve_provider_script "$1"
@@ -97,8 +96,7 @@ function bashunit::helper::build_provider_map() {
 #
 # Pure-bash lookup against the cached provider map.
 # Writes the provider-function name (or empty) into _BASHUNIT_PROVIDER_FN_OUT.
-#
-# @param $1 string Test-function name
+# Arguments: $1 - test-function name
 #
 function bashunit::helper::provider_for_function() {
   local function_name=$1

--- a/src/helper/tags.sh
+++ b/src/helper/tags.sh
@@ -5,8 +5,7 @@
 #
 # Scans a script once and caches its test-function -> tags pairs.
 # Memoized by resolved path, so repeated calls for the same file do not rescan.
-#
-# @param $1 string Path to the test script
+# Arguments: $1 - path to the test script
 #
 function bashunit::helper::build_tags_map() {
   local script=$1
@@ -70,8 +69,7 @@ function bashunit::helper::build_tags_map() {
 #
 # Pure-bash lookup against the cached tags map.
 # Writes the comma-separated tags (or empty) into _BASHUNIT_TAGS_OUT.
-#
-# @param $1 string Test-function name
+# Arguments: $1 - test-function name
 #
 function bashunit::helper::tags_for_function() {
   local function_name=$1
@@ -93,12 +91,10 @@ function bashunit::helper::tags_for_function() {
 # Include uses OR logic (any match passes).
 # Exclude uses OR logic (any match fails).
 # Exclude takes precedence over include.
-#
-# @param $1 string Comma-separated tags for the function
-# @param $2 string Comma-separated include tags (empty = no filter)
-# @param $3 string Comma-separated exclude tags (empty = no filter)
-#
-# @return 0 if function should run, 1 if it should be skipped
+# Arguments: $1 - comma-separated tags for the function,
+#            $2 - comma-separated include tags (empty = no filter),
+#            $3 - comma-separated exclude tags (empty = no filter)
+# Returns: 0 if the function should run, 1 if it should be skipped
 #
 function bashunit::helper::function_matches_tags() {
   local fn_tags="$1"

--- a/src/learn/index.sh
+++ b/src/learn/index.sh
@@ -2,10 +2,8 @@
 
 # Interactive learning module for bashunit: guided tutorials and exercises.
 #
-# Entry point for the src/learn/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/learn/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Sourced in dependency layers, leaves first:
 #   progress -> session -> lessons -> menu

--- a/src/main/index.sh
+++ b/src/main/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/main/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/main/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # The CLI layer: flag parsing per subcommand, plus the run lifecycle it drives.
 # The `cmd_*` parsers stay together rather than moving next to their src/cli/

--- a/src/reports/index.sh
+++ b/src/reports/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/reports/ module: only `source` lines and comments
-# belong here. build.sh emits a file's body before recursing into its `source`
-# lines, so any statement here would run before its dependencies in the built
-# binary (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/reports/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # collect.sh holds the shared result arrays; each writer reads them and nothing
 # else, so the layering is one level deep.

--- a/src/runner/index.sh
+++ b/src/runner/index.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/runner/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary.
+# Entry point for the src/runner/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Sourced in dependency layers, leaves first:
 #   context · payload · diagnostics → parallel · hooks · result → provider · exec → discovery · bench

--- a/src/state/index.sh
+++ b/src/state/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/state/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/state/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # counters.sh and duplicates.sh declare the globals context.sh's per-test reset
 # clears, so they are sourced first.

--- a/src/system/index.sh
+++ b/src/system/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/system/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/system/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Capability probing: what this machine is and what it has. The bottom layer --
 # nothing here touches config, test state, console or the runner.

--- a/src/util/index.sh
+++ b/src/util/index.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-# Entry point for the src/util/ module: only `source` lines and comments belong
-# here. build.sh emits a file's body before recursing into its `source` lines, so
-# any statement here would run before its dependencies in the built binary
-# (adrs/adr-010-src-module-directories.md).
+# Entry point for the src/util/ module. `source` lines and comments only,
+# for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Computation: strings, arithmetic and time. math.sh and clock.sh probe for bc,
 # awk and a sub-second clock through src/system/dependencies.sh, so the edge runs


### PR DESCRIPTION
## 🤔 Background

An audit of every comment in `src/`. **Code is untouched** — every changed line is a comment, verified mechanically.

## 💡 What actually needed fixing

**Duplication, more than verbosity.** All 16 module `index.sh` files repeated the same 4-line justification of why an aggregator may hold only `source` lines. ADR-011 now records that rule once, so each index points at it in one line and keeps only what's specific to that module — its layering and ordering constraints. **30 lines.**

**Two stale references**, both from the module splits: `assert/assertions.sh` pointed at `src/assert.sh:10`, and `coverage/config.sh` used `src/assert.sh` in an example. Nothing else across `src/` referenced a path or function that no longer exists — a good sign for how those refactors went.

**One inconsistent doc style.** `src/helper/` was the last holdout: 5 files used `@param`/`@return` while 33 used the `Arguments:`/`Returns:` form that `.claude/rules/bash-style.md` documents. Converted, 23 blocks.

**Three of my own over-wordy blocks** from this session's refactors — `assert/once.sh` (22 → 16 lines), `assert/assertions.sh`, `runner/result.sh` — keeping every fact, cutting connective prose.

## 📌 Deliberately left alone

Long comments that earn their length:

- `config/env.sh` `create_scratch_dirs` — explains that a missing scratch dir renders a **red suite green**, the worst failure mode for a test runner
- `main/test.sh` — the export-leak contract from #834/#837, and what to do when adding a flag
- `config/rerun.sh` — a two-phase record/replay mechanism not readable from the code

Those are the "why" the style guide asks for, not padding. There was also **no mechanical redundancy** to cut: no comment restates the function below it, and no empty `Arguments:` blocks exist.

## ✅ Verification

2398 → 2331 comment lines, no information lost. Two defects my own conversion introduced were caught and fixed before commit: one `Returns:` line lost a leading `0`, and one joined `Arguments:` line hit 165 chars.

Green: sequential (1630) · `--parallel --simple --strict` (1589) · `make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅`.