### PR TITLE
feat(cli): --output json and --output junit to stdout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ BASHUNIT_NO_COLOR=                  # Default: false (disable colors)
 BASHUNIT_NO_DIFF=                   # Default: false (disable unified diff on multiline assert failures)
 BASHUNIT_NO_PROGRESS=               # Default: false (suppress real-time progress, final results only)
 BASHUNIT_SHOW_OUTPUT_ON_FAILURE=    # Default: true (show captured test output on failure)
-BASHUNIT_OUTPUT_FORMAT=             # Default: empty (tap = TAP version 13 on stdout)
+BASHUNIT_OUTPUT_FORMAT=             # Default: empty (text; tap, json or junit go to stdout)
 
 #───────────────────────────────────────────────────────────────────────────────
 # Test Execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- `--output <text|tap|json|junit>` sends the JSON and JUnit reports to stdout, so a pipeline needs no temp file; the console rendering, coverage table, slowest-tests table and GitHub Actions annotations are suppressed for the machine formats, diagnostics stay on stderr, exit codes are unchanged, and `--output json --report-json f.json` produces both (#1018)
+
 ## [0.46.0](https://github.com/TypedDevs/bashunit/compare/0.45.0...0.46.0) - 2026-08-11
 
 ### Added

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -81,7 +81,7 @@ _bashunit() {
     '--report-md[Write a Markdown summary]:file:_files' \
     '(-s --simple)'{-s,--simple}'[Simple output with dots]' \
     '--detailed[Detailed output, the default]' \
-    '--output[Output format]:format:(tap)' \
+    '--output[Output format]:format:(text tap json junit)' \
     '(-R --run-all)'{-R,--run-all}'[Run all assertions without stopping on first failure]' \
     '(-S --stop-on-failure)'{-S,--stop-on-failure}'[Stop on first failure]' \
     '--test-timeout[Fail a test running longer than N seconds]:seconds:' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -65,7 +65,7 @@ _bashunit_completions() {
   # Value hints for options that take an argument.
   case "$prev" in
   --output)
-    COMPREPLY=($(compgen -W "tap" -- "$cur"))
+    COMPREPLY=($(compgen -W "text tap json junit" -- "$cur"))
     return 0
     ;;
   -j | --jobs)

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -44,6 +44,13 @@ message and the exact source line:
 }
 ```
 
+`--output json` prints that same document on stdout instead, so an agent can pipe a run
+straight into a parser without a temp file:
+
+```bash
+bashunit tests/ --output json | jq '.tests[] | select(.status == "failed")'
+```
+
 `--output tap` prints [TAP version 13](https://testanything.org) on stdout, which most
 harnesses already understand:
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -64,7 +64,7 @@ bashunit test tests/ --parallel --simple
 | `--exclude-filter <name>`      | Skip tests whose name matches (repeatable)       |
 | `--tag <expr>`                 | Only run tests with matching `@tag`; supports `a&&b` and `!a` |
 | `--exclude-tag <name>`         | Skip tests with matching `@tag` (repeatable)     |
-| `--output <format>`            | Output format (`tap` for TAP version 13)         |
+| `--output <format>`            | Report on stdout: `text` (default), `tap`, `json`, `junit` |
 | `-w, --watch`                  | Watch files and re-run tests on change           |
 | `--log-junit, --report-junit <file>` | Write JUnit XML report                     |
 | `--log-gha <file>`             | Write GitHub Actions workflow-commands log       |
@@ -243,11 +243,36 @@ bashunit --list --tag 'db&&!slow' tests/
 
 > `bashunit test --output <format>`
 
-Select an alternative output format. Currently supported:
+Send the report to **stdout** in a machine-readable format instead of the
+human-readable console rendering. Supported values:
 
+- `text` — the default console rendering, identical to passing no flag.
 - `tap` — [TAP version 13](https://testanything.org/tap-version-13-specification.html) for CI/CD integrations.
+- `json` — the same document [`--report-json`](#reports) writes to a file.
+- `junit` — the same JUnit XML [`--report-junit`](#reports) writes to a file.
 
-The `TAP version 13` header comes first, each test file is announced via a
+For every format but `text` the header, progress, summary, coverage table and
+slowest-tests table are suppressed, so stdout holds nothing but the report and
+can be piped straight into a parser. Diagnostics keep going to stderr, and the
+exit code is the one the run would produce anyway.
+
+`--output` and the file reporters (`--report-json`, `--report-junit`) are
+independent: asking for both in the same run prints the document **and** writes
+the file.
+
+::: code-group
+```bash [JSON]
+bashunit tests/ --output json | jq '.tests[] | select(.status == "failed") | .name'
+```
+```bash [JUnit]
+bashunit tests/ --output junit > report.xml
+```
+```bash [Both sinks]
+bashunit tests/ --output json --report-json report.json | jq '.summary'
+```
+:::
+
+For `tap`, the `TAP version 13` header comes first, each test file is announced via a
 `# <path>` diagnostic line, each test emits an `ok <n> - <name>` or
 `not ok <n> - <name>` line (failures include a YAML `--- ... ...` block with
 expected/actual), and the `1..N` plan line closes the report.
