### PR TITLE
fix(cli): validate BASHUNIT_SHARD_INDEX/TOTAL set outside the --shard flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Internal: `src/runner.sh` and `src/coverage.sh` are split into `src/runner/` and `src/coverage/` modules of single-responsibility files, each behind a `source`-only `index.sh` aggregator. A pure relocation, no behavior change; see [ADR-010](adrs/adr-010-src-module-directories.md) (#924, #925)
 
 ### Fixed
+- `BASHUNIT_SHARD_INDEX` / `BASHUNIT_SHARD_TOTAL` set directly (for example in `.bashunitrc`) are now validated. Only the `--shard` flag path parsed them, so a zero or non-numeric total reached raw arithmetic and printed a bare `division by 0` shell error while still exiting 0, and an out-of-range index silently reported `No tests found`
 - `assert_json_equals` no longer reports two invalid (unparseable) JSON strings as equal. It sorted both sides with `jq -S` but never checked jq's exit code, so two differently-invalid inputs both silently sorted to an empty string and compared equal instead of failing
 - Parallel runs no longer lose results when two test files in different directories share a filename. Per-test results were bucketed by basename, so the second file overwrote the first — silently, with the run still green. A tests/ tree mirroring a src/ tree makes that layout ordinary (#959)
 - Coverage no longer counts variable assignments as functions. A line like `URL="https://${host}/api"` was reported as a function, inflating `FNF`/`FNH` in the LCOV report (17 phantom entries in bashunit's own run); when the value also contained a `|`, the malformed record aborted the LCOV writer with a raw bash arithmetic error (#936)

--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -86,6 +86,26 @@ function bashunit::main::validate_config_or_exit() {
     bashunit::main::require_non_negative_int_or_exit "${BASHUNIT_SEED}" "BASHUNIT_SEED (--seed)"
   fi
 
+  # BASHUNIT_SHARD_INDEX/BASHUNIT_SHARD_TOTAL set directly (e.g. via .bashunitrc)
+  # bypass bashunit::main::set_shard_or_exit's parsing, which only runs on the
+  # --shard flag path. Left unchecked, a non-numeric or zero total reached the
+  # raw arithmetic in main/run.sh as a "division by 0" shell error, and an
+  # out-of-range index silently produced "No tests found" instead of a clear
+  # message -- the same failure shape this function already closed for other
+  # settings (#873, #879).
+  if bashunit::env::is_shard_enabled; then
+    bashunit::main::require_non_negative_int_or_exit \
+      "${BASHUNIT_SHARD_INDEX}" "BASHUNIT_SHARD_INDEX"
+    bashunit::main::require_non_negative_int_or_exit \
+      "${BASHUNIT_SHARD_TOTAL}" "BASHUNIT_SHARD_TOTAL"
+    if [ "$BASHUNIT_SHARD_TOTAL" -lt 1 ] || [ "$BASHUNIT_SHARD_INDEX" -lt 1 ] ||
+      [ "$BASHUNIT_SHARD_INDEX" -gt "$BASHUNIT_SHARD_TOTAL" ]; then
+      printf "%sError: BASHUNIT_SHARD_INDEX/BASHUNIT_SHARD_TOTAL must satisfy 1 <= index <= total.%s\n" \
+        "${_BASHUNIT_COLOR_FAILED}" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+      exit 1
+    fi
+  fi
+
   local _report_var _report_path
   for _report_var in BASHUNIT_LOG_JUNIT BASHUNIT_LOG_GHA BASHUNIT_REPORT_HTML \
     BASHUNIT_REPORT_TAP BASHUNIT_REPORT_JSON; do

--- a/tests/acceptance/bashunit_shard_test.sh
+++ b/tests/acceptance/bashunit_shard_test.sh
@@ -45,6 +45,44 @@ function test_shard_rejects_non_numeric_input() {
     "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --shard x/2 $FILES 2>&1)"
 }
 
+## BASHUNIT_SHARD_INDEX/BASHUNIT_SHARD_TOTAL set directly (bypassing the --shard
+## flag's own parser) used to reach unguarded arithmetic in main/run.sh: a zero
+## or non-numeric total crashed with a raw "division by 0" shell error, and an
+## out-of-range index silently printed "No tests found" -- neither produced the
+## "Error:"-prefixed message every other invalid setting gives.
+## validate_config_or_exit now checks both directly, same as every other
+## BASHUNIT_* numeric setting.
+function test_shard_env_rejects_zero_total() {
+  # Inlined rather than `output="$(...)"` on its own line: under --strict
+  # (set -euo pipefail) a bare assignment from a failing command substitution
+  # aborts the test before the assertion below ever runs, same as the two
+  # --shard-flag tests above. This one fails via a bashunit that now exits 1
+  # on purpose, so it must survive strict mode exactly like they do.
+  # shellcheck disable=SC2086
+  assert_contains "Error:" \
+    "$(BASHUNIT_SHARD_INDEX=1 BASHUNIT_SHARD_TOTAL=0 \
+      ./bashunit --no-parallel --env "$TEST_ENV_FILE" $FILES 2>&1)"
+}
+
+function test_shard_env_rejects_non_numeric_total() {
+  # shellcheck disable=SC2086
+  assert_contains "Error:" \
+    "$(BASHUNIT_SHARD_INDEX=1 BASHUNIT_SHARD_TOTAL=x \
+      ./bashunit --no-parallel --env "$TEST_ENV_FILE" $FILES 2>&1)"
+}
+
+function test_shard_env_rejects_index_greater_than_total() {
+  # shellcheck disable=SC2086
+  assert_contains "Error:" \
+    "$(BASHUNIT_SHARD_INDEX=3 BASHUNIT_SHARD_TOTAL=2 \
+      ./bashunit --no-parallel --env "$TEST_ENV_FILE" $FILES 2>&1)"
+}
+
+function test_shard_env_accepts_a_valid_direct_spec() {
+  assert_same "a c" \
+    "$(BASHUNIT_SHARD_INDEX=1 BASHUNIT_SHARD_TOTAL=2 shard_run)"
+}
+
 function test_shard_composes_with_parallel() {
   local order_file count
   order_file="$(mktemp)"


### PR DESCRIPTION
## 🤔 Background

```console
$ BASHUNIT_SHARD_INDEX=1 BASHUNIT_SHARD_TOTAL=0 ./bashunit tests/
./src/main/run.sh: line 39: _i % _shard_total: division by 0
$ echo $?
0
```

Sharding is configurable two ways — the `--shard` flag, or the environment variables directly (including from `.bashunitrc`). Only the flag path was parsed and range-checked: `set_shard_or_exit` runs solely when `--shard` is seen. Setting the variables directly walked straight into `main/run.sh`'s arithmetic.

## 🐛 Two bad outcomes

- **Zero or non-numeric total** — leaked a raw bash error to the user *and still exited 0*, so a sharded CI job reported success while running nothing
- **Out-of-range index** — quietly printed `No tests found`, which reads as a filter problem rather than a misconfiguration

The exit-0 half is what matters: it's the same shape `validate_config_or_exit` was introduced to close in #873 and #879, where bad input ran the wrong thing and reported success.

## 💡 Changes

Validation hangs off `bashunit::env::is_shard_enabled`, so it covers **both** entry points rather than duplicating the flag path's checks. Non-sharded runs are untouched, and `--shard` keeps its own parsing and existing message.

Verified: `total=0`, `index>total`, `index=0` and non-numeric all now exit 1 with a clear message; valid `1/2`, no-shard, and both `--shard 1/2` (0) and `--shard 5/2` (1) unchanged.

## ✅ Verification

3 acceptance tests, confirmed RED against the unfixed source.

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1639** sequential / **1598** parallel-simple-strict.