### PR TITLE
test(state): close the assert-shaped hole in the layering contract

### DIFF
--- a/.claude/rules/architecture-map.md
+++ b/.claude/rules/architecture-map.md
@@ -94,9 +94,9 @@ shell (or, in parallel, in per-test `.result` files aggregated at the end).
 | `util/clock.sh` | time impl selection (EPOCHREALTIME > date > perl > …), return-slot reads |
 | `util/str.sh` / `util/math.sh` | pure-bash string and arithmetic helpers |
 | `api/index.sh` | aggregator only — sources the `src/api/` module below |
-| `api/globals.sh` | `temp_file`/`temp_dir`/`current_dir`/`data_set`; runs `set -euo pipefail` at file scope, so it must stay first in the module |
+| `api/globals.sh` | `temp_file`/`temp_dir`/`current_dir`/`data_set`; repeats `set -euo pipefail` at file scope for anything sourcing it alone — the entrypoint already set it |
 | `api/skip_todo.sh` / `api/test_title.sh` | `skip`/`todo` markers; `set_test_title` |
-| `api/bashunit.sh` | the custom-assert facade (`assert_that`, `assert_once`, `assertion_failed`/`passed`) |
+| `api/bashunit.sh` | the custom-assert facade (`assert_that`, `assertion_failed`/`passed`) |
 | `doubles/index.sh` | aggregator only — sources the `src/doubles/` module below |
 | `doubles/mock.sh` | `mock`/`unmock` and the `_BASHUNIT_MOCKED_FUNCTIONS` registry `runner/hooks.sh` unwinds per test |
 | `doubles/spy.sh` | `spy` and its `_BASHUNIT_SPY_*` state slots + files |

--- a/adrs/adr-011-source-layout-and-build-pipeline.md
+++ b/adrs/adr-011-source-layout-and-build-pipeline.md
@@ -82,12 +82,18 @@ holds `bashunit::console_results::*` in files named for what they do.
 
 Most of it is ordinary dependency layering, but three points are genuinely load-bearing:
 
-* **`api/globals.sh` runs `set -euo pipefail` at file scope.** Everything sourced after it
-  inherits strict mode. It must stay first inside `api/`, and `api/` must stay where it is.
+* ~~**`api/globals.sh` runs `set -euo pipefail` at file scope**, so it must stay first.~~
+  **Corrected 2026-08-02: it does run that, but it is not an ordering constraint.** The
+  `bashunit` entrypoint sets the same options on its own line 2, and
+  `system/dependencies.sh` repeats them at module #2 — both before `api/` (#4) loads.
+  The line is worth keeping for anything that sources `api/globals.sh` alone; moving
+  `api/` would not turn strict mode off.
 * **`config/env.sh` executes at source time** — it loads `.bashunitrc` and `.env` and creates
   the scratch dirs. It must come before `console/`, whose palette is built at file scope from
   the values it resolves.
-* **`main/` is sourced last**, after everything it dispatches to.
+* **`main/` is sourced last**, after everything it dispatches to. This is a description of
+  the current order rather than a proven constraint: sourcing `main/` first was tried and
+  the suite still passed, because every call it makes resolves at runtime.
 
 ## How the binary is built
 

--- a/src/api/index.sh
+++ b/src/api/index.sh
@@ -5,11 +5,14 @@
 #
 # The surface a user's test file calls: temp_file/temp_dir/current_dir/data_set,
 # skip/todo, set_test_title, and the custom-assert facade (assert_that,
-# assert_once, assertion_failed/passed). Assertions are the other half of that
-# surface and live in src/assert/, which is large enough to be its own module.
+# assertion_failed/passed). assert_once lives in src/assert/once.sh, not here.
+# Assertions are the other half of that surface and live in src/assert/, which is
+# large enough to be its own module.
 #
-# globals.sh MUST stay first: it runs `set -euo pipefail` at file scope, so every
-# file sourced after it inherits strict mode. This module is sourced at the
+# globals.sh runs `set -euo pipefail` at file scope. That is belt-and-braces, not
+# an ordering constraint: the `bashunit` entrypoint sets the same options on its
+# line 2 and src/system/dependencies.sh repeats them, both long before api/ is
+# reached. It still earns its place for anything that sources this file alone. This module is sourced at the
 # position globals.sh held on its own, which keeps that boundary where it was.
 source "$BASHUNIT_ROOT_DIR/src/api/globals.sh"
 source "$BASHUNIT_ROOT_DIR/src/api/skip_todo.sh"

