### PR TITLE
fix(ci): coverage workflow globbed a flat tests/unit that no longer exists

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,9 +9,9 @@ name: Coverage
 # so it is not a status check on any commit and cannot gate merges. Coverage is
 # CPU-heavy, so a scheduled cadence keeps it off the critical path.
 #
-# The coverage engine's own meta-tests (tests/unit/coverage_*_test.sh) are
-# excluded from the measured run: executing them under --coverage double-
-# instruments src/coverage.sh and corrupts their assertions.
+# The coverage engine's own meta-tests (tests/unit/coverage/) are excluded from
+# the measured run: executing them under --coverage double-instruments
+# src/coverage/ and corrupts their assertions.
 
 on:
   schedule:
@@ -51,7 +51,11 @@ jobs:
         # run well under the job timeout on the multi-core runner. Parallel LCOV
         # aggregation is deterministic (same total as a sequential run).
         run: |
-          files=$(ls tests/unit/*_test.sh | grep -v '/coverage_')
+          # `find`, not a glob: unit tests live in per-module subdirectories since
+          # #960, so a flat glob there matches nothing and `ls` fails the step.
+          # fixtures/ holds inputs to other tests, never tests themselves.
+          files=$(find tests/unit -name '*_test.sh' \
+            -not -path '*/fixtures/*' -not -path '*/coverage/*')
           # shellcheck disable=SC2086
           ./bashunit --coverage --parallel --jobs auto \
             --coverage-report coverage/lcov.info --coverage-paths src $files

--- a/tests/unit/project/ci_test_paths_test.sh
+++ b/tests/unit/project/ci_test_paths_test.sh
@@ -79,3 +79,52 @@ EOF
 
   assert_empty "$unresolved"
 }
+
+# The same rot hit a second workflow and this file did not catch it, because it
+# only ever looked at tests.yml. coverage.yml globbed `tests/unit/*_test.sh` in a
+# shell step rather than a `test_path:` key, so after #960 its `ls` failed and the
+# nightly coverage run had been red for days -- unnoticed, because that workflow
+# is deliberately non-blocking.
+#
+# This checks the property across every workflow and every shape: any tests/
+# path or glob a workflow names must resolve to something on disk.
+function ci_referenced_test_paths() {
+  # Comment lines are dropped first: the workflows document the broken globs
+  # they replaced, and those must not be read as live references.
+  #
+  # The match is anchored on a boundary so `sample_tests/pass_test.sh` -- a file
+  # test-action.yml writes at runtime -- is not read as a `tests/` path. An
+  # unanchored `tests/` matched its tail and reported it missing.
+  "$GREP" -rhv '^[[:space:]]*#' "$ROOT_DIR"/.github/workflows/ --include='*.yml' 2>/dev/null |
+    "$GREP" -oE '(^|[[:space:]"'"'"'=])tests/[A-Za-z0-9_*/.-]+' |
+    sed 's/^[^t]//' | LC_ALL=C sort -u
+}
+
+function test_every_tests_path_named_by_any_workflow_resolves() {
+  local unresolved=""
+  local token
+  while IFS= read -r token; do
+    [ -z "$token" ] && continue
+    case "$token" in
+    */) continue ;;
+    esac
+
+    local found=0
+    local match
+    for match in $token; do
+      if [ -e "$match" ]; then
+        found=1
+        break
+      fi
+    done
+
+    if [ "$found" -eq 0 ]; then
+      unresolved="$unresolved$token
+"
+    fi
+  done <<EOF
+$(cd "$ROOT_DIR" && ci_referenced_test_paths | "$GREP" -v '^tests/$')
+EOF
+
+  assert_empty "$unresolved"
+}


### PR DESCRIPTION
## 🤔 Background

**The nightly coverage run has failed every night since 2026-08-02.**

```
ls: cannot access 'tests/unit/*_test.sh': No such file or directory
##[error]Process completed with exit code 1
```

Its file list came from `ls tests/unit/*_test.sh`, and **#960** moved every unit test into a per-module subdirectory. The glob matched nothing, `ls` exited non-zero, the step died under `bash -e`. Nobody noticed because this workflow is deliberately non-blocking — it never runs on push or pull_request, so a red nightly isn't a status check on anything.

## 🐛 Two stale paths — the second is the one that mattered

The exclusion `grep -v '/coverage_'` was written for flat filenames; the coverage engine's meta-tests are now `tests/unit/coverage/`. **Fixing only the glob would have restored the run while silently pulling those meta-tests back in** — and the workflow's own comment explains why they're excluded: measuring them under `--coverage` double-instruments `src/coverage/` and corrupts their assertions.

Both are now one `find` with explicit exclusions for `coverage/` and `fixtures/`. That also picks up two files a two-level glob would still have missed.

**65 files** selected — 76 total, minus 9 meta-tests, minus 2 fixtures. Smoke-tested against a real `--coverage` run that writes lcov.

## 🧪 The contract test is the point

It existed already and **didn't catch this**, because it only looked at `tests.yml`. #972 fixed the instance; I didn't go looking for the class. It now checks **every workflow, for any shape**: a `tests/` path or glob a workflow names must resolve to something. Mutation-tested against both files.

Two bugs in that test, worth recording:

- It **documented stripping comments and didn't**, so the broken globs the workflows describe in prose read as live references
- An **unanchored `tests/`** matched the tail of `sample_tests/pass_test.sh` — a file `test-action.yml` writes at runtime — and reported it missing

## ✅ Verification

`make sa` · `make lint` · `bash build.sh bin -v` → `✅ Build verified ✅` · **1658** sequential / **1617** parallel-simple-strict.