### PR TITLE
test(completions): close a blind spot in the zsh flag parity contract

### DIFF
--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -5,7 +5,8 @@
 #   cp completions/_bashunit /usr/local/share/zsh/site-functions/_bashunit
 # then restart zsh (or reinitialize completions with compinit).
 #
-# Kept in sync with src/main.sh by tests/unit/completions_test.sh (anti-drift).
+# Kept in sync with src/main/test.sh and src/main/subcommands.sh by
+# tests/unit/main/completions_test.sh (anti-drift).
 
 _bashunit() {
   local curcontext="$curcontext" ret=1

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -5,7 +5,8 @@
 # or source it from your ~/.bashrc:
 #   source /path/to/bashunit/completions/bashunit.bash
 #
-# Kept in sync with src/main.sh by tests/unit/completions_test.sh (anti-drift).
+# Kept in sync with src/main/test.sh and src/main/subcommands.sh by
+# tests/unit/main/completions_test.sh (anti-drift).
 # Works on bash 3.0+ (plain compgen -W, no bash-completion helpers required).
 
 _BASHUNIT_COMPLETIONS_SUBCOMMANDS="test bench doc init learn upgrade assert watch"

--- a/tests/unit/main/completions_test.sh
+++ b/tests/unit/main/completions_test.sh
@@ -42,10 +42,18 @@ function completions_bash_flags() {
 
 # Flags advertised by the zsh completion script: strip [descriptions], then
 # collect every -x/--long token.
+#
+# The '(-p --parallel)' exclusion groups are stripped as well, and that is the
+# whole point rather than tidiness. A zsh spec names each flag twice --
+# '(-p --parallel)'{-p,--parallel}'[...]' -- once to say "these are mutually
+# exclusive" and once to actually offer them. Reading both halves meant deleting
+# a flag from the offered {..} token left it visible in the exclusion group, so
+# this contract stayed green while zsh had quietly stopped completing the flag.
+# Only the offered forms count.
 function completions_zsh_flags() {
   # Each punctuation char maps to a space (char-by-char); the repeated spaces are intentional.
   # shellcheck disable=SC2020
-  sed 's/\[[^]]*\]//g' "$ZSH_COMPLETION_FILE" |
+  sed 's/\[[^]]*\]//g; s/(\([^)]*\))//g' "$ZSH_COMPLETION_FILE" |
     tr '{}(),"'"'"':' '      ' | tr ' \t' '\n\n' |
     grep -E '^--?[a-zA-Z][a-zA-Z0-9-]*$' |
     LC_ALL=C sort -u


### PR DESCRIPTION
## 🤔 Background

The zsh contract could not detect a flag being **dropped from the completion script** — the one thing it exists to catch.

A zsh option spec names each flag twice:

```zsh
'(-p --parallel)'{-p,--parallel}'[Run tests in parallel]'
```

The parenthesised group declares mutual exclusion; the braced group is what zsh actually offers. `completions_zsh_flags` tokenised the whole line, so it read **both**. Deleting `--parallel` from the braced group left it visible in the exclusion group — contract green, zsh no longer completing the flag.

## 🔬 How it was found

Every contract test in the suite was mutated to check it still fails when the thing it guards breaks. Three did. This one didn't.

Two *other* apparent misses turned out to be **bad mutations of mine, not bad tests**: one sed hit the exclusion group instead of the braced one, another's pattern matched no line at all and silently changed nothing. Both were re-verified before being believed — which is the only reason the remaining finding is real.

| Contract | Mutation | Caught? |
|---|---|---|
| `bash_compatibility` | inject `declare -A` into `src/` | ✅ |
| `build` aggregator | statement in an `index.sh` | ✅ |
| `env_deprecated_aliases` | drop an alias from the list | ✅ |
| `completions` (bash) | drop a flag from the opts var | ✅ |
| `completions` (bash↔`main/`) | add a flag `main/` parses | ✅ |
| **`completions` (zsh)** | **drop a flag from `{-p,--parallel}`** | ❌ → now ✅ |

## 💡 Changes

- Strip exclusion groups before tokenising. Extracted flag set is **byte-identical** on the current file (67 flags), confirming no flag is declared exclusive without also being offered — this narrows what the test *reads*, not what it *checks*.
- Fixed both completion script headers: they pointed at `src/main.sh` and `tests/unit/completions_test.sh`, neither of which has existed since the module split. A header whose whole job is to name the other end of a contract is worse than none when the path is wrong.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1633** sequential / **1592** parallel-simple-strict (unchanged).