### PR TITLE
feat(snapshot): add named snapshots

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -91,8 +91,8 @@ function test_should_add() {
 
 ```bash
 assert_match_snapshot "$output"
-# Re-record: delete the snapshot file and re-run; the assertion writes it when missing
-# (so a deleted snapshot never fails — read the diff before deleting)
+assert_match_named_snapshot "stderr" "$stderr" # multiple snapshots in one test
+# Re-record deliberately: ./bashunit --snapshot-update --filter "test name" tests/
 ```
 
 ## Test Isolation

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Why bashunit
 
 A lightweight, fast testing framework for **Bash 3.0+**, focused on developer experience.
-It ships 71 assertions plus spies, mocks, data providers, snapshots and more.
+It ships 73 assertions plus spies, mocks, data providers, snapshots and more.
 
 ## Quick start
 

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -32,6 +32,7 @@ _bashunit() {
       assert_is_directory_writable assert_is_file assert_is_file_empty
       assert_json_contains assert_json_equals assert_json_key_exists
       assert_less_or_equal_than assert_less_than assert_line_count
+      assert_match_named_snapshot assert_match_named_snapshot_ignore_colors
       assert_match_snapshot assert_match_snapshot_ignore_colors assert_matches
       assert_not_contains assert_not_empty assert_not_equals assert_not_matches
       assert_not_same assert_same assert_string_ends_with

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -45,6 +45,7 @@ assert_is_directory_not_writable assert_is_directory_readable \
 assert_is_directory_writable assert_is_file assert_is_file_empty \
 assert_json_contains assert_json_equals assert_json_key_exists \
 assert_less_or_equal_than assert_less_than assert_line_count \
+assert_match_named_snapshot assert_match_named_snapshot_ignore_colors \
 assert_match_snapshot assert_match_snapshot_ignore_colors assert_matches \
 assert_not_contains assert_not_empty assert_not_equals assert_not_matches \
 assert_not_same assert_same assert_string_ends_with \

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -28,7 +28,7 @@ to narrow it (`bashunit doc json`).
 | **Arrays** | [assert_arrays_equal](#assert-arrays-equal) · [assert_array_contains](#assert-array-contains) · [assert_array_not_contains](#assert-array-not-contains) · [assert_array_length](#assert-array-length) |
 | **JSON** | [assert_json_equals](#assert-json-equals) · [assert_json_contains](#assert-json-contains) · [assert_json_key_exists](#assert-json-key-exists) |
 | **Duration** | [assert_duration](#assert-duration) · [assert_duration_less_than](#assert-duration-less-than) · [assert_duration_greater_than](#assert-duration-greater-than) |
-| **Snapshots** | [assert_match_snapshot](#assert-match-snapshot) · [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors) |
+| **Snapshots** | [assert_match_snapshot](#assert-match-snapshot) · [assert_match_named_snapshot](#assert-match-named-snapshot) · [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors) · [assert_match_named_snapshot_ignore_colors](#assert-match-named-snapshot-ignore-colors) |
 | **Spies** | [assert_have_been_called](#assert-have-been-called) · [assert_not_called](#assert-not-called) · [assert_have_been_called_with](#assert-have-been-called-with) · [assert_have_been_called_with_any](#assert-have-been-called-with-any) · [assert_have_been_called_with_args](#assert-have-been-called-with-args) · [assert_have_been_called_nth_with](#assert-have-been-called-nth-with) · [assert_have_been_called_times](#assert-have-been-called-times) |
 | **Assertions** | [assert_assertion_passes](#assert-assertion-passes) · [assert_assertion_fails](#assert-assertion-fails) · [assert_assertion_fails_with](#assert-assertion-fails-with) |
 | **Manual failure** | [bashunit::fail](#bashunit-fail) |
@@ -1629,6 +1629,34 @@ function test_success() {
 
 function test_failure() {
   assert_match_snapshot_ignore_colors "output that no longer matches the stored snapshot"
+}
+```
+:::
+
+## assert_match_named_snapshot
+> `assert_match_named_snapshot "name" "actual"`
+
+Matches `actual` against a snapshot whose filename includes `name`. Use it for multiple independent snapshots in one test without constructing file paths yourself. Names are normalized so they cannot escape the test's `snapshots/` directory.
+
+::: code-group
+```bash [Example]
+function test_render_modes() {
+  assert_match_named_snapshot "compact" "$(./bin/render --compact)"
+  assert_match_named_snapshot "verbose" "$(./bin/render --verbose)"
+}
+```
+:::
+
+## assert_match_named_snapshot_ignore_colors
+> `assert_match_named_snapshot_ignore_colors "name" "actual"`
+
+Named version of [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors). ANSI escape sequences are stripped from `actual` before it is stored or compared.
+
+::: code-group
+```bash [Example]
+function test_colored_render_modes() {
+  assert_match_named_snapshot_ignore_colors "compact" "$(./bin/render --compact)"
+  assert_match_named_snapshot_ignore_colors "verbose" "$(./bin/render --verbose)"
 }
 ```
 :::

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -575,10 +575,10 @@ steps:
 
 > `bashunit test --snapshot-update`
 
-Re-record snapshots: every `assert_match_snapshot` /
-`assert_match_snapshot_ignore_colors` whose snapshot already exists is
+Re-record snapshots: every snapshot assertion whose file already exists is
 overwritten with the value this run produced, and reported as a recorded
-snapshot instead of a pass. A missing snapshot is written as usual.
+snapshot instead of a pass. A missing snapshot is written as usual. This
+includes default, named and ignore-colors snapshots.
 
 Use it when an output change is deliberate. It replaces deleting snapshot files
 by hand — the path is derived from the test file and function name, so a wrong

--- a/docs/public/bashunit-skill.md
+++ b/docs/public/bashunit-skill.md
@@ -118,7 +118,7 @@ cleaned up automatically and are safe under `--parallel`.
 
 ## Assertions
 
-`bashunit doc` prints the full catalogue (71 assertions) locally; `bashunit doc contains`
+`bashunit doc` prints the full catalogue (73 assertions) locally; `bashunit doc contains`
 filters it. The same list is at https://bashunit.com/assertions. **Do not invent names**
 — a wrong name is a runtime error, not a failed assertion.
 
@@ -132,7 +132,8 @@ filters it. The same list is at https://bashunit.com/assertions. **Do not invent
   `assert_directory_exists`, `assert_file_permissions`
 - Arrays: `assert_array_contains`, `assert_array_length`, `assert_arrays_equal`
 - JSON: `assert_json_equals`, `assert_json_contains`, `assert_json_key_exists`
-- Snapshots: `assert_match_snapshot`, `assert_match_snapshot_ignore_colors`
+- Snapshots: `assert_match_snapshot`, `assert_match_snapshot_ignore_colors`,
+  `assert_match_named_snapshot`, `assert_match_named_snapshot_ignore_colors`
 - Spies: `assert_have_been_called`, `assert_not_called`, `assert_have_been_called_with`,
   `assert_have_been_called_with_any`, `assert_have_been_called_with_args`,
   `assert_have_been_called_times`, `assert_have_been_called_nth_with`

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -20,7 +20,8 @@ Pass `snapshot_file` to point at a specific snapshot — useful to share one sna
 By default each test gets its own, named after the test function.
 
 ::: tip
-You can update the snapshot by deleting it and running its test again.
+Update snapshots deliberately with `--snapshot-update`; combine it with `--filter` to
+re-record a single test.
 :::
 
 ::: code-group
@@ -76,6 +77,27 @@ function test_failure() {
 }
 ```
 :::
+
+## Named snapshots
+
+Use named snapshots when one test needs to capture several independent values:
+
+> `assert_match_named_snapshot "name" "actual"`
+
+```bash
+function test_render_modes() {
+  assert_match_named_snapshot "compact" "$(./bin/render --compact)"
+  assert_match_named_snapshot "verbose" "$(./bin/render --verbose)"
+}
+```
+
+The name becomes a normalized filename suffix, so these resolve beside the default
+snapshot as `test_render_modes.compact.snapshot` and
+`test_render_modes.verbose.snapshot`. Spaces and punctuation are safe and cannot escape
+the test's `snapshots/` directory.
+
+Use `assert_match_named_snapshot_ignore_colors "name" "actual"` for the same behavior
+with ANSI escape sequences removed.
 
 ## Placeholders
 

--- a/src/assert/snapshot.sh
+++ b/src/assert/snapshot.sh
@@ -24,6 +24,19 @@ function assert_match_snapshot() {
   bashunit::snapshot::assert "$actual" "$snapshot_file" "$test_fn"
 }
 
+function assert_match_named_snapshot() {
+  local snapshot_name=$1
+  local _snapshot_normalized
+  bashunit::snapshot::normalize_actual "$2"
+  local actual=$_snapshot_normalized
+  bashunit::helper::find_test_function_name_to_slot
+  local test_fn=$_BASHUNIT_HELPER_TESTFN_OUT
+  bashunit::snapshot::resolve_file "" "$test_fn" "$snapshot_name"
+  local snapshot_file=$_BASHUNIT_SNAPSHOT_FILE_OUT
+
+  bashunit::snapshot::assert "$actual" "$snapshot_file" "$test_fn"
+}
+
 function assert_match_snapshot_ignore_colors() {
   # Only fork sed when the input actually carries an escape sequence; plain,
   # colorless output takes a pure-bash fast path. The sed pattern is kept
@@ -39,6 +52,25 @@ function assert_match_snapshot_ignore_colors() {
   bashunit::helper::find_test_function_name_to_slot
   local test_fn=$_BASHUNIT_HELPER_TESTFN_OUT
   bashunit::snapshot::resolve_file "${2:-}" "$test_fn"
+  local snapshot_file=$_BASHUNIT_SNAPSHOT_FILE_OUT
+
+  bashunit::snapshot::assert "$actual" "$snapshot_file" "$test_fn"
+}
+
+function assert_match_named_snapshot_ignore_colors() {
+  local snapshot_name=$1
+  # Keep this byte-compatible with assert_match_snapshot_ignore_colors: only
+  # ANSI sequences ending in m/K are stripped, and only when ESC is present.
+  local stripped=$2
+  case "$stripped" in
+  *$'\e'*) stripped=$(printf '%s' "$stripped" | sed 's/\x1B\[[0-9;]*[mK]//g') ;;
+  esac
+  local _snapshot_normalized
+  bashunit::snapshot::normalize_actual "$stripped"
+  local actual=$_snapshot_normalized
+  bashunit::helper::find_test_function_name_to_slot
+  local test_fn=$_BASHUNIT_HELPER_TESTFN_OUT
+  bashunit::snapshot::resolve_file "" "$test_fn" "$snapshot_name"
   local snapshot_file=$_BASHUNIT_SNAPSHOT_FILE_OUT
 
   bashunit::snapshot::assert "$actual" "$snapshot_file" "$test_fn"
@@ -214,6 +246,7 @@ _BASHUNIT_SNAPSHOT_FILE_OUT=""
 function bashunit::snapshot::resolve_file() {
   local file_hint="$1"
   local func_name="$2"
+  local snapshot_name="${3:-}"
 
   if [ -n "$file_hint" ]; then
     _BASHUNIT_SNAPSHOT_FILE_OUT=$file_hint
@@ -233,9 +266,13 @@ function bashunit::snapshot::resolve_file() {
   bashunit::helper::normalize_variable_name_to_slot "$base_part"
   local test_file=$_BASHUNIT_HELPER_VARNAME_OUT
   bashunit::helper::normalize_variable_name_to_slot "$func_name"
-  local name="$_BASHUNIT_HELPER_VARNAME_OUT.snapshot"
+  local name=$_BASHUNIT_HELPER_VARNAME_OUT
+  if [ -n "$snapshot_name" ]; then
+    bashunit::helper::normalize_variable_name_to_slot "$snapshot_name"
+    name="$name.$_BASHUNIT_HELPER_VARNAME_OUT"
+  fi
 
-  _BASHUNIT_SNAPSHOT_FILE_OUT="./${dir_part}/snapshots/${test_file}.${name}"
+  _BASHUNIT_SNAPSHOT_FILE_OUT="./${dir_part}/snapshots/${test_file}.${name}.snapshot"
 }
 
 function bashunit::snapshot::initialize() {

--- a/src/console/test_line.sh
+++ b/src/console/test_line.sh
@@ -162,16 +162,21 @@ function bashunit::console_results::print_failed_snapshot_test() {
 
   local line
   line="$(printf "${_BASHUNIT_COLOR_FAILED}✗ Failed${_BASHUNIT_COLOR_DEFAULT}: %s
-    ${_BASHUNIT_COLOR_FAINT}Expected to match the snapshot${_BASHUNIT_COLOR_DEFAULT}\n" "$function_name")"
+    ${_BASHUNIT_COLOR_FAINT}Expected to match the snapshot${_BASHUNIT_COLOR_DEFAULT}
+    ${_BASHUNIT_COLOR_FAINT}Snapshot: %s${_BASHUNIT_COLOR_DEFAULT}
+    ${_BASHUNIT_COLOR_FAINT}Re-record with '--snapshot-update'${_BASHUNIT_COLOR_DEFAULT}\n" \
+    "$function_name" "$snapshot_file")"
 
   if bashunit::dependencies::has_git; then
     local actual_file="${snapshot_file}.tmp"
     echo "$actual_content" >"$actual_file"
 
-    line="$line$(bashunit::console_results::render_diff "$snapshot_file" "$actual_file")"
+    line="$line
+$(bashunit::console_results::render_diff "$snapshot_file" "$actual_file")"
     rm "$actual_file"
   else
-    line="$line$(bashunit::console_results::snapshot_line_diff \
+    line="$line
+$(bashunit::console_results::snapshot_line_diff \
       "$(cat "$snapshot_file")" "$actual_content")"
   fi
 
@@ -282,4 +287,3 @@ function bashunit::console_results::print_worker_stderr() {
     "$_BASHUNIT_COLOR_SKIPPED" "$test_file" "$_BASHUNIT_COLOR_DEFAULT"
   sed 's/^/|/' "$stderr_file"
 }
-

--- a/tests/acceptance/bashunit_fail_test.sh
+++ b/tests/acceptance/bashunit_fail_test.sh
@@ -21,8 +21,12 @@ function test_bashunit_when_a_test_fail_verbose_output_option() {
 }
 
 function test_different_verbose_snapshots_matches() {
-  bashunit::todo \
-    "The different snapshots for these tests should also be identical, option to choose snapshot name?"
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+
+  assert_match_named_snapshot "env" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
+  assert_match_named_snapshot "option" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_SIMPLE" "$test_file" --detailed)"
 }
 
 function test_bashunit_when_a_test_fail_simple_output_env() {
@@ -54,6 +58,10 @@ function test_bashunit_with_a_test_fail_and_exit_immediately() {
 }
 
 function test_different_simple_snapshots_matches() {
-  bashunit::todo \
-    "The different snapshots for these tests should also be identical, option to choose snapshot name?"
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
+
+  assert_match_named_snapshot "env" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_SIMPLE" "$test_file")"
+  assert_match_named_snapshot "option" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file" --simple)"
 }

--- a/tests/acceptance/bashunit_snapshot_named_test.sh
+++ b/tests/acceptance/bashunit_snapshot_named_test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function set_up_before_script() {
+  BASHUNIT_BIN="$(pwd)/bashunit"
+  FIXTURE="$(pwd)/tests/acceptance/fixtures/snapshot_named/named.sh"
+}
+
+function set_up() {
+  WORKDIR="$(mktemp -d)"
+  cp "$FIXTURE" "$WORKDIR/named.sh"
+  SNAPSHOTS="$WORKDIR/snapshots"
+  DEFAULT="$SNAPSHOTS/named_sh.test_named_snapshots.snapshot"
+  FIRST="$SNAPSHOTS/named_sh.test_named_snapshots.first_value.snapshot"
+  SAFE="$SNAPSHOTS/named_sh.test_named_snapshots._______second_.snapshot"
+  COLORED="$SNAPSHOTS/named_sh.test_named_snapshots.colored.snapshot"
+}
+
+function tear_down() {
+  rm -rf "$WORKDIR"
+}
+
+function test_named_snapshots_create_distinct_safe_files() {
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file named.sh) \
+    >/dev/null 2>&1
+
+  assert_same "default value" "$(<"$DEFAULT")"
+  assert_same "named value" "$(<"$FIRST")"
+  assert_same "safe value" "$(<"$SAFE")"
+  assert_same "colored value" "$(<"$COLORED")"
+}
+
+function test_named_snapshot_mismatch_names_the_path_and_update_flag() {
+  mkdir -p "$SNAPSHOTS"
+  printf 'stale value\n' >"$FIRST"
+
+  local output status=0
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    named.sh 2>&1) || status=$?
+
+  assert_same 1 "$status"
+  assert_contains "snapshots/named_sh.test_named_snapshots.first_value.snapshot" "$output"
+  assert_contains "--snapshot-update" "$output"
+}
+
+function test_snapshot_update_rewrites_a_named_snapshot() {
+  mkdir -p "$SNAPSHOTS"
+  printf 'stale value\n' >"$FIRST"
+
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-update named.sh) >/dev/null 2>&1
+
+  assert_same "named value" "$(<"$FIRST")"
+}

--- a/tests/acceptance/bashunit_stop_on_failure_test.sh
+++ b/tests/acceptance/bashunit_stop_on_failure_test.sh
@@ -21,8 +21,12 @@ function test_bashunit_when_stop_on_failure_env() {
 }
 
 function test_different_snapshots_matches() {
-  bashunit::todo \
-    "The different snapshots for these tests should also be identical, option to choose snapshot name?"
+  local test_file=./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh
+
+  assert_match_named_snapshot "option" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --stop-on-failure "$test_file")"
+  assert_match_named_snapshot "env" \
+    "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_STOP_ON_FAILURE" "$test_file")"
 }
 
 function test_bashunit_when_stop_on_failure_env_simple_output() {

--- a/tests/acceptance/bashunit_summary_output_test.sh
+++ b/tests/acceptance/bashunit_summary_output_test.sh
@@ -42,7 +42,8 @@ function test_incomplete_tests_displayed_with_show_incomplete_flag() {
 function test_both_flags_can_be_used_together() {
   local output
   output=$(./bashunit --env "$TEST_ENV_FILE" --no-parallel --simple --show-skipped --show-incomplete \
-    "tests/acceptance/bashunit_fail_test.sh" "tests/acceptance/bashunit_init_test.sh" 2>&1) || true
+    "tests/acceptance/bashunit_execution_error_test.sh" \
+    "tests/acceptance/bashunit_init_test.sh" 2>&1) || true
 
   assert_contains "incomplete test" "$output"
   assert_contains "skipped test" "$output"

--- a/tests/acceptance/fixtures/snapshot_named/named.sh
+++ b/tests/acceptance/fixtures/snapshot_named/named.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+function test_named_snapshots() {
+  assert_match_snapshot "default value"
+  assert_match_named_snapshot "first value" "named value"
+  assert_match_named_snapshot "../../ second!" "safe value"
+  assert_match_named_snapshot_ignore_colors "colored" $'\e[31mcolored value\e[0m'
+}

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_simple_snapshots_matches.env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_simple_snapshots_matches.env.snapshot
@@ -1,0 +1,18 @@
+..[31mF[0m..
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
+|[31m✗ Failed[0m: Assert failing
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
+
+
+
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_simple_snapshots_matches.option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_simple_snapshots_matches.option.snapshot
@@ -1,0 +1,18 @@
+..[31mF[0m..
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
+|[31m✗ Failed[0m: Assert failing
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
+
+
+
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_verbose_snapshots_matches.env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_verbose_snapshots_matches.env.snapshot
@@ -1,0 +1,24 @@
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+[31m✗ Failed[0m: Assert failing
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'0'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+[32m✓ Passed[0m: Assert greater and less than
+[32m✓ Passed[0m: Assert empty
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
+|[31m✗ Failed[0m: Assert failing
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
+
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_verbose_snapshots_matches.option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_fail_test_sh.test_different_verbose_snapshots_matches.option.snapshot
@@ -1,0 +1,24 @@
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh[0m
+[32m✓ Passed[0m: Assert same
+[32m✓ Passed[0m: Assert contains
+[31m✗ Failed[0m: Assert failing
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'0'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+[32m✓ Passed[0m: Assert greater and less than
+[32m✓ Passed[0m: Assert empty
+
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12
+|[31m✗ Failed[0m: Assert failing
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'0'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh:12[0m
+|    [90mSource:[0m
+|    [90m13:[0m assert_same 1 0
+
+[90mTests:     [0m [32m4 passed[0m, [31m1 failed[0m, 5 total
+[90mAssertions:[0m [32m6 passed[0m, [31m1 failed[0m, 7 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_different_snapshots_matches.env.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_different_snapshots_matches.env.snapshot
@@ -1,0 +1,24 @@
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
+[32m✓ Passed[0m: A success
+[31m✗ Failed[0m: B error
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'2'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
+
+[33mStop on failure enabled...[0m
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6
+|[31m✗ Failed[0m: B error
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
+|    [90mSource:[0m
+|    [90m7:[0m assert_same 1 1
+|    [90m8:[0m assert_same 1 2 # error
+|    [90m9:[0m assert_same 2 2
+
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_different_snapshots_matches.option.snapshot
+++ b/tests/acceptance/snapshots/bashunit_stop_on_failure_test_sh.test_different_snapshots_matches.option.snapshot
@@ -1,0 +1,24 @@
+[1mRunning ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh[0m
+[32m✓ Passed[0m: A success
+[31m✗ Failed[0m: B error
+    [90mExpected[0m [1m'1'[0m
+    [90mbut got [0m [1m'2'[0m
+    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
+
+[33mStop on failure enabled...[0m
+[1mThere was 1 failure:[0m
+
+|1) ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6
+|[31m✗ Failed[0m: B error
+|    [90mExpected[0m [1m'1'[0m
+|    [90mbut got [0m [1m'2'[0m
+|    [90mat ./tests/acceptance/fixtures/test_bashunit_when_stop_on_failure.sh:6[0m
+|    [90mSource:[0m
+|    [90m7:[0m assert_same 1 1
+|    [90m8:[0m assert_same 1 2 # error
+|    [90m9:[0m assert_same 2 2
+
+[90mTests:     [0m [32m1 passed[0m, [31m1 failed[0m, 2 total
+[90mAssertions:[0m [32m2 passed[0m, [31m1 failed[0m, 3 total
+
+[41m[30m[1m Some tests failed [0m

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -635,6 +635,20 @@ See Snapshots(/snapshots) for the full workflow, including how to update a snaps
 Same as assert_match_snapshot, but strips ANSI escape sequences from `actual` before comparing. Use it for commands whose colouring depends on the terminal.
 
 
+## assert_match_named_snapshot
+--------------
+> `assert_match_named_snapshot "name" "actual"`
+
+Matches `actual` against a snapshot whose filename includes `name`. Use it for multiple independent snapshots in one test without constructing file paths yourself. Names are normalized so they cannot escape the test's `snapshots/` directory.
+
+
+## assert_match_named_snapshot_ignore_colors
+--------------
+> `assert_match_named_snapshot_ignore_colors "name" "actual"`
+
+Named version of assert_match_snapshot_ignore_colors. ANSI escape sequences are stripped from `actual` before it is stored or compared.
+
+
 ## assert_have_been_called
 --------------
 > `assert_have_been_called "command"`

--- a/tests/unit/assert/snapshot_test.sh
+++ b/tests/unit/assert/snapshot_test.sh
@@ -28,6 +28,8 @@ function test_unsuccessful_assert_match_snapshot() {
 
   assert_matches "Unsuccessful assert match snapshot" "$actual"
   assert_matches "Expected to match the snapshot" "$actual"
+  assert_contains "snapshot_test_sh.test_unsuccessful_assert_match_snapshot.snapshot" "$actual"
+  assert_contains "--snapshot-update" "$actual"
 }
 
 function test_successful_assert_match_snapshot_ignore_colors() {
@@ -58,6 +60,9 @@ function test_unsuccessful_assert_match_snapshot_ignore_colors() {
 
   assert_matches "Unsuccessful assert match snapshot ignore colors" "$actual"
   assert_matches "Expected to match the snapshot" "$actual"
+  assert_contains \
+    "snapshot_test_sh.test_unsuccessful_assert_match_snapshot_ignore_colors.snapshot" "$actual"
+  assert_contains "--snapshot-update" "$actual"
 }
 
 function test_assert_match_snapshot_strips_carriage_returns_from_actual() {


### PR DESCRIPTION
## Summary

- add named snapshot assertions, including ANSI-stripping support
- normalize names into safe per-test snapshot suffixes
- show the resolved path and `--snapshot-update` guidance on mismatches
- replace the named-snapshot TODO coverage and update docs/completions

Closes #986

## Validation

- `make sa`
- `make lint`
- `./bashunit --parallel --simple --strict tests/` (1,628 tests)
- `bash build.sh bin -v` (1,628 tests)