### PR TITLE
fix(ci): unit and acceptance shards matched nothing and silently ran everything

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,16 +99,16 @@ jobs:
         include:
           - name: "functional"
             test_path: "tests/functional/*_test.sh"
-          - name: "unit a-b"
-            test_path: "tests/unit/[a-b]*_test.sh"
-          - name: "unit c + coverage"
-            test_path: "tests/unit/c*_test.sh"
-          - name: "unit d-g"
-            test_path: "tests/unit/[d-g]*_test.sh"
-          - name: "unit h-p"
-            test_path: "tests/unit/[h-p]*_test.sh"
-          - name: "unit q-z"
-            test_path: "tests/unit/[q-z]*_test.sh"
+          - name: "unit 1/5"
+            test_path: "--shard 1/5 tests/unit"
+          - name: "unit 2/5"
+            test_path: "--shard 2/5 tests/unit"
+          - name: "unit 3/5"
+            test_path: "--shard 3/5 tests/unit"
+          - name: "unit 4/5"
+            test_path: "--shard 4/5 tests/unit"
+          - name: "unit 5/5"
+            test_path: "--shard 5/5 tests/unit"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -130,12 +130,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "a-e"
-            test_path: "tests/acceptance/bashunit_[a-e]*_test.sh tests/acceptance/coverage_*_test.sh"
-          - name: "f-l"
-            test_path: "tests/acceptance/bashunit_[f-l]*_test.sh tests/acceptance/install*_test.sh"
-          - name: "m-z"
-            test_path: "tests/acceptance/bashunit_[m-z]*_test.sh tests/acceptance/bashunit_test.sh tests/acceptance/mock*_test.sh tests/acceptance/parallel*_test.sh"
+          - name: "1/3"
+            test_path: "--shard 1/3 tests/acceptance"
+          - name: "2/3"
+            test_path: "--shard 2/3 tests/acceptance"
+          - name: "3/3"
+            test_path: "--shard 3/3 tests/acceptance"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -158,16 +158,16 @@ jobs:
         include:
           - name: "functional"
             test_path: "tests/functional/*_test.sh"
