### PR TITLE
fix(build): raise the standalone binary budget to 544 KiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Performance: `--coverage` is about 1.6x to 2.3x faster. Executable-line classification no longer forks `grep` per source line, which was roughly half of a coverage run's wall time and affected both engines equally (#1005)
 
 ### Fixed
+- Build: the standalone binary size budget is 544 KiB, raised from 500 KiB after ordinary feature growth crossed it; the artifact keeps its indentation rather than being minified (#1045)
 - `assert_within_delta` rejects malformed numbers such as `1.2.3` or `5-3` as non-numeric instead of leaking a raw `bc` parse error or silently evaluating them as an expression (#1026)
 - Report formats are no longer empty under `--parallel`. `--report-junit`, `--report-tap`, `--report-json`, `--report-html` and `--log-junit` all recorded zero tests, because the rows were collected inside the per-test worker and nothing rebuilt them in the parent (#1004)
 

--- a/tests/unit/project/build_test.sh
+++ b/tests/unit/project/build_test.sh
@@ -321,7 +321,21 @@ function test_built_binary_contains_no_source_lines() {
   assert_equals "0" "$(grep -c '^source ' "$build_dir/bashunit")"
 }
 
-function test_built_binary_stays_below_500_kib() {
+# The budget is a guard against the artifact growing without anyone noticing,
+# not a hard product limit. It was raised from 512000 to 557056 (544 KiB) in
+# #1045, after a run of features crossed the old line by 0.3%: the alternatives
+# to raising it were both worse.
+#
+#   as-is                518493 bytes   over
+#   strip blank lines    515249 bytes   still over — and unsafe, because a blank
+#                                       line inside a heredoc is content (#990)
+#   shfmt --minify       471673 bytes   reaches it, by stripping every bit of
+#                                       indentation out of the shipped artifact
+#
+# So: keep the artifact readable and move the line, with headroom for a few more
+# features. Raise it deliberately and record the number again when it is hit —
+# do not silence it.
+function test_built_binary_stays_below_544_kib() {
   if ! build_optimizer_is_available; then
     bashunit::skip "shfmt and jq are required for standalone optimization"
     return
@@ -334,7 +348,7 @@ function test_built_binary_stays_below_500_kib() {
 
   local bytes
   bytes=$(wc -c <"$build_dir/bashunit" | tr -d ' ')
-  assert_less_or_equal_than 512000 "$bytes"
+  assert_less_or_equal_than 557056 "$bytes"
 }
 
 function test_build_assert_valid_syntax_rejects_broken_file() {


### PR DESCRIPTION
## 🤔 Background

Related #1045

**`main` is currently red.** The standalone artifact is 513,422 bytes against a 512,000 limit. #1037 was merged while `Build & Verify` was failing on it, so every PR opened since inherits the red — including #1044.

## 💡 Changes

- Raise the budget to 557,056 bytes (544 KiB) and record the measurements and reasoning next to the assertion, so the next raise is a decision rather than a silencing
- Rename the test to match its number

## Why raise rather than shrink

| approach | bytes | verdict |
|---|---|---|
| as-is | 518,493 | over |
| strip blank lines | 515,249 | still over — **and unsafe**, a blank line inside a heredoc is content (the hazard #990 had to handle) |
| `shfmt --minify` | 471,673 | reaches it, by stripping every bit of indentation out of the shipped artifact |

Blank-line stripping does not even get under the old line, so the real choice was minify-or-raise. Minifying trades away artifact readability permanently to buy back 0.3%; the growth here is ordinary feature accretion, not a builder regression.

## Correcting the issue's premise

#1045 guessed that CI skipped this check. It does not — `build.yml` installs `shfmt` via `go install` and both runners ship `jq`, so the test runs. The gate worked and was merged past. Nothing to fix in the workflow.