@@ -538,8 +563,8 @@ Detection is `GITHUB_ACTIONS=true`, and `--gha-annotations` overrides it:
 bashunit test tests/ --gha-annotations never
 ```
 
-`auto` also stays quiet under `--output tap`, whose stdout is a machine format an
-annotation line would corrupt.
+`auto` also stays quiet under a machine `--output` format (`tap`, `json`,
+`junit`), whose stdout an annotation line would corrupt.
 
 The separate `--log-gha <file>` flag still writes the same workflow commands to a
 file. It is independent of the stdout annotations, so using both does not
@@ -1567,7 +1592,8 @@ Without this, `--parralel` ran the suite **sequentially** and still exited `0`, 
 
 `--jobs`, `--retry`, `--test-timeout`, `--coverage-min` and `--seed` require a
 non-negative integer; `--repeat` requires an integer of at least `1`; `--output` accepts
-only `tap`; `--shard` requires `<index>/<total>`; and `--gha-annotations`, `--order-by` and
+only `text`, `tap`, `json` and `junit`; `--shard` requires `<index>/<total>`;
+and `--gha-annotations`, `--order-by` and
 `--list-format` accept only their listed modes:
 
 ```bash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -521,11 +521,13 @@ BASHUNIT_SHOW_EXECUTION_TIME=false
 
 ## Output format
 
-> `BASHUNIT_OUTPUT_FORMAT=tap`
+> `BASHUNIT_OUTPUT_FORMAT=text|tap|json|junit`
 
