### PR TITLE
chore: drop a dead test helper and fix a doc naming a flag that never existed

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ always wins. `--skip-env-file` skips both `.env` and `.bashunitrc`.
 Specifies the `directory` or `file` containing the tests to be run. `empty` by default.
 
 If a directory is specified, it will execute tests within files ending in `test.sh`.
-When running benchmarks (`--bench`), the same path is used to search for files ending in `bench.sh`.
+When running benchmarks (`bashunit bench`), the same path is used to search for files ending in `bench.sh`.
 
 If you use wildcards, **bashunit** will run any tests it finds.
 

--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -29,15 +29,6 @@ function mock_unknown_linux_os() {
   bashunit::mock bashunit::check_os::is_windows mock_false
 }
 
-function mock_ubuntu_os() {
-  bashunit::mock bashunit::check_os::is_linux mock_true
-  bashunit::mock bashunit::check_os::is_ubuntu mock_true
-
-  bashunit::mock bashunit::check_os::is_alpine mock_false
-  bashunit::mock bashunit::check_os::is_busybox mock_false
-  bashunit::mock bashunit::check_os::is_macos mock_false
-  bashunit::mock bashunit::check_os::is_windows mock_false
-}
 
 function mock_alpine_os() {
   bashunit::mock bashunit::check_os::is_linux mock_true


### PR DESCRIPTION
## 🤔 Background

Two references to things that aren't there, surfaced by an unused-code sweep and both re-verified from scratch rather than taken on report.

## 💡 Changes

**`tests/bootstrap.sh`** defines `mock_ubuntu_os` alongside `mock_alpine_os`, `mock_windows_os` and `mock_unknown_linux_os`. The other three each have a caller; this one has none, and the OS tests that would use it inline the mock sequence instead. It was mocking six `is_*` predicates for nobody.

| Helper | Callers |
|---|---|
| `mock_alpine_os` | 1 |
| `mock_windows_os` | 1 |
| `mock_unknown_linux_os` | 1 |
| **`mock_ubuntu_os`** | **0** |

**`docs/configuration.md`** described benchmarks as `--bench`. No such flag exists — no case arm in `src/main/` parses it — and the rest of the docs correctly call it `bashunit bench`. A documented flag that doesn't exist is worse than an undocumented one: it fails only when a reader trusts it.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1652** sequential / **1611** parallel-simple-strict, both unchanged. `configuration.md` isn't the doc embedded in `bashunit doc`, so no snapshot regeneration.