### PR TITLE
docs(assert): correct the assert_true guidance — arguments need an eval prefix

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -36,11 +36,21 @@ to narrow it (`bashunit doc json`).
 ## assert_true
 > `assert_true bool|function|command`
 
-Takes a **command**, not a test expression. A bracketed condition of the form
-used inside `if` is run as a command word, so the shell reports exit code 127 and
-the assertion fails with `unknown command`. Use the `test` builtin instead —
-`assert_true "test -d /tmp"` — or a purpose-built assertion such as
-`assert_directory_exists`.
+The argument is run as a **single command word**, so it must be a bare command or
+function name with no arguments. Anything with arguments — including a bracketed
+condition of the form used inside `if` — is treated as one long command name, and
+the assertion fails with `unknown command`.
+
+Prefix with `eval` to run anything more than a bare name:
+
+```bash
+assert_true "my_function"            # bare name: works
+assert_true "eval test -d /tmp"      # arguments: needs eval
+assert_true "eval grep -q foo file"  # arguments: needs eval
+```
+
+A purpose-built assertion is usually clearer still — `assert_directory_exists`
+rather than a hand-rolled `test -d`.
 
 Reports an error if the argument result in a truthy value: `true` or `0`.
 

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -2,15 +2,12 @@
 --------------
 > `assert_true bool|function|command`
 
-Takes a **command**, not a test expression. A bracketed condition of the form
-used inside `if` is run as a command word, so the shell reports exit code 127 and
-the assertion fails with `unknown command`. Use the `test` builtin instead —
-`assert_true "test -d /tmp"` — or a purpose-built assertion such as
-`assert_directory_exists`.
+The argument is run as a **single command word**, so it must be a bare command or
+function name with no arguments. Anything with arguments — including a bracketed
+condition of the form used inside `if` — is treated as one long command name, and
+the assertion fails with `unknown command`.
 
-Reports an error if the argument result in a truthy value: `true` or `0`.
-
-- assert_false is similar but different.
+Prefix with `eval` to run anything more than a bare name:
 
 
 ## assert_false


### PR DESCRIPTION
## 🤔 Background

#991 documented `assert_true "test -d /tmp"` as the way to test a condition. **That doesn't work**, and I should have run it before writing it down.

`bashunit::run_command_or_eval` invokes its argument as a **single command word**. It never splits on whitespace, so `test -d /tmp` is looked up as a command literally named `test -d /tmp`. The assertion fails with `unknown command: test -d /tmp` — correct behaviour, wrong advice.

## 💡 The forms that actually work

Each verified by running it, not assumed:

```bash
assert_true "my_function"            # bare name
assert_true "eval test -d /tmp"      # arguments need eval
assert_true "eval [ -d /tmp ]"       # brackets work too, with eval
```

The `eval ` prefix is already a supported branch in `run_command_or_eval` — it was simply never documented, which made the single-word restriction look like a bug rather than a calling convention.

## 📋 Follow-up

Whether requiring `eval` is the right interface at all — given how surprising it is that `assert_true "grep -q foo file"` fails — is worth deciding separately, and I'll file it.

## ✅ Verification

Doc snapshot regenerated. `make sa` · `make lint` · full suite and acceptance green.