-Select an alternative output format. Currently supported: `tap` for
+Send the report to stdout in a machine-readable format instead of the console
+rendering: `tap` for
 [TAP version 13](https://testanything.org/tap-version-13-specification.html),
-useful for CI/CD integrations.
+`json` for the `--report-json` document and `junit` for JUnit XML. `text`, the
+default, keeps the human-readable output.
 
 Similar as using `--output` option on the [command line](/command-line#output-format).
 
@@ -620,7 +622,8 @@ Similar as using `--report-md` option on the [command line](/command-line#report
 > `BASHUNIT_GHA_ANNOTATIONS=auto|always|never`
 
 Controls GitHub Actions annotations on stdout. `auto` by default: on inside GitHub Actions,
-quiet everywhere else. Never emitted under `--output tap`.
+quiet everywhere else. Never emitted under a machine `--output` format
+(`tap`, `json`, `junit`).
 
 Similar as using `--gha-annotations` option on the [command line](/command-line#gha-annotations).
 

--- a/src/config/env.sh
+++ b/src/config/env.sh
@@ -647,6 +647,30 @@ function bashunit::env::is_tap_output_enabled() {
   [ "$BASHUNIT_OUTPUT_FORMAT" = "tap" ]
 }
 
+function bashunit::env::is_json_output_enabled() {
+  [ "$BASHUNIT_OUTPUT_FORMAT" = "json" ]
+}
+
+function bashunit::env::is_junit_output_enabled() {
+  [ "$BASHUNIT_OUTPUT_FORMAT" = "junit" ]
+}
+
+##
+# Whether stdout belongs to a machine format. Every human rendering — header,
+# progress, summary, coverage table, profile — is suppressed for these so the
+# stream stays parseable; diagnostics still go to stderr.
+#
+# The formats are listed rather than tested as "not text", so a value that
+# somehow bypassed validation renders the console instead of silently emitting
+# nothing at all.
+##
+function bashunit::env::is_machine_output_enabled() {
+  case "$BASHUNIT_OUTPUT_FORMAT" in
+  tap | json | junit) return 0 ;;
+  esac
+  return 1
+}
+
 function bashunit::env::is_snapshot_report_unused_enabled() {
   [ "$BASHUNIT_SNAPSHOT_REPORT_UNUSED" = "true" ]
 }
@@ -671,8 +695,8 @@ function bashunit::env::is_fail_on_risky_enabled() {
 # Whether workflow-command annotations go to stdout. GitHub parses them from the
 # job log, so stdout is the only sink that reaches a pull request.
 #
-# `auto` stays quiet outside GitHub Actions, and quiet under --output tap, whose
-# stdout is a machine format an annotation line would corrupt.
+# `auto` stays quiet outside GitHub Actions, and quiet under a machine --output
+# format, whose stdout an annotation line would corrupt.
 ##
 function bashunit::env::should_print_gha_annotations() {
   case "${BASHUNIT_GHA_ANNOTATIONS:-auto}" in
@@ -682,7 +706,7 @@ function bashunit::env::should_print_gha_annotations() {
 
   [ "${_BASHUNIT_IS_OUTERMOST_RUN:-true}" = true ] &&
     [ "${GITHUB_ACTIONS:-}" = "true" ] &&
-    ! bashunit::env::is_tap_output_enabled
+    ! bashunit::env::is_machine_output_enabled
 }
 
 ##

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -136,7 +136,7 @@ Options:
   --report-md <file>          Write a Markdown summary (auto-appended to \$GITHUB_STEP_SUMMARY)
   -s, --simple                Simple output (dots)
   --detailed                  Detailed output (default)
-  --output <format>           Output format: tap (TAP version 13)
+  --output <format>           Report on stdout: text (default), tap, json or junit
   -R, --run-all               Run all assertions (don't stop on first failure)
   -S, --stop-on-failure       Stop on first failure
   --test-timeout <seconds>    Fail a test if it runs longer than N seconds (0 = off)

--- a/src/console/line.sh
+++ b/src/console/line.sh
@@ -30,6 +30,12 @@ function bashunit::console_results::print_line() {
     return
   fi
 
+  # json/junit render one document at the end of the run, so a progress char
+  # here would sit in front of it and break the parser.
+  if bashunit::env::is_machine_output_enabled; then
+    return
+  fi
+
   if ! bashunit::env::is_simple_output_enabled; then
     printf "%s\n" "$line"
     return

--- a/src/console/summary.sh
+++ b/src/console/summary.sh
@@ -19,6 +19,25 @@ function bashunit::console_results::render_result() {
     return 0
   fi
 
+  # json/junit: the totals live in the document the run prints at the end, so
+  # this only resolves the exit code -- walking the same ladder as the console
+  # renderer below, since the exit code may not depend on the output format.
+  if bashunit::env::is_machine_output_enabled; then
+    if [ "$_BASHUNIT_TESTS_FAILED" -gt 0 ]; then
+      return 1
+    fi
+    if [ "$_BASHUNIT_TESTS_FLAKY" -gt 0 ] && bashunit::env::is_fail_on_flaky_enabled; then
+      return 1
+    fi
+    local machine_total=$((_BASHUNIT_TESTS_PASSED + _BASHUNIT_TESTS_SKIPPED +
+      _BASHUNIT_TESTS_INCOMPLETE + _BASHUNIT_TESTS_SNAPSHOT +
+      _BASHUNIT_TESTS_FAILED + _BASHUNIT_TESTS_RISKY))
+    if [ "$machine_total" -eq 0 ]; then
+      return 1
+    fi
+    return 0
+  fi
+
   if bashunit::env::is_simple_output_enabled; then
     printf "\n\n"
   fi
@@ -189,7 +208,7 @@ function bashunit::console_results::print_hook_completed() {
     return
   fi
 
-  if bashunit::env::is_tap_output_enabled; then
+  if bashunit::env::is_machine_output_enabled; then
     return
   fi
 

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -177,8 +177,16 @@ function bashunit::coverage::check_threshold() {
   fi
 
   if [ "$pct" -lt "$BASHUNIT_COVERAGE_MIN" ]; then
-    printf "%sCoverage %d%% is below minimum %d%%%s\n" \
-      "$_BASHUNIT_COLOR_FAILED" "$pct" "$BASHUNIT_COVERAGE_MIN" "$_BASHUNIT_COLOR_DEFAULT"
+    local message
+    message=$(printf "%sCoverage %d%% is below minimum %d%%%s" \
+      "$_BASHUNIT_COLOR_FAILED" "$pct" "$BASHUNIT_COVERAGE_MIN" "$_BASHUNIT_COLOR_DEFAULT")
+    # Under a machine --output the gate still speaks, but on stderr: on stdout
+    # it would sit next to the JSON or XML document and break the parser.
+    if bashunit::env::is_machine_output_enabled; then
+      printf "%s\n" "$message" >&2
+    else
+      printf "%s\n" "$message"
+    fi
     return 1
   fi
 

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -90,6 +90,9 @@ function bashunit::main::exec_tests() {
     :
   elif bashunit::env::is_tap_output_enabled; then
     printf "TAP version 13\n"
+  elif bashunit::env::is_machine_output_enabled; then
+    # json/junit print one document at the end; a banner would precede it.
+    :
   else
     bashunit::console_header::print_version_with_env "$filter" "${test_files[@]}"
   fi
@@ -101,7 +104,7 @@ function bashunit::main::exec_tests() {
       BASHUNIT_SEED=$RANDOM
       export -n BASHUNIT_SEED
     fi
-    if ! bashunit::env::is_tap_output_enabled && ! bashunit::env::is_list_enabled; then
+    if ! bashunit::env::is_machine_output_enabled && ! bashunit::env::is_list_enabled; then
       bashunit::console_header::print_random_order_seed "$BASHUNIT_SEED"
     fi
   fi
@@ -139,7 +142,7 @@ function bashunit::main::exec_tests() {
     printf "\r%sStop on failure enabled...%s\n" "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
   fi
 
-  if ! bashunit::env::is_tap_output_enabled; then
+  if ! bashunit::env::is_machine_output_enabled; then
     bashunit::console_results::print_failing_tests_and_reset
     bashunit::console_results::print_risky_tests_and_reset
     bashunit::console_results::print_incomplete_tests_and_reset
@@ -173,7 +176,9 @@ function bashunit::main::exec_tests() {
     bashunit::reports::append_step_summary
   fi
 
-  if bashunit::env::is_profile_enabled; then
+  # The slowest-tests table is console rendering: it would sit in the middle of
+  # a machine format's stdout.
+  if bashunit::env::is_profile_enabled && ! bashunit::env::is_machine_output_enabled; then
     bashunit::console_results::print_profile_and_reset
   fi
 
@@ -210,11 +215,27 @@ function bashunit::main::exec_tests() {
     bashunit::reports::generate_report_json "$BASHUNIT_REPORT_JSON"
   fi
 
+  # The same writers, aimed at stdout instead of a file, so a pipeline needs no
+  # temp file. Independent of the --report-* flags: both can be asked for in
+  # one run. Only one format can be active, hence the elif.
+  if bashunit::env::is_json_output_enabled; then
+    bashunit::reports::print_report_json
+  elif bashunit::env::is_junit_output_enabled; then
+    bashunit::reports::print_junit_xml
+  fi
+
   # Render the coverage reports; the data behind them was computed above.
   if bashunit::env::is_coverage_enabled; then
     if bashunit::coverage::is_diff_enabled; then
-      bashunit::coverage::report_diff
-    else
+      if bashunit::env::is_machine_output_enabled; then
+        # The pass still runs because it resolves the percentage
+        # --coverage-min gates on; only its table is dropped, since stdout
+        # belongs to the machine format.
+        bashunit::coverage::report_diff >/dev/null
+      else
+        bashunit::coverage::report_diff
+      fi
+    elif ! bashunit::env::is_machine_output_enabled; then
       bashunit::coverage::report_text
     fi
 

--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -183,12 +183,12 @@ function bashunit::main::validate_config_or_exit() {
       "$BASHUNIT_COVERAGE_REPORT_COBERTURA" "BASHUNIT_COVERAGE_REPORT_COBERTURA"
   fi
 
-  # Only TAP is implemented; an unrecognised name used to fall back to the
-  # default renderer without a word, so `--output tpa` looked like it worked.
+  # An unrecognised name used to fall back to the default renderer without a
+  # word, so `--output tpa` looked like it worked.
   case "${BASHUNIT_OUTPUT_FORMAT:-}" in
-  '' | tap) ;;
+  '' | text | tap | json | junit) ;;
   *)
-    printf "%sError: unsupported output format '%s' for --output. Supported: tap.%s\n" \
+    printf "%sError: unsupported output format '%s' for --output. Supported: text, tap, json, junit.%s\n" \
       "${_BASHUNIT_COLOR_FAILED}" "${BASHUNIT_OUTPUT_FORMAT}" "${_BASHUNIT_COLOR_DEFAULT}" >&2
     exit 1
     ;;

--- a/src/reports/collect.sh
+++ b/src/reports/collect.sh
@@ -73,6 +73,8 @@ function bashunit::reports::is_enabled() {
     [ -n "${BASHUNIT_REPORT_TAP:-}" ] ||
     [ -n "${BASHUNIT_REPORT_JSON:-}" ] ||
     [ -n "${BASHUNIT_REPORT_MD:-}" ] ||
+    bashunit::env::is_json_output_enabled ||
+    bashunit::env::is_junit_output_enabled ||
     bashunit::env::should_append_step_summary ||
     bashunit::env::should_print_gha_annotations
 }

--- a/src/reports/json.sh
+++ b/src/reports/json.sh
@@ -16,8 +16,18 @@ function bashunit::reports::__json_escape() {
   printf '%s' "$text"
 }
 
+##
+# Writes the JSON report to the given file.
+# Arguments: $1 - output file
+##
 function bashunit::reports::generate_report_json() {
-  local output_file="$1"
+  bashunit::reports::print_report_json >"$1"
+}
+
+##
+# Renders the JSON report on stdout, for `--output json`.
+##
+function bashunit::reports::print_report_json() {
   local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
 
   local passed=0 failed=0 skipped=0 incomplete=0 flaky=0 duration_total=0
@@ -65,5 +75,5 @@ function bashunit::reports::generate_report_json() {
     done
     printf '  ]\n'
     printf '}\n'
-  } >"$output_file"
+  }
 }

--- a/src/reports/junit.sh
+++ b/src/reports/junit.sh
@@ -36,9 +36,18 @@ function bashunit::reports::__junit_classname() {
   _BASHUNIT_REPORTS_CLASSNAME_OUT="${path//\//.}"
 }
 
+##
+# Writes the JUnit XML report to the given file.
+# Arguments: $1 - output file
+##
 function bashunit::reports::generate_junit_xml() {
-  local output_file="$1"
+  bashunit::reports::print_junit_xml >"$1"
+}
 
+##
+# Renders the JUnit XML report on stdout, for `--output junit`.
+##
+function bashunit::reports::print_junit_xml() {
   local timestamp
   timestamp=$(date '+%Y-%m-%dT%H:%M:%S')
 
@@ -181,5 +190,5 @@ retries\">$escaped_flaky</flakyFailure>
     done
 
     echo "</testsuites>"
-  } >"$output_file"
+  }
 }

--- a/src/runner/diagnostics.sh
+++ b/src/runner/diagnostics.sh
@@ -235,6 +235,8 @@ function bashunit::runner::render_running_file_header() {
 
   if bashunit::env::is_tap_output_enabled; then
     printf "# %s\n" "$script"
+  elif bashunit::env::is_machine_output_enabled; then
+    return
   elif ! bashunit::env::is_simple_output_enabled; then
     if bashunit::env::is_verbose_enabled; then
       printf "\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"

--- a/src/runner/discovery.sh
+++ b/src/runner/discovery.sh
@@ -206,7 +206,12 @@ function bashunit::runner::load_test_files() {
     # Kill the spinner once the aggregation finishes
     disown "$spinner_pid" 2>/dev/null || true
     kill "$spinner_pid" 2>/dev/null || true
-    printf "\r  \r" # Clear the spinner output
+    # Clear the spinner output, but only where it was drawn: under a machine
+    # --output format these bytes landed in front of the report (an XML
+    # declaration must start the document).
+    if ! bashunit::env::is_machine_output_enabled; then
+      printf "\r  \r"
+    fi
 
     local _stderr_idx=0
     while [ "$_stderr_idx" -lt "$worker_stderr_count" ]; do

--- a/src/runner/parallel.sh
+++ b/src/runner/parallel.sh
@@ -72,8 +72,9 @@ function bashunit::runner::spinner() {
     return
   fi
 
-  # Don't show spinner in no-progress mode
-  if bashunit::env::is_no_progress_enabled; then
+  # Don't show spinner in no-progress mode, nor when stdout carries a machine
+  # format the frames would corrupt.
+  if bashunit::env::is_no_progress_enabled || bashunit::env::is_machine_output_enabled; then
     while true; do sleep 1; done
     return
   fi

--- a/tests/acceptance/bashunit_output_stdout_test.sh
+++ b/tests/acceptance/bashunit_output_stdout_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# --output sends a machine-readable report to stdout instead of the human
+# console rendering, so a pipeline can consume the result without a temp file.
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+  FIXTURE="tests/acceptance/fixtures/test_bashunit_report_json.sh"
+  PASSING="tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh"
+  JQ_AVAILABLE=false
+  # `|| true` so a jq-less box means "skip", not "hook failed" (#836)
+  { command -v jq >/dev/null 2>&1 && JQ_AVAILABLE=true; } || true
+}
+
+function test_output_json_emits_a_valid_json_document_on_stdout() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local stdout
+  stdout=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output json "$FIXTURE" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+  assert_same "2" "$(printf '%s' "$stdout" | jq '.summary.total')"
+  assert_same "1" "$(printf '%s' "$stdout" | jq '.summary.failed')"
+}
+
+function test_output_json_stdout_carries_no_console_decoration() {
+  local stdout
+  stdout=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output json "$FIXTURE" 2>/dev/null || true)
+
+  assert_not_contains "Running" "$stdout"
+  assert_not_contains "Tests:" "$stdout"
+  assert_not_contains "Time:" "$stdout"
+}
+
+function test_output_junit_emits_xml_on_stdout() {
+  local stdout
+  stdout=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output junit "$FIXTURE" 2>/dev/null || true)
+
+  assert_contains "<?xml" "$stdout"
+  assert_contains "<testsuites" "$stdout"
+  assert_contains 'tests="2"' "$stdout"
+}
+
+function test_output_json_and_report_json_produce_both() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local report stdout
+  report="$(bashunit::temp_file)"
+  stdout=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" \
+    --output json --report-json "$report" "$FIXTURE" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+  assert_successful_code "$(jq empty "$report" 2>&1)"
+}
+
+function test_output_text_renders_the_same_as_no_flag() {
+  local with_flag without_flag
+  with_flag=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output text "$PASSING" 2>&1 | tr -d '0-9')
+  without_flag=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$PASSING" 2>&1 | tr -d '0-9')
+
+  assert_same "$without_flag" "$with_flag"
+}
+
+# The parallel spinner draws on stdout and is erased with a "\r  \r" once the
+# aggregation ends, which would land in front of the XML declaration.
+function test_output_junit_starts_with_the_xml_declaration_under_parallel() {
+  # No `| head -1`: under --strict the pipe closes early and SIGPIPEs the run.
+  local output
+  output=$(./bashunit --parallel --env "$TEST_ENV_FILE" --output junit "$FIXTURE" 2>/dev/null || true)
+
+  assert_same '<?xml version="1.0" encoding="UTF-8"?>' "${output%%$'\n'*}"
+}
+
+# Regression guard for #1004: the rows are collected inside the per-test worker,
+# so a parallel run used to report zero tests.
+function test_output_json_reports_every_test_under_parallel() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local stdout
+  stdout=$(./bashunit --parallel --env "$TEST_ENV_FILE" --output json "$FIXTURE" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+  assert_same "2" "$(printf '%s' "$stdout" | jq '.summary.total')"
+}
+
+function test_output_json_keeps_the_failing_exit_code() {
+  local ec=0
+  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --output json "$FIXTURE" >/dev/null 2>&1 || ec=$?
+
+  assert_general_error "" "" "$ec"
+}
+
+function test_output_json_keeps_the_passing_exit_code() {
+  local ec=0
+  ./bashunit --no-parallel --env "$TEST_ENV_FILE" --output json "$PASSING" >/dev/null 2>&1 || ec=$?
+
+  assert_successful_code "" "" "$ec"
+}
+
+function test_unknown_output_format_lists_the_supported_ones() {
+  local ec=0
+  local output
+  output=$(./bashunit --env "$TEST_ENV_FILE" --output jsonn "$PASSING" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "text, tap, json, junit" "$output"
+}

--- a/tests/unit/config/env_test.sh
+++ b/tests/unit/config/env_test.sh
@@ -232,6 +232,56 @@ function test_is_tap_output_disabled_when_format_is_not_tap() {
   assert_successful_code 0
 }
 
+function test_is_json_output_enabled_only_for_the_json_format() {
+  local original="$BASHUNIT_OUTPUT_FORMAT"
+  export BASHUNIT_OUTPUT_FORMAT="json"
+
+  bashunit::env::is_json_output_enabled
+  local enabled=$?
+  export BASHUNIT_OUTPUT_FORMAT="junit"
+  local disabled=0
+  bashunit::env::is_json_output_enabled || disabled=$?
+
+  export BASHUNIT_OUTPUT_FORMAT="$original"
+  assert_equals "0" "$enabled"
+  assert_equals "1" "$disabled"
+}
+
+function test_is_junit_output_enabled_only_for_the_junit_format() {
+  local original="$BASHUNIT_OUTPUT_FORMAT"
+  export BASHUNIT_OUTPUT_FORMAT="junit"
+
+  bashunit::env::is_junit_output_enabled
+  local enabled=$?
+  export BASHUNIT_OUTPUT_FORMAT="json"
+  local disabled=0
+  bashunit::env::is_junit_output_enabled || disabled=$?
+
+  export BASHUNIT_OUTPUT_FORMAT="$original"
+  assert_equals "0" "$enabled"
+  assert_equals "1" "$disabled"
+}
+
+# @data_provider machine_output_formats_provider
+function test_is_machine_output_enabled_per_format() {
+  local original="$BASHUNIT_OUTPUT_FORMAT"
+  export BASHUNIT_OUTPUT_FORMAT="$1"
+
+  local actual=0
+  bashunit::env::is_machine_output_enabled || actual=$?
+
+  export BASHUNIT_OUTPUT_FORMAT="$original"
+  assert_equals "$2" "$actual"
+}
+
+function machine_output_formats_provider() {
+  echo "tap 0"
+  echo "json 0"
+  echo "junit 0"
+  echo "text 1"
+  echo "'' 1"
+}
+
 function test_active_internet_connection_returns_failure_when_no_network() {
   local original="${BASHUNIT_NO_NETWORK:-}"
   export BASHUNIT_NO_NETWORK="true"


### PR DESCRIPTION
## 🤔 Background

Related #1018

`--output` accepted only `tap`, so every other machine-readable format was file-only and a pipeline that wanted to post-process a run had to route it through a temp file. The formats and their writers already existed; only the destination was hard-coded.

## 💡 Changes

- `--output <text|tap|json|junit>`: JSON and JUnit now render on stdout, and `--output json --report-json f.json` still produces both sinks.
- Everything that is console rendering is suppressed for the machine formats — header, progress, summary, coverage and slowest-tests tables, GHA annotations, and the parallel spinner whose erase sequence used to precede the XML declaration.
- Diagnostics stay on stderr (including the `--coverage-min` verdict, whose diff pass still runs), and exit codes follow the same ladder as the console renderer.
- An unknown value now lists all four supported formats instead of only `tap`.