### PR TITLE
chore(sa): remove 11 dead ShellCheck disable directives

### DIFF
--- a/src/config/parallel.sh
+++ b/src/config/parallel.sh
@@ -9,7 +9,6 @@ function bashunit::parallel::must_stop_on_failure() {
 }
 
 function bashunit::parallel::cleanup() {
-  # shellcheck disable=SC2153
   local target="$TEMP_DIR_PARALLEL_TEST_SUITE"
   case "$target" in
   */bashunit/parallel/*)

--- a/src/console/line.sh
+++ b/src/console/line.sh
@@ -14,7 +14,6 @@ _BASHUNIT_TOTAL_TESTS_COUNT=0
 # Arguments: $1 - test type, $2 - already formatted line
 ##
 function bashunit::console_results::print_line() {
-  # shellcheck disable=SC2034
   local type=$1
   local line=$2
 

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -51,7 +51,6 @@ function bashunit::coverage::enable_trap() {
 
   # Set DEBUG trap to record line execution
   # Use ${VAR:-} to handle unset variables when set -u is active (in subshells)
-  # shellcheck disable=SC2154
   trap 'bashunit::coverage::record_line "${BASH_SOURCE[0]:-}" "${LINENO:-}"' DEBUG
 }
 

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -63,7 +63,6 @@ function bashunit::coverage::should_track() {
   IFS=','
   local pattern
   for pattern in $BASHUNIT_COVERAGE_EXCLUDE; do
-    # shellcheck disable=SC2254
     case "$normalized_file" in
     *$pattern*)
       IFS="$old_ifs"

--- a/src/runner/exec.sh
+++ b/src/runner/exec.sh
@@ -165,7 +165,6 @@ function bashunit::runner::execute_test_body() {
   fi
 
   # Run set_up and capture exit code without || to preserve errexit behavior
-  # shellcheck disable=SC2030
   _BASHUNIT_SETUP_COMPLETED=false
   local setup_exit_code=0
   bashunit::runner::run_set_up "$test_file"

--- a/src/runner/hooks.sh
+++ b/src/runner/hooks.sh
@@ -22,7 +22,6 @@ function bashunit::runner::cleanup_on_exit() {
   # Additionally, the stdout redirect from execute_test_hook leaks into the
   # EXIT trap. Restore stdout from saved FD 5 so export_subshell_context
   # output reaches test_execution_result.
-  # shellcheck disable=SC2031
   if [ "${_BASHUNIT_SETUP_COMPLETED:-true}" != "true" ]; then
     exec 1>&5
     if [ "$exit_code" -eq 0 ]; then
@@ -103,7 +102,6 @@ function bashunit::runner::execute_file_hook() {
   # NOT this executor: on Bash >= 4 the trap also fires HERE when the hook call
   # itself returns non-zero, and an unconditional return skipped
   # record_file_hook_failure entirely (silent failures, off-by-one counts, #836).
-  # shellcheck disable=SC2154
   trap '_BASHUNIT_HOOK_ERR_STATUS=$?
     if [ "${FUNCNAME[0]:-}" != "bashunit::runner::execute_file_hook" ]; then
       set +Eu +o pipefail
@@ -224,7 +222,6 @@ function bashunit::runner::execute_test_hook() {
   # See the twin comment in execute_file_hook: conditional return keeps the
   # early-exit semantics for intermediate failures without silently returning
   # from THIS executor when the trap re-fires here on Bash >= 4 (#836).
-  # shellcheck disable=SC2154
   trap '_BASHUNIT_HOOK_ERR_STATUS=$?
     if [ "${FUNCNAME[0]:-}" != "bashunit::runner::execute_test_hook" ]; then
       set +Eu +o pipefail

--- a/src/runner/payload.sh
+++ b/src/runner/payload.sh
@@ -184,7 +184,6 @@ function bashunit::runner::extract_assertion_runtime_output() {
   echo "$runtime_output"
 }
 
-# shellcheck disable=SC2295
 ##
 # Parses the encoded per-test result's last line into the counts out-slots
 # (_BASHUNIT_RUNNER_COUNTS_*_OUT). Pure read: never mutates the cumulative

--- a/src/state/payload.sh
+++ b/src/state/payload.sh
@@ -16,7 +16,6 @@ unset _bashunit_base64_help
 # in line parsing, so encode_base64 emits this token and both decode sites map it
 # back to "". Single source of truth keeps the encode (helpers.sh) and decode
 # (helpers.sh, runner/payload.sh) sides byte-identical.
-# shellcheck disable=SC2034 # read cross-file in helpers.sh and runner/payload.sh
 _BASHUNIT_BASE64_EMPTY_SENTINEL="_BASHUNIT_EMPTY_"
 
 function bashunit::state::encode_field() {

--- a/src/system/check_os.sh
+++ b/src/system/check_os.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-# shellcheck disable=SC2034
 _BASHUNIT_OS="Unknown"
 _BASHUNIT_DISTRO="Unknown"
 


### PR DESCRIPTION
## 🤔 Background

A `# shellcheck disable=` for a warning that no longer fires is dead weight — and misleading, since it tells the next reader the line below is doing something ShellCheck objects to when it is not. This project has found stale ones twice before (#928, #947), both times by accident rather than by looking.

## 💡 Changes

- Removed **11 dead directives across 9 files**: `SC2153`, `SC2034` ×3, `SC2154` ×3, `SC2254`, `SC2030`, `SC2031`, `SC2295`
- **Kept** every `SC1091` / `SC2155` / `SC2016` disable — those don't fire only because both gates exclude those codes globally, which is not the same as being obsolete; they still work for anyone running plain `shellcheck`
- Explanatory comments above or beside a removed directive are kept where they still say something true

## 🔍 How they were found

Mechanically, not by eye: strip every disable from a file, re-run ShellCheck, see which declared codes come back. Two details decided correct-vs-wrong:

- **In place, not in `/tmp`.** `.shellcheckrc` sets `source-path=src` + `external-sources=true`, so copying a file elsewhere breaks source resolution and changes what `SC2154`/`SC2034` report — the exact codes under test.
- **Both gates.** `make sa` runs `-xC` (follows `source`); CI's `ludeeus/action-shellcheck` does not. They disagree on cross-file symbols, so a directive only counts as dead if it fires under *neither*. That didn't change the final list, but assuming it would have been luck.

## ✅ Verification

Every changed line is a comment (diff filtered to confirm). `make sa` · `make lint` · CI-mode ShellCheck (no `-x`, exact CI opts, clean) · `bash build.sh bin -v` → `✅ Build verified ✅`.

Suites match baseline exactly: **1630** sequential, **1589** parallel/simple/strict.