### PR TITLE
feat(api): conditional skip helpers (skip_if, skip_unless_command, skip_on)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `bashunit::skip_if`, `bashunit::skip_unless`, `bashunit::skip_unless_command` and `bashunit::skip_on <windows|macos|linux>` mark the test skipped **and** end it, replacing the `bashunit::skip && return` idiom whose missing `return` silently kept the body running; an unknown OS name is a usage error, not a test that never skips (#1019)
 - `--output <text|tap|json|junit>` sends the JSON and JUnit reports to stdout, so a pipeline needs no temp file; the console rendering, coverage table, slowest-tests table and GitHub Actions annotations are suppressed for the machine formats, diagnostics stay on stderr, exit codes are unchanged, and `--output json --report-json f.json` produces both (#1018)
 
 ## [0.46.0](https://github.com/TypedDevs/bashunit/compare/0.45.0...0.46.0) - 2026-08-11

--- a/docs/globals.md
+++ b/docs/globals.md
@@ -85,6 +85,16 @@ bashunit::print_line          # 70 dashes
 bashunit::print_line 40 '='   # 40 equals signs
 ```
 
+## Conditional skips
+
+These mark the test skipped **and end it**, so no `&& return` is needed. See
+[Skipping and incomplete tests](/skipping-incomplete#conditional-skips).
+
+- `bashunit::skip_if <condition> [reason]` — skip when the condition succeeds.
+- `bashunit::skip_unless <condition> [reason]` — skip when it fails.
+- `bashunit::skip_unless_command <cmd> [cmd...]` — skip when a command is missing.
+- `bashunit::skip_on <windows|macos|linux> [reason]` — skip on that platform.
+
 ## Custom assertion helpers
 
 These helpers are intended for building [custom assertions](/custom-asserts).

--- a/docs/skipping-incomplete.md
+++ b/docs/skipping-incomplete.md
@@ -46,6 +46,58 @@ Some tests skipped
 ```
 :::
 
+## Conditional skips
+
+`bashunit::skip` marks the test skipped but does **not** stop it, which is why
+every example above ends in `&& return`. The four helpers below do both: they
+mark the test skipped and end it right there.
+
+> `bashunit::skip_if <condition> "[reason]"`
+> `bashunit::skip_unless <condition> "[reason]"`
+> `bashunit::skip_unless_command <command> [<command>…]`
+> `bashunit::skip_on <windows|macos|linux> "[reason]"`
+
+The condition of `skip_if`/`skip_unless` is evaluated as a shell command, so it
+may carry arguments. `skip_unless_command` takes any number of commands and
+reports `requires <command>` for the first one missing. `skip_on` accepts
+`windows`, `macos` or `linux`; any other name is a usage error rather than a
+test that silently never skips.
+
+::: code-group
+```bash [Example]
+function test_file_permissions() {
+  bashunit::skip_on windows "Git Bash fakes POSIX permissions"
+
+  assert_file_permissions 644 "$file"
+}
+
+function test_decimal_math() {
+  bashunit::skip_unless_command bc
+
+  assert_equals "4.0" "$(calculate "1.5 + 2.5")"
+}
+
+function test_only_locally() {
+  bashunit::skip_if "[ -n \"${CI:-}\" ]" "too slow for CI"
+
+  assert_successful_code "$(long_running_job)"
+}
+```
+```[Output]
+↷ Skipped: File permissions
+    Git Bash fakes POSIX permissions
+↷ Skipped: Decimal math
+    requires bc
+
+Tests:      2 skipped, 1 passed, 3 total
+```
+:::
+
+::: tip
+Called from inside a test's own `$(...)` subshell, these helpers end that
+subshell only — the same as any `exit`. Call them from the test body.
+:::
+
 ## bashunit::todo
 > `bashunit::todo "[pending]"`
 

--- a/src/api/skip_todo.sh
+++ b/src/api/skip_todo.sh
@@ -1,13 +1,130 @@
 #!/usr/bin/env bash
 
-function bashunit::skip() {
+##
+# Marks the running test skipped. The label is read `depth` frames up the
+# stack, so every public helper states its own distance to the test function.
+# Arguments: $1 - reason (optional), $2 - stack depth of the test function
+##
+function bashunit::skip::__mark() {
   local reason=${1-}
+  local depth=${2:-2}
   local label
-  label="$(bashunit::helper::normalize_test_function_name "${FUNCNAME[1]}")"
+  # :- so a helper called from outside a test (a sourced file's top level) does
+  # not abort the run with an unbound FUNCNAME entry under strict mode.
+  label="$(bashunit::helper::normalize_test_function_name "${FUNCNAME[$depth]:-}")"
 
   bashunit::console_results::print_skipped_test "${label}" "${reason}"
 
   bashunit::state::add_assertions_skipped
+}
+
+##
+# Marks the test skipped and ends it.
+#
+# A Bash 3.0 function cannot return on its caller's behalf, but the test body
+# runs inside the capture subshell (bashunit::runner::execute_test_body), whose
+# EXIT trap encodes the assertion counters and the captured output. Exiting
+# here therefore ends the test with its counters and reports intact, which is
+# what `bashunit::skip && return` did by hand at every call site.
+#
+# Called from inside a test's own `$(...)`, it ends that subshell only, as any
+# exit would.
+# Arguments: $1 - reason (optional)
+##
+function bashunit::skip::__mark_and_stop() {
+  bashunit::skip::__mark "${1-}" 3
+  exit 0
+}
+
+function bashunit::skip() {
+  bashunit::skip::__mark "${1-}" 2
+}
+
+##
+# Skips the test when the condition succeeds. The condition is evaluated as a
+# shell command, so it can carry arguments:
+#
+#   bashunit::skip_if "[ -n \"${CI:-}\" ]" "flaky on CI"
+#
+# Arguments: $1 - condition, $2 - reason (optional)
+##
+function bashunit::skip_if() {
+  local condition=${1-}
+  local reason=${2-}
+
+  if eval "$condition"; then
+    bashunit::skip::__mark_and_stop "$reason"
+  fi
+}
+
+##
+# Skips the test unless the condition succeeds; the mirror of skip_if.
+# Arguments: $1 - condition, $2 - reason (optional)
+##
+function bashunit::skip_unless() {
+  local condition=${1-}
+  local reason=${2-}
+
+  if eval "$condition"; then
+    return 0
+  fi
+
+  bashunit::skip::__mark_and_stop "$reason"
+}
+
+##
+# Skips the test unless every given command resolves, naming the first one
+# missing as the reason.
+# Arguments: $@ - commands
+##
+function bashunit::skip_unless_command() {
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      bashunit::skip::__mark_and_stop "requires $cmd"
+    fi
+  done
+}
+
+##
+# Skips the test on the given operating system: windows, macos or linux.
+# An unrecognised name is a usage error, reported through the Error channel,
+# rather than a test that silently never skips.
+# Arguments: $1 - os, $2 - reason (optional)
+##
+function bashunit::skip_on() {
+  local os=${1-}
+  local reason=${2-}
+  local matches=false
+
+  case "$os" in
+  windows)
+    if bashunit::check_os::is_windows; then
+      matches=true
+    fi
+    ;;
+  macos)
+    if bashunit::check_os::is_macos; then
+      matches=true
+    fi
+    ;;
+  linux)
+    if bashunit::check_os::is_linux; then
+      matches=true
+    fi
+    ;;
+  *)
+    # Same machine-detectable channel as an assertion misuse, so the runner
+    # reports it as an Error instead of letting a typo pass for a green test.
+    bashunit::assert::usage_error_detail "bashunit::skip_on" \
+      "accepts windows, macos or linux, got '$os'"
+    return 1
+    ;;
+  esac
+
+  if [ "$matches" = true ]; then
+    bashunit::skip::__mark_and_stop "$reason"
+  fi
 }
 
 function bashunit::todo() {

--- a/tests/acceptance/bashunit_conditional_skip_test.sh
+++ b/tests/acceptance/bashunit_conditional_skip_test.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# bashunit::skip marks a test skipped but does not stop it, so every call site
+# had to remember `&& return`. The conditional helpers below do both.
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+  FIXTURE="tests/acceptance/fixtures/test_bashunit_conditional_skip.sh"
+  OS_FIXTURE="tests/acceptance/fixtures/test_bashunit_skip_on.sh"
+}
+
+function run_fixture() { # $1 = extra flags, $2 = fixture
+  # shellcheck disable=SC2086
+  NO_COLOR=1 ./bashunit $1 --env "$TEST_ENV_FILE" "${2:-$FIXTURE}" 2>&1 || true
+}
+
+function test_skip_if_marks_the_test_skipped_and_stops_the_body() {
+  local output
+  output=$(run_fixture "--no-parallel")
+
+  assert_contains "Skipped: Skip if true stops the body" "$output"
+  assert_contains "condition met" "$output"
+  assert_not_contains "unreachable" "$output"
+}
+
+function test_skip_if_lets_the_body_run_when_the_condition_is_false() {
+  local output
+  output=$(run_fixture "--no-parallel")
+
+  assert_not_contains "never used" "$output"
+  assert_contains "Passed: Skip if false runs the body" "$output"
+}
+
+function test_skip_unless_command_names_the_missing_command() {
+  local output
+  output=$(run_fixture "--no-parallel")
+
+  assert_contains "requires definitely_not_a_command" "$output"
+  assert_contains "Passed: Skip unless command present" "$output"
+}
+
+function test_every_skipped_test_is_counted_once() {
+  local output
+  output=$(run_fixture "--no-parallel")
+
+  # 6 skipped: skip_if true, skip_if compound, skip_unless false,
+  # skip_unless_command missing and the two data-provider cases.
+  assert_contains "6 skipped" "$output"
+  assert_contains "3 passed" "$output"
+}
+
+function test_the_counts_are_the_same_under_parallel() {
+  local sequential parallel
+  sequential=$(run_fixture "--no-parallel" | "$GREP" -c "Skipped:")
+  parallel=$(run_fixture "--parallel" | "$GREP" -c "Skipped:")
+
+  assert_same "$sequential" "$parallel"
+}
+
+function test_skip_on_skips_only_the_running_os() {
+  local output
+  output=$(run_fixture "--no-parallel" "$OS_FIXTURE")
+
+  assert_contains "Skipped: Skip on the current os" "$output"
+  assert_contains "not for this os" "$output"
+  assert_contains "Passed: Skip on another os runs the body" "$output"
+}
+
+function test_skip_on_an_unknown_os_is_a_usage_error() {
+  local output
+  output=$(run_fixture "--no-parallel" "$OS_FIXTURE")
+
+  assert_contains "Error: Skip on an unknown os" "$output"
+  assert_contains "windows, macos or linux" "$output"
+}
+
+function test_reports_carry_the_skipped_tests() {
+  local report
+  report="$(bashunit::temp_file)"
+  NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" \
+    --report-junit "$report" "$FIXTURE" >/dev/null 2>&1 || true
+
+  assert_contains 'skipped="6"' "$(cat "$report")"
+  assert_contains "condition met" "$(cat "$report")"
+}

