### PR TITLE
test(compat): catch += append assignments away from the line start

### DIFF
--- a/tests/unit/project/bash_compatibility_test.sh
+++ b/tests/unit/project/bash_compatibility_test.sh
@@ -43,7 +43,11 @@ function test_src_has_no_printf_assignment() {
 # `arr[${#arr[@]}]=x` to append to an array. Arithmetic `(( x += 1 ))` is fine on
 # 3.0, so only assignment-position `+=` is matched here.
 function test_src_has_no_append_assignment() {
-  local pattern='^[[:space:]]*(local[[:space:]]+|declare[[:space:]]+[^[:space:]]+[[:space:]]+|export[[:space:]]+)?'
+  # Anchored at a statement boundary, not just start-of-line: `cmd; x+=y`,
+  # `if c; then x+=y; fi` and `for i; do x+=y; done` are all Bash 3.1+ append
+  # assignments, and a `^`-only anchor walked straight past every one of them.
+  local pattern='(^|[;&|]|\bthen\b|\bdo\b|\belse\b)[[:space:]]*'
+  pattern="$pattern"'(local[[:space:]]+|declare[[:space:]]+[^[:space:]]+[[:space:]]+|export[[:space:]]+)?'
   pattern="$pattern"'[A-Za-z_][A-Za-z0-9_]*(\[[^]]*\])?\+='
 
   assert_empty "$(bashunit::compat::offenders "$pattern")"


### PR DESCRIPTION
## 🤔 Background

The Bash 3.0 gate greps `src/` for prohibited syntax. Its append-assignment pattern was anchored with `^[[:space:]]*`, so it only ever saw an append that **began a line**. Every one of these is a Bash 3.1+ append, and every one walked past it:

```bash
cmd; x+=y
if cond; then x+=y; fi
for i in 1 2; do x+=y; done
if c; then :; else x+=y; fi
true && x+=y
```

## 💡 Changes

The anchor now accepts a **statement boundary** — start of line, `;`, `&`, `|`, or a `then`/`do`/`else` keyword — instead of only the start of a line.

`src/` is clean today, so this fixes no live breakage; it closes the hole before something lands in it.

## 🧪 Mutation-tested

All eight append forms confirmed red. Two forms confirmed to stay silent:

- `echo "a+=b"` — the characters inside a string
- `$((a+=1))` — arithmetic append, valid on Bash 3.0 and not the construct being banned

## ⚠️ How this was found — two false alarms first

Probing the gate by appending a snippet with `printf '%s'` writes a **literal backslash-n** rather than a newline, so several multi-line probes collapsed to one line and reported *"not caught"* for cases the gate handled correctly.

An `&>>` probe reported the same way for a different reason: on Bash 3.2 that token is a **syntax error**, so bashunit failed to source and no test ran at all.

Neither was a gate defect. Verify the mutation landed before believing the result.

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1654** sequential / **1613** parallel-simple-strict, unchanged.