### PR TITLE
test: fix two tests that could not fail

### DIFF
--- a/tests/unit/assert/string_test.sh
+++ b/tests/unit/assert/string_test.sh
@@ -28,9 +28,13 @@ function test_successful_assert_equals() {
 }
 
 function test_successful_assert_equals_with_special_chars() {
-  local string="${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT} foo"
+  # Two independently-colored strings, not the same variable twice: both
+  # sides must have their ANSI codes stripped for this to pass, so a broken
+  # strip on either side would surface here.
+  local str1="${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT} foo"
+  local str2="${_BASHUNIT_COLOR_PASSED}✗ Failed${_BASHUNIT_COLOR_DEFAULT} foo"
 
-  assert_equals "$string" "$string"
+  assert_equals "$str1" "$str2"
 }
 
 function test_unsuccessful_assert_equals() {

--- a/tests/unit/config/env_test.sh
+++ b/tests/unit/config/env_test.sh
@@ -51,7 +51,7 @@ function test_env_flag_returns_failure_when_false() {
 
   if "$fn_name"; then
     eval "export $var_name='$original_value'"
-    fail "Expected $fn_name to return failure when $var_name=false"
+    bashunit::fail "Expected $fn_name to return failure when $var_name=false"
     return
   fi
 
@@ -121,7 +121,7 @@ function test_is_dev_mode_disabled_when_dev_log_empty() {
 
   if bashunit::env::is_dev_mode_enabled; then
     export BASHUNIT_DEV_LOG="$original"
-    fail "Expected is_dev_mode_enabled to return failure when BASHUNIT_DEV_LOG is empty"
+    bashunit::fail "Expected is_dev_mode_enabled to return failure when BASHUNIT_DEV_LOG is empty"
     return
   fi
 
@@ -224,7 +224,7 @@ function test_is_tap_output_disabled_when_format_is_not_tap() {
 
   if bashunit::env::is_tap_output_enabled; then
     export BASHUNIT_OUTPUT_FORMAT="$original"
-    fail "Expected is_tap_output_enabled to return failure when format is empty"
+    bashunit::fail "Expected is_tap_output_enabled to return failure when format is empty"
     return
   fi
 
@@ -238,7 +238,7 @@ function test_active_internet_connection_returns_failure_when_no_network() {
 
   if bashunit::env::active_internet_connection; then
     export BASHUNIT_NO_NETWORK="$original"
-    fail "Expected active_internet_connection to fail when BASHUNIT_NO_NETWORK=true"
+    bashunit::fail "Expected active_internet_connection to fail when BASHUNIT_NO_NETWORK=true"
     return
   fi
 
@@ -269,7 +269,7 @@ function test_supports_color_returns_failure_when_TERM_is_dumb() {
 
   if bashunit::env::supports_color; then
     export TERM="$original_term"
-    fail "Expected supports_color to fail when TERM=dumb"
+    bashunit::fail "Expected supports_color to fail when TERM=dumb"
     return
   fi
 
@@ -284,7 +284,7 @@ function test_supports_color_returns_failure_when_tput_reports_below_8_colors() 
 
   if bashunit::env::supports_color; then
     export TERM="$original_term"
-    fail "Expected supports_color to fail when tput colors reports 2"
+    bashunit::fail "Expected supports_color to fail when tput colors reports 2"
     return
   fi
 


### PR DESCRIPTION
## 🤔 Background

Two tests that pass unconditionally. Both found by **mutation** — breaking the thing each claims to guard and checking whether it notices. Neither is visible by reading.

## 1. A variable compared against itself

```bash
local string="${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT} foo"
assert_equals "$string" "$string"
```

Whatever transform `assert_equals` applies lands on both sides identically, so the assertion holds regardless of what that transform does. Now it compares two strings **coloured differently with the same visible text**, so ANSI stripping has to actually work.

**The proof needed care.** An asymmetric mutation (disabling the strip on one side) is caught even by a self-comparison — my first attempt did exactly that and wrongly suggested the old test was fine. The valid probe is symmetric, disabling the strip on *both* sides:

| Test version | Failures under symmetric mutation |
|---|---|
| old (self-comparison) | 3 — slept through it |
| new | **4** — catches it |

## 2. Six calls to a function that doesn't exist

`tests/unit/config/env_test.sh` called a bare `fail` at six sites inside `if <check>; then ... fi` guards. **There is no bare `fail` in this codebase** — only `bashunit::fail`. Those branches never ran while the code under test behaved, so nothing surfaced.

Forcing `is_parallel_run_enabled` to return true:

```
old: line 54: fail: command not found
new: Expected bashunit::env::is_parallel_run_enabled to return failure when BASHUNIT_PARALLEL_RUN=false
```

Six assertion strings were dead text.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1652** sequential / **1611** parallel-simple-strict — unchanged, because these tests already passed. That was the problem.