--- a/tests/acceptance/fixtures/test_bashunit_conditional_skip.sh
+++ b/tests/acceptance/fixtures/test_bashunit_conditional_skip.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Fixture for the conditional skip helpers. Every assertion placed after a
+# helper that must skip is deliberately impossible: it fails the fixture run if
+# the helper stopped marking the test but let the body continue.
+
+function test_skip_if_true_stops_the_body() {
+  bashunit::skip_if true "condition met"
+  assert_same "unreachable" "reached"
+}
+
+function test_skip_if_false_runs_the_body() {
+  bashunit::skip_if false "never used"
+  assert_same "ok" "ok"
+}
+
+function test_skip_if_evaluates_a_compound_condition() {
+  bashunit::skip_if "[ 1 -eq 1 ]" "compound condition met"
+  assert_same "unreachable" "reached"
+}
+
+function test_skip_unless_runs_the_body_when_the_condition_holds() {
+  bashunit::skip_unless true "never used"
+  assert_same "ok" "ok"
+}
+
+function test_skip_unless_stops_the_body_when_the_condition_fails() {
+  bashunit::skip_unless false "condition not met"
+  assert_same "unreachable" "reached"
+}
+
+function test_skip_unless_command_missing() {
+  bashunit::skip_unless_command definitely_not_a_command
+  assert_same "unreachable" "reached"
+}
+
+function test_skip_unless_command_present() {
+  bashunit::skip_unless_command bash
+  assert_same "ok" "ok"
+}
+
+# @data_provider provide_two_values
+function test_skip_if_inside_a_data_provider() {
+  bashunit::skip_if true "provider skip"
+  assert_same "unreachable" "$1"
+}
+
+function provide_two_values() {
+  echo "a"
+  echo "b"
+}