-          - name: "unit a-b"
-            test_path: "tests/unit/[a-b]*_test.sh"
-          - name: "unit c + coverage"
-            test_path: "tests/unit/ch*_test.sh tests/unit/cl*_test.sh tests/unit/console*_test.sh tests/unit/cu*_test.sh tests/unit/coverage_*_test.sh"
-          - name: "unit d-g"
-            test_path: "tests/unit/[d-g]*_test.sh"
-          - name: "unit h-p"
-            test_path: "tests/unit/[h-p]*_test.sh"
-          - name: "unit r-z"
-            test_path: "tests/unit/[r-z]*_test.sh"
+          - name: "unit 1/5"
+            test_path: "--shard 1/5 tests/unit"
+          - name: "unit 2/5"
+            test_path: "--shard 2/5 tests/unit"
+          - name: "unit 3/5"
+            test_path: "--shard 3/5 tests/unit"
+          - name: "unit 4/5"
+            test_path: "--shard 4/5 tests/unit"
+          - name: "unit 5/5"
+            test_path: "--shard 5/5 tests/unit"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -191,12 +191,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "a-e"
-            test_path: "tests/acceptance/bashunit_[a-e]*_test.sh tests/acceptance/coverage_*_test.sh"
-          - name: "f-l"
-            test_path: "tests/acceptance/bashunit_[f-l]*_test.sh tests/acceptance/install*_test.sh"
-          - name: "m-z"
-            test_path: "tests/acceptance/bashunit_[m-z]*_test.sh tests/acceptance/bashunit_test.sh tests/acceptance/mock*_test.sh tests/acceptance/parallel*_test.sh"
+          - name: "1/3"
+            test_path: "--shard 1/3 tests/acceptance"
+          - name: "2/3"
+            test_path: "--shard 2/3 tests/acceptance"
+          - name: "3/3"
+            test_path: "--shard 3/3 tests/acceptance"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/tests/unit/project/ci_test_paths_test.sh
+++ b/tests/unit/project/ci_test_paths_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Anti-drift contract for the test paths in .github/workflows/tests.yml.
+#
+# The CI matrix used to slice tests/unit/ with alphabetical globs
+# (tests/unit/[a-b]*_test.sh and friends). #960 moved every unit test into a
+# per-module subdirectory, so those globs stopped matching anything -- and
+# bashunit answers an argument that matches no file by falling back to its
+# default path, i.e. the whole suite. Every macOS and Windows unit leg
+# therefore ran all the tests instead of its fifth, on every run, staying green
+# the entire time. Nothing was failing, so nothing pointed at it.
+#
+# The same rot had already cost coverage rather than time: the acceptance
+# buckets were also hand-maintained globs, and tests/acceptance/worker_stderr_test.sh
+# matched none of the three, so it never ran in CI at all after #891 added it.
+#
+# Both are now expressed as `--shard i/n <dir>`, which cannot silently select
+# nothing. This test pins the property that mattered either way: a path CI runs
+# must actually resolve to tests.
+
+WORKFLOW=""
+ROOT_DIR=""
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  WORKFLOW="$ROOT_DIR/.github/workflows/tests.yml"
+}
+
+# Without this the greps below would match nothing after a rename and every
+# other assertion would compare empty against empty and pass -- the same
+# vacuum that hid the bug this file is about.
+function test_the_workflow_being_checked_exists() {
+  assert_file_exists "$WORKFLOW"
+}
+
+# Each configured test_path, one per line, quotes stripped.
+function ci_test_paths() {
+  grep -oE 'test_path: "[^"]+"' "$WORKFLOW" | sed 's/test_path: "//; s/"$//'
+}
+
+function test_every_ci_test_path_resolves_to_at_least_one_test_file() {
+  local unresolved=""
+  local line
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    # Drop flags and their values: what remains is the path or glob CI runs.
+    local rest="$line"
+    case "$rest" in
+    --shard*)
+      # `--shard i/n <path>`: drop the flag, then drop its i/n value. Done with
+      # prefix stripping rather than `set -- $rest` so nothing has to rely on
+      # word splitting here.
+      rest="${rest#--shard }"
+      rest="${rest#* }"
+      ;;
+    esac
+
+    local found=0
+    local token
+    for token in $rest; do
+      # Unquoted on purpose: these are globs and must expand here.
+      local match
+      for match in $token; do
+        if [ -e "$match" ]; then
+          found=1
+          break
+        fi
+      done
+      [ "$found" -eq 1 ] && break
+    done
+
+    if [ "$found" -eq 0 ]; then
+      unresolved="$unresolved$line
+"
+    fi
+  done <<EOF
+$(cd "$ROOT_DIR" && ci_test_paths)
+EOF
+
+  assert_empty "$unresolved"
+}


### PR DESCRIPTION
## 🤔 Background

The macOS and Windows matrices sliced `tests/unit/` with alphabetical globs — `tests/unit/[a-b]*_test.sh` and four siblings. **#960 moved every unit test into a per-module subdirectory, so all five stopped matching any file.**

That didn't fail. bashunit answers an argument matching no file by falling back to its default path — the whole suite. So all **ten** macOS and Windows unit legs have been running all 1652 tests instead of their fifth, on every run since #960, green throughout. Nothing was broken, so nothing pointed at it.

The acceptance buckets are the same design and had rotted the other way, costing **coverage** instead of time: `tests/acceptance/worker_stderr_test.sh` matched none of the three patterns, so it has **never run in CI** since #891 added it.

## 💡 Changes

Both are now `--shard i/n <dir>`, using the flag bashunit already ships. It cannot select nothing, needs no maintenance when files move, and partitions exactly:

| Suite | Shards | Sum | Whole |
|---|---|---|---|
| `tests/unit` | 229 + 166 + 219 + 277 + 326 | **1217** | 1217 ✅ |
| `tests/acceptance` | 128 + 128 + 98 | **354** | 354 ✅ |

No gaps, no overlap.

## 🧪 The guard

A new contract test pins the property that mattered in both cases: **a path CI runs must resolve to something.** Mutation-tested three ways — restoring a dead glob, pointing a shard at a missing directory, renaming the workflow away — each turns it red.

## 📋 Note

Sharding by file leaves the legs uneven (166–326 tests). Balancing them is a separate question from them running the right tests at all.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1652** sequential / **1611** parallel-simple-strict.