### PR TITLE
chore(benchmark): clean up three leftovers from the module split

### DIFF
--- a/src/benchmark/annotations.sh
+++ b/src/benchmark/annotations.sh
@@ -2,6 +2,13 @@
 
 # Parsing the @revs/@its/@max_ms markers above a bench function.
 
+##
+# Fails when a marker is present in the annotation but produced no value, which
+# only happens when its argument is malformed. Silently falling back to the
+# default ran a different benchmark than the one asked for: `@revs=abc` quietly
+# became one revolution, and `@max_ms=abc` dropped the threshold entirely (#884).
+# Arguments: $1 annotation line, $2 marker name, $3 value extracted so far
+##
 function bashunit::benchmark::reject_malformed_marker() {
   local annotation=$1
   local marker=$2

--- a/src/benchmark/results.sh
+++ b/src/benchmark/results.sh
@@ -2,21 +2,11 @@
 
 # The collected bench results and the table they print as.
 
-#!/usr/bin/env bash
-
 _BASHUNIT_BENCH_NAMES=()
 _BASHUNIT_BENCH_REVS=()
 _BASHUNIT_BENCH_ITS=()
 _BASHUNIT_BENCH_AVERAGES=()
 _BASHUNIT_BENCH_MAX_MILLIS=()
-
-##
-# Fails when a marker is present in the annotation but produced no value, which
-# only happens when its argument is malformed. Silently falling back to the
-# default ran a different benchmark than the one asked for: `@revs=abc` quietly
-# became one revolution, and `@max_ms=abc` dropped the threshold entirely (#884).
-# Arguments: $1 annotation line, $2 marker name, $3 value extracted so far
-##
 
 function bashunit::benchmark::add_result() {
   _BASHUNIT_BENCH_NAMES[${#_BASHUNIT_BENCH_NAMES[@]}]="$1"
@@ -25,8 +15,6 @@ function bashunit::benchmark::add_result() {
   _BASHUNIT_BENCH_AVERAGES[${#_BASHUNIT_BENCH_AVERAGES[@]}]="$4"
   _BASHUNIT_BENCH_MAX_MILLIS[${#_BASHUNIT_BENCH_MAX_MILLIS[@]}]="$5"
 }
-
-# shellcheck disable=SC2155
 
 function bashunit::benchmark::print_results() {
   if ! bashunit::env::is_bench_mode_enabled; then


### PR DESCRIPTION
## 🤔 Background

Three leftovers in `src/benchmark/`, all traceable to the same `refactor(benchmark): group the bench implementation` split, all inert.

## 💡 Changes

**A second `#!/usr/bin/env bash` at line 5 of `results.sh`.** Only the *first* line is stripped when embedding (`tail -n +2`), so the stray one was copied verbatim into the released binary — the built artifact held **22** shebang lines and now holds **21**. Harmless, but nobody wrote it on purpose.

**A docblock for `bashunit::benchmark::reject_malformed_marker`** sitting in `results.sh`, while the function itself lives in `annotations.sh` — the function moved and its documentation didn't. Moved to sit above the function it describes, text unchanged. A docblock floating above an unrelated function is worse than none: it reads as documentation for whatever follows.

**A dead `# shellcheck disable=SC2155`** — zero findings with the directive removed *and* the global exclusion lifted, under both `-x` and plain invocation.

## ⚠️ A correction to my own earlier claim

While briefing this work I asserted that all five remaining `SC2155` disables were dead. **That was wrong for four of them.** I had checked by running ShellCheck with the directives still in place, which trivially reports nothing.

Removed properly, they surface real findings:

| File | SC2155 findings suppressed |
|---|---|
| `reports/html.sh` | 7 |
| `reports/junit.sh` | 5 |
| `assert/snapshot.sh` | 3 |
| `helper/naming.sh` | 2 |
| `benchmark/results.sh` | **0 — genuinely dead** |

They stay, and #963 was right to keep them.

## ✅ Verification

Function count unchanged at **612**. `make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1646** sequential / **1605** parallel-simple-strict, both unchanged.