--- a/tests/acceptance/fixtures/test_bashunit_skip_on.sh
+++ b/tests/acceptance/fixtures/test_bashunit_skip_on.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Fixture for bashunit::skip_on. The OS names are resolved at run time so the
+# same file proves both branches on every platform CI runs.
+
+function current_os() {
+  if bashunit::check_os::is_windows; then
+    echo "windows"
+  elif bashunit::check_os::is_macos; then
+    echo "macos"
+  else
+    echo "linux"
+  fi
+}
+
+function another_os() {
+  if bashunit::check_os::is_windows; then
+    echo "linux"
+  else
+    echo "windows"
+  fi
+}
+
+function test_skip_on_the_current_os() {
+  bashunit::skip_on "$(current_os)" "not for this os"
+  assert_same "unreachable" "reached"
+}
+
+function test_skip_on_another_os_runs_the_body() {
+  bashunit::skip_on "$(another_os)" "never used"
+  assert_same "ok" "ok"
+}
+
+function test_skip_on_an_unknown_os() {
+  bashunit::skip_on "plan9" "typo in the os name"
+  assert_same "ok" "ok"
+}

--- a/tests/unit/api/skip_todo_test.sh
+++ b/tests/unit/api/skip_todo_test.sh
@@ -11,6 +11,54 @@ function test_skip_output_with_reason() {
     "$(bashunit::skip "Skipped because is skippable")"
 }
 
