### PR TITLE
refactor(coverage,reports): share three copy-pasted parsers

### DIFF
--- a/src/coverage/html_file.sh
+++ b/src/coverage/html_file.sh
@@ -7,14 +7,13 @@ function bashunit::coverage::generate_file_html() {
   local output_file="$2"
 
   local display_file="${file#"$(pwd)"/}"
-  local executable hit pct class stats rest
+  local executable hit pct class stats
   stats=$(bashunit::coverage::get_cached_stats "$file")
-  executable="${stats%%:*}"
-  rest="${stats#*:}"
-  hit="${rest%%:*}"
-  rest="${rest#*:}"
-  pct="${rest%%:*}"
-  class="${rest#*:}"
+  bashunit::coverage::split_stats "$stats"
+  executable="$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
+  hit="$_BASHUNIT_COVERAGE_SPLIT_HIT_OUT"
+  pct="$_BASHUNIT_COVERAGE_SPLIT_PCT_OUT"
+  class="$_BASHUNIT_COVERAGE_SPLIT_CLASS_OUT"
   local uncovered=$((executable - hit))
 
   # Pre-load all line hits into indexed array (performance optimization)

--- a/src/coverage/report_html.sh
+++ b/src/coverage/report_html.sh
@@ -32,11 +32,10 @@ function bashunit::coverage::report_html() {
 
     local stats executable hit pct
     stats=$(bashunit::coverage::get_cached_stats "$file")
-    executable="${stats%%:*}"
-    stats="${stats#*:}"
-    hit="${stats%%:*}"
-    stats="${stats#*:}"
-    pct="${stats%%:*}"
+    bashunit::coverage::split_stats "$stats"
+    executable="$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
+    hit="$_BASHUNIT_COVERAGE_SPLIT_HIT_OUT"
+    pct="$_BASHUNIT_COVERAGE_SPLIT_PCT_OUT"
 
     total_executable=$((total_executable + executable))
     total_hit=$((total_hit + hit))

--- a/src/coverage/report_text.sh
+++ b/src/coverage/report_text.sh
@@ -20,14 +20,13 @@ function bashunit::coverage::report_text() {
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
     has_files=true
 
-    local executable hit pct class stats rest
+    local executable hit pct class stats
     stats=$(bashunit::coverage::get_cached_stats "$file")
-    executable="${stats%%:*}"
-    rest="${stats#*:}"
-    hit="${rest%%:*}"
-    rest="${rest#*:}"
-    pct="${rest%%:*}"
-    class="${rest#*:}"
+    bashunit::coverage::split_stats "$stats"
+    executable="$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
+    hit="$_BASHUNIT_COVERAGE_SPLIT_HIT_OUT"
+    pct="$_BASHUNIT_COVERAGE_SPLIT_PCT_OUT"
+    class="$_BASHUNIT_COVERAGE_SPLIT_CLASS_OUT"
 
     total_executable=$((total_executable + executable))
     total_hit=$((total_hit + hit))

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -33,16 +33,33 @@ function bashunit::coverage::calculate_percentage() {
   fi
 }
 
+# Return slots for bashunit::coverage::_compute_file_stats.
+_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT=""
+_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT=""
+_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT=""
+_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT=""
+
+# Computes one file's executable/hit/pct/class into the four slots above.
+# Shared by get_file_stats and precompute_file_stats so the two cannot drift
+# on how compute_file_coverage's "executable:hit" string is parsed or how
+# pct/class are derived from it.
+function bashunit::coverage::_compute_file_stats() {
+  local file="$1"
+  local stats
+  stats=$(bashunit::coverage::compute_file_coverage "$file")
+  _BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT="${stats%%:*}"
+  _BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT="${stats##*:}"
+  _BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT=$(bashunit::coverage::calculate_percentage \
+    "$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT" "$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT")
+  _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT=$(bashunit::coverage::get_coverage_class \
+    "$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT")
+}
+
 # Get file coverage stats as "executable:hit:pct:class"
 function bashunit::coverage::get_file_stats() {
-  local file="$1"
-  local stats executable hit pct class
-  stats=$(bashunit::coverage::compute_file_coverage "$file")
-  executable="${stats%%:*}"
-  hit="${stats##*:}"
-  pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
-  class=$(bashunit::coverage::get_coverage_class "$pct")
-  echo "${executable}:${hit}:${pct}:${class}"
+  bashunit::coverage::_compute_file_stats "$1"
+  echo "${_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT}:${_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT}:\
+${_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT}:${_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT}"
 }
 
 
@@ -70,19 +87,14 @@ function bashunit::coverage::precompute_file_stats() {
   while IFS= read -r file; do
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
-    local stats executable hit pct class
-    stats=$(bashunit::coverage::compute_file_coverage "$file")
-    executable="${stats%%:*}"
-    hit="${stats##*:}"
-    pct=$(bashunit::coverage::calculate_percentage "$hit" "$executable")
-    class=$(bashunit::coverage::get_coverage_class "$pct")
+    bashunit::coverage::_compute_file_stats "$file"
 
     local idx="$_BASHUNIT_COVERAGE_STATS_COUNT"
     _BASHUNIT_COVERAGE_STATS_FILES[idx]="$file"
-    _BASHUNIT_COVERAGE_STATS_EXEC[idx]="$executable"
-    _BASHUNIT_COVERAGE_STATS_HIT[idx]="$hit"
-    _BASHUNIT_COVERAGE_STATS_PCT[idx]="$pct"
-    _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$class"
+    _BASHUNIT_COVERAGE_STATS_EXEC[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT"
+    _BASHUNIT_COVERAGE_STATS_HIT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT"
+    _BASHUNIT_COVERAGE_STATS_PCT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT"
+    _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT"
     _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
     _BASHUNIT_COVERAGE_STATS_LOOKUP="${_BASHUNIT_COVERAGE_STATS_LOOKUP}|${file}=${idx}|"
   done < <(bashunit::coverage::get_tracked_files)
@@ -101,6 +113,26 @@ function bashunit::coverage::get_cached_stats() {
     ;;
   esac
   bashunit::coverage::get_file_stats "$file"
+}
+
+# Return slots for bashunit::coverage::split_stats.
+_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT=""
+_BASHUNIT_COVERAGE_SPLIT_HIT_OUT=""
+_BASHUNIT_COVERAGE_SPLIT_PCT_OUT=""
+_BASHUNIT_COVERAGE_SPLIT_CLASS_OUT=""
+
+# Splits a "executable:hit:pct:class" string (as returned by get_cached_stats/
+# get_file_stats) into the four slots above. No fork. The report writers that
+# consume this format (report_text, report_html, generate_file_html) share
+# this parser so they cannot drift from each other on field order or count.
+function bashunit::coverage::split_stats() {
+  local stats="$1" rest
+  _BASHUNIT_COVERAGE_SPLIT_EXEC_OUT="${stats%%:*}"
+  rest="${stats#*:}"
+  _BASHUNIT_COVERAGE_SPLIT_HIT_OUT="${rest%%:*}"
+  rest="${rest#*:}"
+  _BASHUNIT_COVERAGE_SPLIT_PCT_OUT="${rest%%:*}"
+  _BASHUNIT_COVERAGE_SPLIT_CLASS_OUT="${rest#*:}"
 }
 
 function bashunit::coverage::get_percentage() {

--- a/src/reports/collect.sh
+++ b/src/reports/collect.sh
@@ -2,6 +2,14 @@
 
 # Collected per-test results: the shared arrays every report writer reads, and the API the runner calls to fill them.
 
+# Strips ANSI CSI escape sequences (color codes, cursor moves, erase-line, ...)
+# from $1. Shared by every writer's own escape/encode function below as their
+# first step, so the definition of "what is an ANSI escape sequence" for
+# report output lives in exactly one place instead of one regex per format.
+function bashunit::reports::__strip_ansi() {
+  printf '%s' "$1" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g'
+}
+
 _BASHUNIT_REPORTS_TEST_FILES=()
 _BASHUNIT_REPORTS_TEST_NAMES=()
 _BASHUNIT_REPORTS_TEST_STATUSES=()

--- a/src/reports/gha.sh
+++ b/src/reports/gha.sh
@@ -4,8 +4,7 @@
 
 function bashunit::reports::__gha_encode() {
   local text="$1"
-  # Strip ANSI escape sequences first (one sed call)
-  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g')
+  text=$(bashunit::reports::__strip_ansi "$text")
   # Percent-encode reserved chars per GHA workflow-commands spec.
   # Bash 3.0+ parameter expansion avoids extra awk/sed calls.
   # Order matters: encode '%' first so the sequences we inject stay literal.

--- a/src/reports/json.sh
+++ b/src/reports/json.sh
@@ -6,7 +6,7 @@
 # Strips ANSI/control chars that cannot appear inline, keeps \t\r\n as escapes.
 function bashunit::reports::__json_escape() {
   local text="$1"
-  text=$(printf '%s' "$text" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' | tr -d '\000-\010\013\014\016-\037')
+  text=$(bashunit::reports::__strip_ansi "$text" | tr -d '\000-\010\013\014\016-\037')
   # Backslash first so escapes added below are not doubled.
   text="${text//\\/\\\\}"
   text="${text//\"/\\\"}"

--- a/src/reports/junit.sh
+++ b/src/reports/junit.sh
@@ -7,8 +7,7 @@ function bashunit::reports::__xml_escape() {
   local text="$1"
   # Strip ANSI escape sequences and control characters invalid in XML 1.0,
   # then escape XML special characters (& first to avoid double-escaping)
-  echo "$text" \
-    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+  bashunit::reports::__strip_ansi "$text" \
     | tr -d '\000-\010\013\014\016-\037' \
     | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
 }

--- a/src/reports/tap.sh
+++ b/src/reports/tap.sh
@@ -8,8 +8,7 @@
 # is safe inside a YAML single-quoted scalar. Bash 3.0+ compatible.
 ##
 function bashunit::reports::__tap_message() {
-  echo "$1" \
-    | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g' \
+  bashunit::reports::__strip_ansi "$1" \
     | tr '\n' ' ' \
     | sed -e "s/'/''/g"
 }

--- a/tests/unit/coverage/reporting_test.sh
+++ b/tests/unit/coverage/reporting_test.sh
@@ -452,6 +452,42 @@ EOF
   rm -f "$temp_file"
 }
 
+function test_coverage_split_stats_populates_all_four_slots() {
+  bashunit::coverage::split_stats "12:8:66:medium"
+
+  assert_equals "12" "$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
+  assert_equals "8" "$_BASHUNIT_COVERAGE_SPLIT_HIT_OUT"
+  assert_equals "66" "$_BASHUNIT_COVERAGE_SPLIT_PCT_OUT"
+  assert_equals "medium" "$_BASHUNIT_COVERAGE_SPLIT_CLASS_OUT"
+}
+
+function test_coverage_split_stats_round_trips_get_cached_stats() {
+  BASHUNIT_COVERAGE="true"
+  bashunit::coverage::init
+
+  local temp_file
+  temp_file=$(mktemp)
+  cat >"$temp_file" <<'EOF'
+#!/usr/bin/env bash
+echo "line 1"
+echo "line 2"
+EOF
+
+  echo "$temp_file" >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  bashunit::coverage::precompute_file_stats
+
+  local stats
+  stats=$(bashunit::coverage::get_cached_stats "$temp_file")
+  bashunit::coverage::split_stats "$stats"
+
+  assert_equals "2" "$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
+  local rebuilt="${_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT}:${_BASHUNIT_COVERAGE_SPLIT_HIT_OUT}"
+  rebuilt="${rebuilt}:${_BASHUNIT_COVERAGE_SPLIT_PCT_OUT}:${_BASHUNIT_COVERAGE_SPLIT_CLASS_OUT}"
+  assert_equals "$stats" "$rebuilt"
+
+  rm -f "$temp_file"
+}
+
 function test_coverage_report_lcov_includes_branch_records_for_if_else() {
   BASHUNIT_COVERAGE="true"
   bashunit::coverage::init

--- a/tests/unit/reports/reports_test.sh
+++ b/tests/unit/reports/reports_test.sh
@@ -290,6 +290,22 @@ function test_generate_junit_xml_failure_element_with_xml_escaping() {
   assert_contains 'Expected &quot;value1&quot; &amp; &quot;value2&quot; to be &gt; other</failure>' "$content"
 }
 
+function test_generate_junit_xml_strips_ansi_color_codes() {
+  _mock_state_functions
+  BASHUNIT_LOG_JUNIT="report.xml"
+
+  local msg
+  msg=$(printf 'expected \033[32mgreen\033[0m got \033[31mred\033[0m')
+  bashunit::reports::add_test "test_fail.sh" "test_color" "100" "1" "failed" "$msg"
+  bashunit::reports::generate_junit_xml "$_TEMP_OUTPUT_FILE"
+
+  local content
+  content=$(cat "$_TEMP_OUTPUT_FILE")
+
+  assert_contains 'expected green got red' "$content"
+  assert_not_contains $'\033[' "$content"
+}
+
 # === HTML report generation tests ===
 
 function test_generate_report_html_creates_valid_html_structure() {
@@ -540,6 +556,22 @@ function test_generate_report_tap_todo_directive_for_incomplete_test() {
   bashunit::reports::generate_report_tap "$_TEMP_OUTPUT_FILE"
 
   assert_contains "ok 1 - test_todo # TODO" "$(cat "$_TEMP_OUTPUT_FILE")"
+}
+
+function test_generate_report_tap_strips_ansi_color_codes() {
+  _mock_state_functions
+  BASHUNIT_REPORT_TAP="report.tap"
+
+  local msg
+  msg=$(printf 'expected \033[32mgreen\033[0m got \033[31mred\033[0m')
+  bashunit::reports::add_test "test.sh" "test_color" "100" "1" "failed" "$msg"
+  bashunit::reports::generate_report_tap "$_TEMP_OUTPUT_FILE"
+
+  local content
+  content=$(cat "$_TEMP_OUTPUT_FILE")
+
+  assert_contains 'expected green got red' "$content"
+  assert_not_contains $'\033[' "$content"
 }
 
 function test_generate_report_html_applies_status_css_classes() {


### PR DESCRIPTION
## 🤔 Background

Three fragments that **had to change together** but were maintained separately.

None was findable by hashing whole function bodies — each lives inside a larger function that differs around it, which is exactly the shape that survives an exact-duplicate scan. (An earlier pass over all 577 functions found zero identical bodies; that was true and also not the whole picture.)

## 💡 Changes

1. **`get_file_stats` / `precompute_file_stats`** each parsed `compute_file_coverage`'s `"executable:hit"` output and re-derived pct and class, in byte-identical five-line runs → one `_compute_file_stats` behind return slots.

2. **The `"executable:hit:pct:class"` string** returned by `get_cached_stats` was taken apart independently in `report_text.sh`, `html_file.sh`, and a near-identical variant in `report_html.sh`. Three separate opinions about a four-field format is the **#959 shape**: nothing fails until someone adds a field → one fork-free `split_stats`.

3. **The ANSI CSI regex** was byte-identical in four report writers (junit, json, gha, tap) → one `__strip_ansi` in `collect.sh`.

The writers keep their own escape functions — only the strip step is shared. They read different field subsets and are *allowed* to diverge, so merging the loops would fail the very test this refactor is applied on: **must the two copies change together?**

## ✅ Behaviour checked, not asserted

- junit, tap and json reports generated before and after are **byte-identical** once timings are normalised
- a run with coloured failures emits **zero** ESC bytes into junit
- the shared helper standardises on `printf '%s'` where two writers used `echo`, which also drops echo's trailing newline — immaterial because every caller captures through `$()`, and the final bytes of all three report files are unchanged

## 🚫 Left alone deliberately

Unifying this regex with the narrower m/K-only stripper in `util/str.sh` and `assert/snapshot.sh`. That's a real behaviour difference, not duplication, and belongs to whoever owns the decision.

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1650** sequential / **1609** parallel-simple-strict — baseline + 4 regression pins.