### PR TITLE
feat(reports): JUnit XML with per-file suites, classname and system-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - The coverage engine in use is reported by `--verbose`, and an explicit `BASHUNIT_COVERAGE_ENGINE=xtrace` that the running Bash cannot honour now warns instead of being silently ignored (#1005)
 
 ### Changed
+- The JUnit XML shape changed: one `<testsuite>` per test file (with its own counts, time and timestamp) instead of a single flat suite, `classname` on every `<testcase>`, `<failure message="...">` carrying the first informative line of the real message with `type="AssertionFailed"`, `<system-out>` with the test's captured output, and aggregate totals on `<testsuites>`. Consumers that group by suite or classname (Jenkins, GitLab, dorny/test-reporter) now get real groupings (#1016)
 - Performance: `--coverage` is about 1.6x to 2.3x faster. Executable-line classification no longer forks `grep` per source line, which was roughly half of a coverage run's wall time and affected both engines equally (#1005)
 
 ### Fixed

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -459,6 +459,8 @@ bashunit test tests/ --report-json report.json
 ```
 :::
 
+The JUnit XML groups results into one `<testsuite>` per test file, each with its own counts, time and timestamp. Every `<testcase>` carries `classname` (the file path in dotted form, e.g. `tests.unit.assert.core_test`), `name`, `file` and `time`; a failure's `message` attribute holds the first informative line of the real assertion message with the full text in the element body, and the test's captured output travels in `<system-out>`. That is the shape Jenkins, GitLab, Azure and `dorny/test-reporter` group and de-duplicate by.
+
 ### Markdown summary
 
 > `bashunit test --report-md <file>`

--- a/src/reports/collect.sh
+++ b/src/reports/collect.sh
@@ -18,6 +18,17 @@ _BASHUNIT_REPORTS_TEST_ASSERTIONS=()
 _BASHUNIT_REPORTS_TEST_FAILURES=()
 _BASHUNIT_REPORTS_TEST_LINES=()
 _BASHUNIT_REPORTS_TEST_RETRIES=()
+_BASHUNIT_REPORTS_TEST_OUTPUTS=()
+
+# The captured output of the test about to be recorded. The runner sets this
+# once per test before the add_test_* dispatch, so the report writers can carry
+# it (JUnit <system-out>) without threading one more argument through every
+# wrapper; add_test consumes and clears it.
+_BASHUNIT_REPORTS_CURRENT_OUTPUT=""
+
+function bashunit::reports::set_current_test_output() {
+  _BASHUNIT_REPORTS_CURRENT_OUTPUT="$1"
+}
 
 function bashunit::reports::add_test_snapshot() {
   bashunit::reports::add_test "$1" "$2" "$3" "$4" "snapshot"
@@ -77,6 +88,8 @@ function bashunit::reports::add_test() {
   local status="$5"
   local failure_message="${6:-}"
   local retries="${7:-0}"
+  local test_output="$_BASHUNIT_REPORTS_CURRENT_OUTPUT"
+  _BASHUNIT_REPORTS_CURRENT_OUTPUT=""
 
   # Capture the line number from the current test location ("file:line"),
   # but only when it belongs to this test's file, so a stale location from a
@@ -102,7 +115,7 @@ function bashunit::reports::add_test() {
   # Fields are base64-encoded because a failure message carries newlines and
   # arbitrary text, either of which would break a delimited line.
   if bashunit::parallel::is_enabled; then
-    printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
       "$(bashunit::helper::encode_base64 "$file")" \
       "$(bashunit::helper::encode_base64 "$test_name")" \
       "$(bashunit::helper::encode_base64 "$status")" \
@@ -111,6 +124,7 @@ function bashunit::reports::add_test() {
       "$(bashunit::helper::encode_base64 "$failure_message")" \
       "$(bashunit::helper::encode_base64 "$line")" \
       "$(bashunit::helper::encode_base64 "$retries")" \
+      "$(bashunit::helper::encode_base64 "$test_output")" \
       >>"${REPORTS_OUTPUT_PATH:-/dev/null}" 2>/dev/null || true
   fi
 
@@ -122,6 +136,7 @@ function bashunit::reports::add_test() {
   _BASHUNIT_REPORTS_TEST_FAILURES[${#_BASHUNIT_REPORTS_TEST_FAILURES[@]}]="$failure_message"
   _BASHUNIT_REPORTS_TEST_LINES[${#_BASHUNIT_REPORTS_TEST_LINES[@]}]="$line"
   _BASHUNIT_REPORTS_TEST_RETRIES[${#_BASHUNIT_REPORTS_TEST_RETRIES[@]}]="$retries"
+  _BASHUNIT_REPORTS_TEST_OUTPUTS[${#_BASHUNIT_REPORTS_TEST_OUTPUTS[@]}]="$test_output"
 }
 
 ##
@@ -133,8 +148,8 @@ function bashunit::reports::load_spooled() {
   bashunit::reports::is_enabled || return 0
   [ -f "${REPORTS_OUTPUT_PATH:-}" ] || return 0
 
-  local file test_name status duration assertions failure_message line retries n
-  while IFS='|' read -r file test_name status duration assertions failure_message line retries; do
+  local file test_name status duration assertions failure_message line retries test_output n
+  while IFS='|' read -r file test_name status duration assertions failure_message line retries test_output; do
     [ -n "$file" ] || continue
     local n=${#_BASHUNIT_REPORTS_TEST_FILES[@]}
     _BASHUNIT_REPORTS_TEST_FILES[n]=$(bashunit::helper::decode_base64 "$file")
@@ -145,5 +160,6 @@ function bashunit::reports::load_spooled() {
     _BASHUNIT_REPORTS_TEST_FAILURES[n]=$(bashunit::helper::decode_base64 "$failure_message")
     _BASHUNIT_REPORTS_TEST_LINES[n]=$(bashunit::helper::decode_base64 "$line")
     _BASHUNIT_REPORTS_TEST_RETRIES[n]=$(bashunit::helper::decode_base64 "$retries")
+    _BASHUNIT_REPORTS_TEST_OUTPUTS[n]=$(bashunit::helper::decode_base64 "$test_output")
   done <"$REPORTS_OUTPUT_PATH"
 }

--- a/src/reports/junit.sh
+++ b/src/reports/junit.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2155
 
-# JUnit XML report writer.
+# JUnit XML report writer. One <testsuite> per test file, because that is the
+# unit Jenkins, GitLab, Azure and dorny/test-reporter group results by; a flat
+# suite collapsed every run into one undifferentiated bucket.
 
 function bashunit::reports::__xml_escape() {
   local text="$1"
@@ -12,64 +13,173 @@ function bashunit::reports::__xml_escape() {
     | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' -e 's/"/\&quot;/g' -e "s/'/\&apos;/g"
 }
 
+# Milliseconds to "S.mmm" seconds, written into the slot below. Pure bash on
+# purpose: the previous `env LC_ALL=C awk` call (needed so the radix stays a
+# dot, #912) forked once per testcase; printf with a literal dot is
+# locale-immune and free.
+_BASHUNIT_REPORTS_MS_TO_S_OUT=""
+function bashunit::reports::__ms_to_s() {
+  local ms="${1:-0}"
+  case "$ms" in
+    '' | *[!0-9]*) ms=0 ;;
+  esac
+  _BASHUNIT_REPORTS_MS_TO_S_OUT="$((ms / 1000)).$(printf '%03d' "$((ms % 1000))")"
+}
+
+# Test file path to the dotted classname consumers group by:
+# tests/unit/assert/core_test.sh -> tests.unit.assert.core_test
+_BASHUNIT_REPORTS_CLASSNAME_OUT=""
+function bashunit::reports::__junit_classname() {
+  local path="$1"
+  path="${path#./}"
+  path="${path%.sh}"
+  _BASHUNIT_REPORTS_CLASSNAME_OUT="${path//\//.}"
+}
+
 function bashunit::reports::generate_junit_xml() {
   local output_file="$1"
 
-  local tests_skipped=$(bashunit::state::get_tests_skipped)
-  local tests_incomplete=$(bashunit::state::get_tests_incomplete)
-  local tests_failed=$(bashunit::state::get_tests_failed)
-  local time_ms=$(bashunit::clock::total_runtime_in_milliseconds)
-  local time
-  # `env` rather than a bare `LC_ALL=C` prefix: C keeps awk's radix a dot for the
-  # XML, and that prefix form segfaults inside `$()` on Bash 5.3 macOS (#912).
-  time=$(env LC_ALL=C awk -v ms="$time_ms" 'BEGIN {printf "%.3f", ms/1000}')
+  local timestamp
+  timestamp=$(date '+%Y-%m-%dT%H:%M:%S')
+
+  # Group rows by file in first-appearance order. Parallel indexed arrays
+  # instead of declare -A (Bash 3.0): suite lookup is a linear scan over the
+  # file count, which stays small next to the test count.
+  local suite_files suite_tests suite_failures suite_skipped suite_time cases
+  suite_files=()
+  suite_tests=()
+  suite_failures=()
+  suite_skipped=()
+  suite_time=()
+  cases=()
+
+  local total_tests="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
+  local total_failures=0
+  local total_skipped=0
+  local total_time_ms=0
+
+  local i j s
+  for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+    local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
+    local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+    local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
+    local duration_ms="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-0}"
+    local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
+    local test_output="${_BASHUNIT_REPORTS_TEST_OUTPUTS[$i]:-}"
+    case "$duration_ms" in '' | *[!0-9]*) duration_ms=0 ;; esac
+
+    s=-1
+    for j in ${suite_files[@]+"${!suite_files[@]}"}; do
+      if [ "${suite_files[$j]}" = "$file" ]; then
+        s=$j
+        break
+      fi
+    done
+    if [ "$s" -eq -1 ]; then
+      s=${#suite_files[@]}
+      suite_files[s]="$file"
+      suite_tests[s]=0
+      suite_failures[s]=0
+      suite_skipped[s]=0
+      suite_time[s]=0
+      cases[s]=""
+    fi
+
+    suite_tests[s]=$((suite_tests[s] + 1))
+    suite_time[s]=$((suite_time[s] + duration_ms))
+    total_time_ms=$((total_time_ms + duration_ms))
+
+    local test_time escaped_name classname
+    bashunit::reports::__ms_to_s "$duration_ms"
+    test_time=$_BASHUNIT_REPORTS_MS_TO_S_OUT
+    escaped_name=$(bashunit::reports::__xml_escape "$name")
+    bashunit::reports::__junit_classname "$file"
+    classname=$_BASHUNIT_REPORTS_CLASSNAME_OUT
+
+    local case_xml="    <testcase classname=\"$classname\" name=\"$escaped_name\"
+        file=\"$file\" time=\"$test_time\">
+"
+
+    if [ "$status" = "failed" ]; then
+      suite_failures[s]=$((suite_failures[s] + 1))
+      total_failures=$((total_failures + 1))
+      local escaped_message plain_message msg_head
+      escaped_message=$(bashunit::reports::__xml_escape "$failure_message")
+      # The first informative line as @message: many consumers show only the
+      # attribute, and a constant "Test failed" there hid the real reason
+      # (#1016). The "✗ Failed: <name>" banner repeats the name attribute, so
+      # when a further line exists that one speaks for the failure instead.
+      plain_message=$(bashunit::reports::__strip_ansi "$failure_message")
+      msg_head="${plain_message%%$'\n'*}"
+      case "$msg_head" in
+        '✗ Failed:'* | '✗ Error:'*)
+          local msg_rest="${plain_message#*$'\n'}"
+          if [ "$msg_rest" != "$plain_message" ]; then
+            msg_head="${msg_rest%%$'\n'*}"
+            msg_head="${msg_head#"${msg_head%%[![:space:]]*}"}"
+          fi
+          ;;
+      esac
+      local first_line
+      first_line=$(bashunit::reports::__xml_escape "$msg_head")
+      case_xml="$case_xml      <failure message=\"$first_line\" type=\"AssertionFailed\">$escaped_message</failure>
+"
+    elif [ "$status" = "flaky" ]; then
+      # Jenkins and GitLab render flakyFailure natively, and it does not count
+      # towards failures="" -- which is the point: the test passed.
+      local escaped_flaky
+      escaped_flaky=$(bashunit::reports::__xml_escape "$failure_message")
+      case_xml="$case_xml      <flakyFailure message=\"Test passed after ${_BASHUNIT_REPORTS_TEST_RETRIES[$i]:-0} \
+retries\">$escaped_flaky</flakyFailure>
+"
+    elif [ "$status" = "risky" ]; then
+      suite_skipped[s]=$((suite_skipped[s] + 1))
+      total_skipped=$((total_skipped + 1))
+      case_xml="$case_xml      <skipped message=\"Test has no assertions (risky)\"/>
+"
+    elif [ "$status" = "skipped" ]; then
+      suite_skipped[s]=$((suite_skipped[s] + 1))
+      total_skipped=$((total_skipped + 1))
+      case_xml="$case_xml      <skipped/>
+"
+    elif [ "$status" = "incomplete" ]; then
+      suite_skipped[s]=$((suite_skipped[s] + 1))
+      total_skipped=$((total_skipped + 1))
+      case_xml="$case_xml      <skipped message=\"Test incomplete\"/>
+"
+    fi
+
+    if [ -n "$test_output" ]; then
+      local escaped_output
+      escaped_output=$(bashunit::reports::__xml_escape "$test_output")
+      case_xml="$case_xml      <system-out>$escaped_output</system-out>
+"
+    fi
+
+    cases[s]="${cases[s]}$case_xml    </testcase>
+"
+  done
+
+  local total_time
+  bashunit::reports::__ms_to_s "$total_time_ms"
+  total_time=$_BASHUNIT_REPORTS_MS_TO_S_OUT
 
   {
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    echo "<testsuites>"
-    echo "  <testsuite name=\"bashunit\" tests=\"${#_BASHUNIT_REPORTS_TEST_NAMES[@]}\""
-    echo "             failures=\"$tests_failed\" errors=\"0\""
-    echo "             skipped=\"$(( tests_skipped + tests_incomplete ))\""
-    echo "             time=\"$time\">"
+    echo "<testsuites name=\"bashunit\" tests=\"$total_tests\" failures=\"$total_failures\"" \
+      "skipped=\"$total_skipped\" errors=\"0\" time=\"$total_time\">"
 
-    local i
-    for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
-      local file="${_BASHUNIT_REPORTS_TEST_FILES[$i]:-}"
-      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
-      local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
-      local test_time_ms="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
-      local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
-      local test_time
-      test_time=$(env LC_ALL=C awk -v ms="$test_time_ms" 'BEGIN {printf "%.3f", ms/1000}')
-
-      echo "    <testcase file=\"$file\""
-      echo "        name=\"$name\""
-      echo "        time=\"$test_time\">"
-
-      # Add failure element for failed tests with actual failure message
-      if [ "$status" = "failed" ]; then
-        local escaped_message
-        escaped_message=$(bashunit::reports::__xml_escape "$failure_message")
-        echo "      <failure message=\"Test failed\">$escaped_message</failure>"
-      elif [ "$status" = "flaky" ]; then
-        # Jenkins and GitLab render flakyFailure natively, and it does not count
-        # towards failures="" -- which is the point: the test passed.
-        local escaped_flaky
-        escaped_flaky=$(bashunit::reports::__xml_escape "$failure_message")
-        echo "      <flakyFailure message=\"Test passed after ${_BASHUNIT_REPORTS_TEST_RETRIES[$i]:-0} \
-retries\">$escaped_flaky</flakyFailure>"
-      elif [ "$status" = "risky" ]; then
-        echo "      <skipped message=\"Test has no assertions (risky)\"/>"
-      elif [ "$status" = "skipped" ]; then
-        echo "      <skipped/>"
-      elif [ "$status" = "incomplete" ]; then
-        echo "      <skipped message=\"Test incomplete\"/>"
-      fi
-
-      echo "    </testcase>"
+    for s in ${suite_files[@]+"${!suite_files[@]}"}; do
+      local suite_time_s
+      bashunit::reports::__ms_to_s "${suite_time[$s]}"
+      suite_time_s=$_BASHUNIT_REPORTS_MS_TO_S_OUT
+      echo "  <testsuite name=\"${suite_files[$s]}\" tests=\"${suite_tests[$s]}\"" \
+        "failures=\"${suite_failures[$s]}\" skipped=\"${suite_skipped[$s]}\" errors=\"0\"" \
+        "time=\"$suite_time_s\" timestamp=\"$timestamp\">"
+      printf '%s' "${cases[$s]}"
+      echo "  </testsuite>"
     done
 
-    echo "  </testsuite>"
     echo "</testsuites>"
   } >"$output_file"
 }

--- a/src/runner/exec.sh
+++ b/src/runner/exec.sh
@@ -450,6 +450,10 @@ function bashunit::runner::run_test() {
   local runtime_output=$attempt_display_output
   local runtime_error=$attempt_runtime_error
 
+  # Retain the test's captured output for the report writers (JUnit
+  # <system-out>): add_test consumes it in whichever status branch fires below.
+  bashunit::reports::set_current_test_output "$runtime_output"
+
   # parse_result accumulates _BASHUNIT_TEST_EXIT_CODE; reset it so each test's
   # exit code is read in isolation (a non-zero/timed-out test must not poison
   # the next one).

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -21,6 +21,36 @@ function test_bashunit_when_log_junit_env() {
   rm log-junit.xml
 }
 
+function test_junit_carries_classname_suites_and_captured_output() {
+  local fixture=tests/acceptance/fixtures/test_bashunit_junit_shape.sh
+  local report
+  report="$(bashunit::temp_file)"
+
+  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --log-junit "$report" "$fixture" >/dev/null 2>&1 || true
+
+  local content
+  content="$(cat "$report")"
+  assert_contains "<testsuite name=\"$fixture\" tests=\"2\" failures=\"1\"" "$content"
+  assert_contains 'classname="tests.acceptance.fixtures.test_bashunit_junit_shape"' "$content"
+  assert_contains '<system-out>hello from the test body</system-out>' "$content"
+  assert_contains 'message="Expected &apos;expected junit value&apos;"' "$content"
+}
+
+# Regression guard for #1004: the rows are spooled by the workers and replayed
+# in the parent, so the new columns must survive the fork boundary too.
+function test_junit_captured_output_survives_parallel() {
+  local fixture=tests/acceptance/fixtures/test_bashunit_junit_shape.sh
+  local report
+  report="$(bashunit::temp_file)"
+
+  ./bashunit --parallel --env "$TEST_ENV_FILE" --log-junit "$report" "$fixture" >/dev/null 2>&1 || true
+
+  local content
+  content="$(cat "$report")"
+  assert_contains '<system-out>hello from the test body</system-out>' "$content"
+  assert_contains 'classname="tests.acceptance.fixtures.test_bashunit_junit_shape"' "$content"
+}
+
 function test_bashunit_report_junit_is_alias_of_log_junit() {
   local test_file=./tests/acceptance/fixtures/test_bashunit_when_log_junit.sh
   local report=report-junit-alias.xml

--- a/tests/acceptance/fixtures/test_bashunit_junit_shape.sh
+++ b/tests/acceptance/fixtures/test_bashunit_junit_shape.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# One passing test that prints output (feeds <system-out>) and one failing
+# test in the same file, so the JUnit report has a suite with both counts.
+function test_junit_pass_with_output() {
+  echo "hello from the test body"
+  assert_same "ok" "ok"
+}
+
+function test_junit_fail() {
+  assert_same "expected junit value" "actual junit value"
+}

--- a/tests/unit/reports/report_junit_structure_test.sh
+++ b/tests/unit/reports/report_junit_structure_test.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329,SC2034 # Mock functions are invoked indirectly
+
+_XMLLINT_AVAILABLE=false
+if command -v xmllint >/dev/null 2>&1; then
+  _XMLLINT_AVAILABLE=true
+fi
+
+function set_up() {
+  _BASHUNIT_REPORTS_TEST_FILES=()
+  _BASHUNIT_REPORTS_TEST_NAMES=()
+  _BASHUNIT_REPORTS_TEST_STATUSES=()
+  _BASHUNIT_REPORTS_TEST_DURATIONS=()
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=()
+  _BASHUNIT_REPORTS_TEST_FAILURES=()
+  _BASHUNIT_REPORTS_TEST_LINES=()
+  _BASHUNIT_REPORTS_TEST_RETRIES=()
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=()
+}
+
+function test_junit_groups_testcases_into_one_suite_per_file() {
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  assert_contains '<testsuite name="tests/unit/a_test.sh"' "$content"
+  assert_contains '<testsuite name="tests/unit/b_test.sh"' "$content"
+  assert_not_contains '<testsuite name="bashunit"' "$content"
+  rm -f "$out"
+}
+
+function test_junit_testcase_carries_classname_name_file_and_time() {
+  local out
+  out="$(mktemp)"
+  _BASHUNIT_REPORTS_TEST_FILES=("tests/unit/assert/core_test.sh")
+  _BASHUNIT_REPORTS_TEST_NAMES=("it adds")
+  _BASHUNIT_REPORTS_TEST_STATUSES=("passed")
+  _BASHUNIT_REPORTS_TEST_DURATIONS=("1500")
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=("1")
+  _BASHUNIT_REPORTS_TEST_FAILURES=("")
+  _BASHUNIT_REPORTS_TEST_LINES=("10")
+  _BASHUNIT_REPORTS_TEST_RETRIES=("0")
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=("")
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  assert_contains 'classname="tests.unit.assert.core_test"' "$content"
+  assert_contains 'name="it adds"' "$content"
+  assert_contains 'file="tests/unit/assert/core_test.sh"' "$content"
+  assert_contains 'time="1.500"' "$content"
+  rm -f "$out"
+}
+
+function test_junit_failure_message_is_first_line_of_the_real_message() {
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  assert_contains '<failure message="Expected 1 but got 2" type="AssertionFailed">' "$content"
+  assert_contains 'second line detail</failure>' "$content"
+  assert_not_contains 'message="Test failed"' "$content"
+  rm -f "$out"
+}
+
+function test_junit_failure_message_skips_the_failed_banner_line() {
+  local out
+  out="$(mktemp)"
+  _BASHUNIT_REPORTS_TEST_FILES=("tests/x_test.sh")
+  _BASHUNIT_REPORTS_TEST_NAMES=("it fails")
+  _BASHUNIT_REPORTS_TEST_STATUSES=("failed")
+  _BASHUNIT_REPORTS_TEST_DURATIONS=("5")
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=("1")
+  _BASHUNIT_REPORTS_TEST_FAILURES=("$(printf "✗ Failed: it fails\n    Expected 'a'\n    but got 'b'")")
+  _BASHUNIT_REPORTS_TEST_LINES=("3")
+  _BASHUNIT_REPORTS_TEST_RETRIES=("0")
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=("")
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  # The banner repeats the name attribute; the next line carries the reason.
+  assert_contains 'message="Expected &apos;a&apos;"' "$content"
+  # The body still opens with the full message, banner included.
+  assert_contains 'Failed: it fails' "$content"
+  rm -f "$out"
+}
+
+function test_junit_system_out_present_only_when_the_test_printed_output() {
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  assert_contains '<system-out>debug: setting up</system-out>' "$content"
+  # Exactly one testcase printed output, so exactly one system-out element.
+  assert_same "1" "$(grep -c '<system-out>' "$out" | tr -d ' ')"
+  rm -f "$out"
+}
+
+function test_junit_per_suite_counts_and_aggregate_totals() {
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  # Outer aggregate: 3 tests, 1 failure, 1 skipped.
+  assert_contains '<testsuites name="bashunit" tests="3" failures="1" skipped="1" errors="0"' "$content"
+  # Suite a: 2 tests, 1 failure. Suite b: 1 test, 1 skipped.
+  assert_matches '<testsuite name="tests/unit/a_test.sh" tests="2" failures="1" skipped="0"' "$content"
+  assert_matches '<testsuite name="tests/unit/b_test.sh" tests="1" failures="0" skipped="1"' "$content"
+  rm -f "$out"
+}
+
+function test_junit_suites_carry_a_timestamp() {
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  assert_matches 'timestamp="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}"' "$(cat "$out")"
+  rm -f "$out"
+}
+
+function test_junit_output_is_well_formed_xml() {
+  if [ "$_XMLLINT_AVAILABLE" = false ]; then bashunit::skip "xmllint required"; return; fi
+  local out
+  out="$(mktemp)"
+  set_up_two_file_fixture
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  assert_successful_code "$(xmllint --noout "$out" 2>&1)"
+  rm -f "$out"
+}
+
+function test_junit_escapes_xml_in_system_out_and_failure() {
+  local out
+  out="$(mktemp)"
+  _BASHUNIT_REPORTS_TEST_FILES=("tests/x_test.sh")
+  _BASHUNIT_REPORTS_TEST_NAMES=("it escapes")
+  _BASHUNIT_REPORTS_TEST_STATUSES=("failed")
+  _BASHUNIT_REPORTS_TEST_DURATIONS=("5")
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=("1")
+  _BASHUNIT_REPORTS_TEST_FAILURES=('a < b & "c"')
+  _BASHUNIT_REPORTS_TEST_LINES=("3")
+  _BASHUNIT_REPORTS_TEST_RETRIES=("0")
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=('<tag> & "quoted"')
+
+  bashunit::reports::generate_junit_xml "$out"
+
+  local content
+  content="$(cat "$out")"
+  assert_contains 'a &lt; b &amp; &quot;c&quot;' "$content"
+  assert_contains '<system-out>&lt;tag&gt; &amp; &quot;quoted&quot;</system-out>' "$content"
+  rm -f "$out"
+}
+
+# Three tests across two files: a passing test with captured output and a
+# multi-line failure in file a, a skipped test in file b.
+function set_up_two_file_fixture() {
+  _BASHUNIT_REPORTS_TEST_FILES=("tests/unit/a_test.sh" "tests/unit/a_test.sh" "tests/unit/b_test.sh")
+  _BASHUNIT_REPORTS_TEST_NAMES=("it passes" "it fails" "it skips")
+  _BASHUNIT_REPORTS_TEST_STATUSES=("passed" "failed" "skipped")
+  _BASHUNIT_REPORTS_TEST_DURATIONS=("100" "200" "0")
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=("1" "1" "0")
+  _BASHUNIT_REPORTS_TEST_FAILURES=("" "$(printf 'Expected 1 but got 2\nsecond line detail')" "")
+  _BASHUNIT_REPORTS_TEST_LINES=("10" "20" "5")
+  _BASHUNIT_REPORTS_TEST_RETRIES=("0" "0" "0")
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=("debug: setting up" "" "")
+}

--- a/tests/unit/reports/reports_test.sh
+++ b/tests/unit/reports/reports_test.sh
@@ -16,6 +16,8 @@ function set_up() {
   _BASHUNIT_REPORTS_TEST_FAILURES=()
   _BASHUNIT_REPORTS_TEST_LINES=()
   _BASHUNIT_REPORTS_TEST_RETRIES=()
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=()
+  _BASHUNIT_REPORTS_CURRENT_OUTPUT=""
   _BASHUNIT_TEST_LOCATION=""
 
   # Unset report env vars by default
@@ -189,7 +191,7 @@ function test_generate_junit_xml_creates_valid_xml_header() {
   content=$(cat "$_TEMP_OUTPUT_FILE")
 
   assert_contains '<?xml version="1.0" encoding="UTF-8"?>' "$content"
-  assert_contains '<testsuites>' "$content"
+  assert_contains '<testsuites name="bashunit"' "$content"
   assert_contains '</testsuites>' "$content"
 }
 
@@ -203,12 +205,11 @@ function test_generate_junit_xml_includes_testsuite_attributes() {
   local content
   content=$(cat "$_TEMP_OUTPUT_FILE")
 
-  assert_contains '<testsuite name="bashunit"' "$content"
-  assert_contains 'tests="1"' "$content"
-  assert_contains 'failures="1"' "$content"
-  assert_contains 'skipped="3"' "$content"
-  assert_contains 'errors="0"' "$content"
-  assert_contains 'time="1.234"' "$content"
+  # One suite per test file; the counts derive from the recorded rows, not the
+  # global state counters (#1016).
+  assert_contains '<testsuite name="test.sh" tests="1" failures="0" skipped="0" errors="0"' "$content"
+  assert_contains '<testsuites name="bashunit" tests="1" failures="0" skipped="0" errors="0"' "$content"
+  assert_contains 'time="0.100"' "$content"
 }
 
 function test_generate_junit_xml_includes_testcase_elements() {
@@ -221,8 +222,8 @@ function test_generate_junit_xml_includes_testcase_elements() {
   local content
   content=$(cat "$_TEMP_OUTPUT_FILE")
 
-  assert_contains '<testcase file="my_test.sh"' "$content"
-  assert_contains 'name="test_example"' "$content"
+  assert_contains '<testcase classname="my_test" name="test_example"' "$content"
+  assert_contains 'file="my_test.sh"' "$content"
   assert_contains 'time="0.500"' "$content"
   assert_not_contains 'status=' "$content"
   assert_not_contains 'assertions=' "$content"
@@ -270,7 +271,7 @@ function test_generate_junit_xml_incomplete_testcase() {
   assert_not_contains '<failure' "$content"
 }
 
-function test_generate_junit_xml_failure_element_without_type() {
+function test_generate_junit_xml_failure_message_carries_the_real_reason() {
   _mock_state_functions
   BASHUNIT_LOG_JUNIT="report.xml"
 
@@ -281,9 +282,9 @@ function test_generate_junit_xml_failure_element_without_type() {
   local content
   content=$(cat "$_TEMP_OUTPUT_FILE")
 
-  assert_contains '<failure message="Test failed">' "$content"
+  assert_contains "<failure message=\"$failure_msg\" type=\"AssertionFailed\">" "$content"
   assert_contains "$failure_msg</failure>" "$content"
-  assert_not_contains 'type=' "$content"
+  assert_not_contains 'message="Test failed"' "$content"
 }
 
 function test_generate_junit_xml_failure_element_with_xml_escaping() {


### PR DESCRIPTION
## 🤔 Background

Related #1016

The JUnit report was a single flat `<testsuite>` with no `classname`, a constant `message="Test failed"` and no captured output, so Jenkins, GitLab, Azure and `dorny/test-reporter` collapsed every run into one undifferentiated bucket.

## 💡 Changes

- One `<testsuite>` per test file with its own counts, time and timestamp; aggregate totals move to `<testsuites>`
- Every `<testcase>` gets `classname` (dotted file path), `name`, `file` and `time`; `<failure message>` carries the first informative line of the real message with `type="AssertionFailed"` and the full text in the body
- The test's captured output is retained as a new reports column (spooled across the `--parallel` fork boundary, #1004 guard) and emitted as `<system-out>` when non-empty
- Per-testcase seconds are formatted in pure bash with a literal dot, removing the per-testcase `awk` fork the #912 locale workaround existed for; existing ANSI/control/XML escaping unchanged