+# Only the paths that do NOT skip can be asserted from a test: skipping ends
+# the calling test on purpose, so those are covered in
+# tests/acceptance/bashunit_conditional_skip_test.sh.
+function test_skip_if_a_false_condition_leaves_the_test_running() {
+  bashunit::skip_if false "never used"
+
+  assert_same "reached" "reached"
+}
+
+function test_skip_if_evaluates_the_condition_as_a_shell_command() {
+  bashunit::skip_if "[ 1 -eq 2 ]" "never used"
+
+  assert_same "reached" "reached"
+}
+
+function test_skip_unless_a_true_condition_leaves_the_test_running() {
+  bashunit::skip_unless true "never used"
+
+  assert_same "reached" "reached"
+}
+
+function test_skip_unless_command_accepts_several_present_commands() {
+  bashunit::skip_unless_command bash command
+
+  assert_same "reached" "reached"
+}
+
+function test_skip_on_an_unknown_os_reports_a_usage_error() {
+  local output
+  local ec=0
+
+  output=$(bashunit::skip_on "plan9" "reason" 2>&1) || ec=$?
+
+  assert_equals "1" "$ec"
+  assert_contains "bashunit::skip_on accepts windows, macos or linux, got 'plan9'" "$output"
+}
+
+function test_skip_on_another_os_leaves_the_test_running() {
+  local other="windows"
+  if bashunit::check_os::is_windows; then
+    other="linux"
+  fi
+
+  bashunit::skip_on "$other" "never used"
+
+  assert_same "reached" "reached"
+}
+
 function test_todo_output() {
   assert_same "$(bashunit::console_results::print_incomplete_test "Todo output")" \
     "$(bashunit::todo)"

--- a/tests/unit/assert/files_test.sh
+++ b/tests/unit/assert/files_test.sh
@@ -193,10 +193,7 @@ function test_fails_assert_file_not_contains() {
 
 # shellcheck disable=SC2155
 function test_successful_assert_file_permissions() {
-  # Windows (Git Bash) fakes POSIX permissions, so chmod/stat are unreliable there.
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash fakes POSIX permissions"
 
   local file="/tmp/test_successful_assert_file_permissions_$$"
   touch "$file"
@@ -209,9 +206,7 @@ function test_successful_assert_file_permissions() {
 
 # shellcheck disable=SC2155
 function test_successful_assert_file_permissions_accepts_leading_zero() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash fakes POSIX permissions"
 
   local file="/tmp/test_assert_file_permissions_leading_zero_$$"
   touch "$file"
@@ -224,9 +219,7 @@ function test_successful_assert_file_permissions_accepts_leading_zero() {
 
 # shellcheck disable=SC2155
 function test_unsuccessful_assert_file_permissions() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash fakes POSIX permissions"
 
   local file="/tmp/test_unsuccessful_assert_file_permissions_$$"
   touch "$file"
@@ -258,9 +251,7 @@ function symlink_fixture_dir() {
 }
 
 function test_successful_assert_is_symlink() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/target"
@@ -271,9 +262,7 @@ function test_successful_assert_is_symlink() {
 
 # The case nothing covers today: a link whose target is gone is still a link.
 function test_successful_assert_is_symlink_when_the_target_is_missing() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   ln -s "$dir/never_created" "$dir/dangling"
@@ -282,9 +271,7 @@ function test_successful_assert_is_symlink_when_the_target_is_missing() {
 }
 
 function test_unsuccessful_assert_is_symlink_on_a_regular_file() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/plain"
@@ -297,9 +284,7 @@ function test_unsuccessful_assert_is_symlink_on_a_regular_file() {
 }
 
 function test_successful_assert_is_not_symlink() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/plain"
@@ -308,9 +293,7 @@ function test_successful_assert_is_not_symlink() {
 }
 
 function test_unsuccessful_assert_is_not_symlink() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/target"
@@ -324,9 +307,7 @@ function test_unsuccessful_assert_is_not_symlink() {
 }
 
 function test_successful_assert_symlink_to() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/target"
@@ -336,9 +317,7 @@ function test_successful_assert_symlink_to() {
 }
 
 function test_unsuccessful_assert_symlink_to_reports_both_targets() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/target"
@@ -352,9 +331,7 @@ function test_unsuccessful_assert_symlink_to_reports_both_targets() {
 }
 
 function test_unsuccessful_assert_symlink_to_on_a_regular_file() {
-  if bashunit::check_os::is_windows; then
-    bashunit::skip && return
-  fi
+  bashunit::skip_on windows "Git Bash does not create real symlinks"
   local dir
   dir=$(symlink_fixture_dir)
   : >"$dir/plain"

--- a/tests/unit/util/math_test.sh
+++ b/tests/unit/util/math_test.sh
@@ -38,10 +38,7 @@ function test_calculate_zero_result() {
 }
 
 function test_calculate_with_bc_for_decimal() {
-  if ! bashunit::dependencies::has_bc; then
-    bashunit::skip "bc not available"
-    return
-  fi
+  bashunit::skip_unless_command bc
 
   local result
   result=$(bashunit::math::calculate "1.5 + 2.5")
@@ -50,10 +47,7 @@ function test_calculate_with_bc_for_decimal() {
 }
 
 function test_calculate_fallback_to_awk_for_decimal() {
-  if ! bashunit::dependencies::has_awk; then
-    bashunit::skip "awk not available"
-    return
-  fi
+  bashunit::skip_unless_command awk
 
   bashunit::mock bashunit::dependencies::has_bc false
 


### PR DESCRIPTION
## 🤔 Background

Related #1019

`bashunit::skip` marks a test skipped but does not stop it, so every call site has to remember `&& return` — 32 test files in this repo repeat that shape. Forget the `return` and the body keeps running on a platform where it cannot pass; no linter catches it.

## 💡 Changes

- `bashunit::skip_if`, `bashunit::skip_unless`, `bashunit::skip_unless_command` and `bashunit::skip_on <windows|macos|linux>` mark the test skipped **and** end it, with the reason reaching the console and the reports as before.
- Ending the caller uses the capture subshell's existing EXIT trap, so counters and captured output survive — no new early-exit mechanism, and Bash 3.0 safe.
- An unknown OS name goes through the usage-error channel and is reported as an Error, rather than a test that silently never skips.
- The 11 Windows guards in `files_test.sh` and the two dependency guards in `math_test.sh` are migrated as proof of the ergonomics.