### PR TITLE
fix(coverage): reference shared threshold defaults instead of bare literals

### DIFF
--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -76,9 +76,11 @@ function bashunit::main::validate_config_or_exit() {
   # false on a non-integer operand, leaking a raw shell error into the
   # coverage report and silently mis-bucketing every file's class (#879).
   bashunit::main::require_non_negative_int_or_exit \
-    "${BASHUNIT_COVERAGE_THRESHOLD_LOW:-50}" "BASHUNIT_COVERAGE_THRESHOLD_LOW"
+    "${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}" \
+    "BASHUNIT_COVERAGE_THRESHOLD_LOW"
   bashunit::main::require_non_negative_int_or_exit \
-    "${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-80}" "BASHUNIT_COVERAGE_THRESHOLD_HIGH"
+    "${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}" \
+    "BASHUNIT_COVERAGE_THRESHOLD_HIGH"
 
   if [ -n "${BASHUNIT_SEED:-}" ]; then
     bashunit::main::require_non_negative_int_or_exit "${BASHUNIT_SEED}" "BASHUNIT_SEED (--seed)"


### PR DESCRIPTION
## 🤔 Background

`src/main/validate.sh` fell back to a hardcoded `50`/`80`, while `config/env.sh` declares `_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW`/`_HIGH` and all three other consumers read the named constants.

## 📏 Severity, stated precisely

**This fallback is unreachable.** `env.sh` assigns with `:=`, so `BASHUNIT_COVERAGE_THRESHOLD_LOW`/`_HIGH` are always set by the time `main/` is sourced and the `:-` branch never fires. Verified empirically. An audit note flagged this as a latent divergence risk — that overstated it, and it's worth saying so rather than inheriting the framing.

It's still worth removing: a dead fallback carrying a number that duplicates a named constant is a trap for whoever makes it reachable, and reads as a fourth, disagreeing source of truth to anyone grepping for the default.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1633** sequential / **1592** parallel-simple-strict, both unchanged.