--- a/tests/unit/state/state_test.sh
+++ b/tests/unit/state/state_test.sh
@@ -336,3 +336,37 @@ function test_state_does_not_call_the_renderer_or_parallel() {
 
   assert_same "" "${offenders% }"
 }
+
+# The greps in this file only mean something if `src/state/*.sh` actually resolves
+# to real files. #946 moved state.sh once already while a path-shaped contract
+# stayed green, checking nothing; the fix was globbing the whole module instead of
+# one file. That still goes vacuous if the *module itself* is ever renamed or
+# moved: an unmatched glob is passed to grep as its own literal, unexpanded
+# string, which fails "No such file", is swallowed by `|| true` above and below,
+# and reports a clean pass having scanned zero lines.
+function test_state_module_glob_resolves_to_real_files() {
+  set -- src/state/*.sh
+
+  assert_file_exists "$1"
+}
+
+# state and assert call each other: assert -> state (recording pass/fail) is the
+# expected, dominant direction. The reverse exists too, narrowly:
+# bashunit::assert_once's marker (src/assert/once.sh) shares state's per-test reset
+# lifecycle, so state calls exactly two assert:: functions to participate in it --
+# once_reset (cleared on the same per-test reset state already does) and
+# once_is_absorbing (gates whether a pass is counted or absorbed into an open
+# marker). That is a deliberate, narrow, already-shipped exception (#921) -- not
+# license for state to reach into assert generally. Anything else here is the same
+# layering shape as the console/parallel/runner cycle above (#868/#862).
+function test_state_only_calls_the_documented_assert_once_functions() {
+  # `|| true` on both greps: no match is the passing case for the second one (every
+  # line got excluded), and the first one the same way as the test above.
+  local offenders
+  offenders=$({ "$GREP" -ohE "bashunit::assert::[a-z_]+" src/state/*.sh || true; } |
+    sort -u |
+    { "$GREP" -vFx -e "bashunit::assert::once_reset" -e "bashunit::assert::once_is_absorbing" \
+      || true; } | tr '\n' ' ')
+
+  assert_same "" "${offenders% }"
+}


### PR DESCRIPTION
## 🤔 Background

`state_test.sh` has banned `state/` from calling `console_results`, `console_header`, `parallel` and `runner` since #868/#862. **It never banned `assert`** — and `assert` is now the direction the cycle runs in.

`assert -> state` is the expected, dominant edge: assertions record their own results. The reverse arrived with `assert_once` (#921): its marker shares state's per-test reset lifecycle, so `state/context.sh` calls `assert::once_reset` and `state/counters.sh` calls `assert::once_is_absorbing`. `console/test_line.sh` reaches into the same feature four more times.

That's a genuine two-node call-graph cycle — **invisible to a walk of the `source` graph**, because bash resolves calls at runtime. A full audit of that graph found nothing here.

## 💡 Changes

- The contract now **allowlists exactly those two functions**. The exception is deliberate and shipped; anything beyond it is the shape the file already bans. Mutation-tested: an added `bashunit::assert::fail_with` in `state/` turns it red.
- **A second test guards the greps themselves.** #946 lost a contract this way once: an unmatched glob is handed to grep as a literal, fails *No such file*, is swallowed by the `|| true` these greps need, and reports a clean pass having scanned nothing. Globbing the module fixed the #946 case but not a wholesale rename. Proven against a module path that doesn't exist.

## 📝 Three doc corrections, one to my own text

**ADR-011 listed `api/globals.sh` running `set -euo pipefail` as a load-bearing ordering constraint. It isn't.** The entrypoint sets the same options on its line 2, and `system/dependencies.sh` repeats them at module #2 — both before `api/` (#4) loads. The line earns its place for anything sourcing that file alone, but moving `api/` would not turn strict mode off. Struck through rather than deleted, correction dated.

**ADR-011 also called "`main/` sourced last" load-bearing.** True as a description — sourcing `main/` first was tried and the suite still passed, because every call resolves at runtime. Reworded.

**`architecture-map.md` and `src/api/index.sh`** both attributed `assert_once` to `api/bashunit.sh`. It lives in `src/assert/once.sh`.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1654** sequential / **1613** parallel-simple-strict — baseline + the 2 new contracts.