### PR TITLE
feat(config): named suites in .bashunitrc and --suite <name>

### DIFF
--- a/.bashunitrc
+++ b/.bashunitrc
@@ -1,0 +1,19 @@
+# bashunit's own project config.
+#
+# No global settings on purpose: the defaults are what a contributor should
+# get. What lives here are the named suites the Makefile and CI run, so the
+# option sets have one home instead of being repeated per target.
+#
+# The suites carry options only, not `paths`: the file list comes from the
+# Makefile's `find`, which excludes tests/**/fixtures/ -- four fixture files
+# end in _test.sh but are inputs to other tests, not tests. An explicit path
+# argument replaces a suite's `paths`, so the two compose.
+
+[suite:parallel]
+parallel = true
+simple = true
+
+[suite:strict]
+parallel = true
+simple = true
+strict = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- Named suites: a `[suite:<name>]` section in `.bashunitrc` groups paths and options, `--suite <name>` runs one (repeatable, union of their paths) and `--list-suites` prints the defined names; precedence is CLI flags > suite settings > global `.bashunitrc` > `.env` > defaults, and an explicit path replaces the suite's `paths` (#1021)
 - Per-test `# @timeout <seconds>`, `# @retry <n>` and `# @skip [reason]` annotations in the comment block above a test, overriding the run-wide `--test-timeout` and `--retry` in both directions (`@timeout 0` opts a test out of a global timeout); a malformed value aborts the run, and the scan rides on the existing per-file pass so it costs no extra fork (#1020)
 - `bashunit::skip_if`, `bashunit::skip_unless`, `bashunit::skip_unless_command` and `bashunit::skip_on <windows|macos|linux>` mark the test skipped **and** end it, replacing the `bashunit::skip && return` idiom whose missing `return` silently kept the body running; an unknown OS name is a usage error, not a test that never skips (#1019)
 - `--output <text|tap|json|junit>` sends the JSON and JUnit reports to stdout, so a pipeline needs no temp file; the console rendering, coverage table, slowest-tests table and GitHub Actions annotations are suppressed for the machine formats, diagnostics stay on stderr, exit codes are unchanged, and `--output json --report-json f.json` produces both (#1018)

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "  docker/alpine            Run into a Docker Linux/Alpine:latest image"
 	@echo "  pre_commit/install       Install the pre-commit hook"
 	@echo "  pre_commit/run           Function that will be called when the pre-commit hook runs"
+	@echo "  test/strict              Run the suite the way CI's strict job does"
 	@echo "  sa                       Run shellcheck static analysis tool"
 	@echo "  lint                     Run editorconfig linter tool"
 	@echo "  docs/install             Install docs npm dependencies (in docs/)"
@@ -100,8 +101,15 @@ pre_commit/install:
 pre_commit/run:
 	@$(MAKE) -j3 test/parallel sa lint
 
+# The option sets live in .bashunitrc as named suites; the file list stays here
+# because it is the one `find` that excludes tests/**/fixtures/.
 test/parallel: $(TEST_SCRIPTS)
-	@bash ./bashunit --parallel --simple $(TEST_SCRIPTS)
+	@bash ./bashunit --suite parallel $(TEST_SCRIPTS)
+
+# What CI's strict job runs: the mode that catches set -euo pipefail breakage
+# a plain sequential run never sees.
+test/strict: $(TEST_SCRIPTS)
+	@bash ./bashunit --suite strict $(TEST_SCRIPTS)
 
 # sa: xargs (unlike `find -exec {} \;`) propagates shellcheck's exit code, so
 # findings actually fail the target; the excludes mirror the CI workflow's

--- a/adrs/adr-011-source-layout-and-build-pipeline.md
+++ b/adrs/adr-011-source-layout-and-build-pipeline.md
@@ -52,7 +52,7 @@ Seventeen, in load order. The order is the dependency layering: leaves first.
 | 2 | `system/` | 4 | 189 | capability probing: OS, `command -v`, small I/O |
 | 3 | `util/` | 4 | 474 | computation: strings, arithmetic, time |
 | 4 | `api/` | 5 | 205 | the surface a user's test file calls (except assertions) |
-| 5 | `config/` | 4 | 961 | `BASHUNIT_*` defaults, scratch dirs, parallel mode, rerun cache |
+| 5 | `config/` | 5 | 1163 | `BASHUNIT_*` defaults, scratch dirs, parallel mode, rerun cache, named suites |
 | 6 | `coverage/` | 15 | 3102 | line/branch tracking, diff coverage and the five report formats |
 | 7 | `state/` | 6 | 474 | counters, per-test context, result payload, parallel aggregation |
 | 8 | `console/` | 9 | 1278 | everything printed: palette, header, per-test lines, totals |

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -67,6 +67,8 @@ _bashunit() {
     '(-f --filter)'{-f,--filter}'[Only run tests matching the name]:name:' \
     '--tag[Only run tests with matching @tag; supports a&&b and !a]:tag:' \
     '--exclude-filter[Skip tests whose name matches]:name:' \
+    '--suite[Run a named suite from .bashunitrc]:suite:' \
+    '--list-suites[Print the suites defined in .bashunitrc and exit]' \
     '--exclude-tag[Skip tests with matching @tag]:tag:' \
     '--log-junit[Write JUnit XML report]:file:_files' \
     '--gha-annotations[GitHub Actions annotations on stdout]:mode:(auto always never)' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -17,14 +17,14 @@ _BASHUNIT_COMPLETIONS_DOC_OPTS="--custom -e --env --boot -h --help"
 _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --changed --coverage --coverage-exclude \
 --coverage-diff --coverage-min --coverage-paths --coverage-report --coverage-report-cobertura --coverage-report-html \
 --debug --detailed --dry-run --env --exclude-filter --exclude-tag --fail-on-flaky --fail-on-risky --failures-only \
---filter --gha-annotations --help --jobs --list --list-format --log-gha --log-junit --login --no-color \
+--filter --gha-annotations --help --jobs --list --list-format --list-suites --log-gha --log-junit --login --no-color \
 --no-coverage-report --no-output --no-output-on-failure --no-parallel \
 --no-progress --no-snapshot-create --order-by --output --parallel --profile \
 --random-order --repeat --report-html \
 --report-json --report-junit --report-md --report-tap --rerun-failed --retry --run-all \
 --seed --shard --show-incomplete --show-output --show-skipped --simple \
 --skip-env-file --snapshot-report-unused --snapshot-update \
---stop-on-failure --strict --tag \
+--stop-on-failure --strict --suite --tag \
 --test-timeout --verbose \
 --watch -R -S -a -e -f -h -j -l -p -r -s -vvv -w"
 
@@ -88,7 +88,7 @@ _bashunit_completions() {
     COMPREPLY=($(compgen -W "auto always never" -- "$cur"))
     return 0
     ;;
-  -f | --filter | --exclude-filter | --tag | --exclude-tag | --repeat | --retry | --seed | --shard | --test-timeout)
+  -f | --filter | --exclude-filter | --suite | --tag | --exclude-tag | --repeat | --retry | --seed | --shard | --test-timeout)
     return 0
     ;;
   esac

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -62,6 +62,8 @@ bashunit test tests/ --parallel --simple
 | `-e, --env, --boot <file>`     | Load custom env/bootstrap file (supports args)   |
 | `-f, --filter <name>`          | Only run tests matching name                     |
 | `--exclude-filter <name>`      | Skip tests whose name matches (repeatable)       |
+| `--suite <name>`               | Run a `[suite:<name>]` from `.bashunitrc` (repeatable) |
+| `--list-suites`                | Print the suites defined in `.bashunitrc` and exit |
 | `--tag <expr>`                 | Only run tests with matching `@tag`; supports `a&&b` and `!a` |
 | `--exclude-tag <name>`         | Skip tests with matching `@tag` (repeatable)     |
 | `--output <format>`            | Report on stdout: `text` (default), `tap`, `json`, `junit` |
@@ -238,6 +240,34 @@ Use [`--list`](#list) to check what an expression actually selects:
 ```bash
 bashunit --list --tag 'db&&!slow' tests/
 ```
+
+### Suites
+
+> `bashunit test --suite <name>`
+> `bashunit test --list-suites`
+
+A project with several tiers of tests can name them in `.bashunitrc` instead of
+keeping the paths and their flags in a Makefile. See
+[named suites](/configuration#named-suites) for the file syntax.
+
+```bash
+bashunit --suite unit                 # that suite's paths, with its options
+bashunit --suite unit --suite e2e     # the union of both
+bashunit --list-suites                # print the defined names, exit 0
+```
+
+Precedence, from strongest: **CLI flags → suite settings → global
+`.bashunitrc` settings → `.env` → built-in defaults.** A suite's options are
+placed before the ones you type, so `--suite unit --no-parallel` runs
+sequentially even when the suite asks for `parallel = true`. In the same way an
+explicit path argument **replaces** the suite's `paths`, keeping its options:
+
+```bash
+bashunit --suite unit tests/unit/assert/basic_test.sh
+```
+
+An unknown name exits non-zero and lists the defined suites; a suite section
+that is not `key = value` exits non-zero quoting the offending line.
 
 ### Output format
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,61 @@ The two files are read differently, which is why they behave differently: `.env`
 empty entry is unconditional (hence the preservation rule above), while `.bashunitrc` is
 parsed as literal `KEY=value` lines and only fills names that are not already set.
 
+## Named suites
+
+A project with more than one tier of tests can name each tier in `.bashunitrc`
+and select it with [`--suite`](/command-line#suites), instead of keeping the
+paths and their flags in a Makefile:
+
+```ini
+# .bashunitrc
+BASHUNIT_SHOW_HEADER=false      # global settings still live at the top level
+
+[suite:unit]
+paths = tests/unit
+parallel = true
+
+[suite:acceptance]
+paths = tests/acceptance
+no-parallel = true
+test-timeout = 60
+
+[suite:ci]
+paths = tests/unit tests/functional
+tag = !slow
+```
+
+```bash
+bashunit --suite unit
+bashunit --suite unit --suite acceptance   # the union of their paths
+bashunit --list-suites
+```
+
+Inside a section:
+
+- `paths` is the list of files or directories the suite runs, separated by spaces.
+- **Every other key is a long option without its leading dashes.** Underscores
+  read as dashes, so `test_timeout` and `test-timeout` are the same key.
+- `= true` means the bare flag, `= false` leaves it out, anything else is the
+  option's value. A value may contain spaces (`report-md = a report.md`) but
+  not newlines.
+
+Precedence is the same chain as everywhere else, with suites sitting between
+the command line and the global config: **CLI flags → suite settings → global
+`.bashunitrc` → `.env` → defaults.** An explicit path argument likewise
+replaces the suite's `paths` and keeps its options.
+
+An unknown suite name exits non-zero listing the defined ones, and a line
+inside a section that is not `key = value` — or an option that is not a real
+flag — exits non-zero quoting it, rather than running something other than what
+was asked for.
+
+::: tip
+A suite does not have to carry `paths`. bashunit's own `.bashunitrc` defines
+option-only suites (`parallel`, `strict`) that its `Makefile` combines with the
+file list it already computes.
+:::
+
 ## Default path
 
 > `BASHUNIT_DEFAULT_PATH=directory|file`

--- a/src/config/index.sh
+++ b/src/config/index.sh
@@ -19,3 +19,4 @@
 source "$BASHUNIT_ROOT_DIR/src/config/parallel.sh"
 source "$BASHUNIT_ROOT_DIR/src/config/env.sh"
 source "$BASHUNIT_ROOT_DIR/src/config/rerun.sh"
+source "$BASHUNIT_ROOT_DIR/src/config/suites.sh"

--- a/src/config/suites.sh
+++ b/src/config/suites.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+# Named suites in .bashunitrc.
+#
+# A `[suite:<name>]` section names a set of paths and the options they run
+# with, so a project with several tiers of tests keeps them in its config
+# instead of in a Makefile:
+#
+#   [suite:unit]
+#   paths = tests/unit
+#   parallel = true
+#   test-timeout = 60
+#
+# Every key but the reserved `paths` is a long option without its leading
+# dashes (underscores are accepted for the dashes). `= true` means the bare
+# flag, `= false` means "leave it out", anything else is the option's value.
+# The suite's options are placed BEFORE the caller's on the command line, so an
+# explicit flag still wins.
+#
+# The per-suite argv is stored as one newline-separated string because Bash 3.0
+# has no array of arrays; a value may therefore contain spaces but not
+# newlines.
+
+_BASHUNIT_SUITE_NAMES=()
+_BASHUNIT_SUITE_PATHS=()
+_BASHUNIT_SUITE_ARGS=()
+_BASHUNIT_SUITES_LOADED_FILE=""
+
+_BASHUNIT_SUITE_PATHS_OUT=""
+_BASHUNIT_SUITE_ARGS_OUT=""
+
+##
+# Aborts with a message quoting the line the config file could not be read as.
+# Arguments: $1 - file, $2 - what is wrong, $3 - the offending line
+##
+function bashunit::suites::_abort() {
+  printf "%sError: %s in %s: '%s'.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED:-}" "$2" "$1" "$3" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+  exit 1
+}
+
+##
+# Parses the `[suite:<name>]` sections of a config file into the maps above.
+# Memoized by path: the pre-scan and the expansion both call it.
+# Arguments: $1 - config file (default .bashunitrc)
+##
+function bashunit::suites::load() {
+  local file=${1:-.bashunitrc}
+
+  if [ "$file" = "$_BASHUNIT_SUITES_LOADED_FILE" ]; then
+    return 0
+  fi
+  _BASHUNIT_SUITES_LOADED_FILE="$file"
+  _BASHUNIT_SUITE_NAMES=()
+  _BASHUNIT_SUITE_PATHS=()
+  _BASHUNIT_SUITE_ARGS=()
+
+  [ -f "$file" ] || return 0
+
+  local line raw key val index=-1
+  # shellcheck disable=SC2094 # _abort takes the path only to name it in the
+  # message it prints on stderr; nothing here writes to the file being read.
+  while IFS= read -r line || [ -n "$line" ]; do
+    raw=$line
+    line=${line#"${line%%[![:space:]]*}"}
+    line=${line%"${line##*[![:space:]]}"}
+
+    case "$line" in
+    '' | '#'* | ';'*) continue ;;
+    esac
+
+    # A section header: `[suite:name]` opens one, any other section closes the
+    # current one so the global KEY=value lines after it are left to
+    # load_config_file.
+    case "$line" in
+    '['*']')
+      case "$line" in
+      '[suite:'*']')
+        local name=${line#\[suite:}
+        name=${name%\]}
+        name=${name#"${name%%[![:space:]]*}"}
+        name=${name%"${name##*[![:space:]]}"}
+        if [ -z "$name" ]; then
+          bashunit::suites::_abort "$file" "a suite section needs a name" "$raw"
+        fi
+        index=$((${#_BASHUNIT_SUITE_NAMES[@]}))
+        _BASHUNIT_SUITE_NAMES[index]="$name"
+        _BASHUNIT_SUITE_PATHS[index]=""
+        _BASHUNIT_SUITE_ARGS[index]=""
+        ;;
+      *) index=-1 ;;
+      esac
+      continue
+      ;;
+    esac
+
+    # Outside a suite section this is a global setting, load_config_file's job.
+    if [ "$index" -lt 0 ]; then
+      continue
+    fi
+
+    case "$line" in
+    *=*) ;;
+    *) bashunit::suites::_abort "$file" "a suite entry must be 'key = value'" "$raw" ;;
+    esac
+
+    key=${line%%=*}
+    val=${line#*=}
+    key=${key%"${key##*[![:space:]]}"}
+    val=${val#"${val%%[![:space:]]*}"}
+    val=${val%"${val##*[![:space:]]}"}
+    case "$val" in
+    \"*\") val=${val#\"} val=${val%\"} ;;
+    \'*\') val=${val#\'} val=${val%\'} ;;
+    esac
+
+    if [ "$key" = "paths" ] || [ "$key" = "path" ]; then
+      _BASHUNIT_SUITE_PATHS[index]="$val"
+      continue
+    fi
+
+    # Underscores read as dashes so `test_timeout` and `test-timeout` are the
+    # same key, matching how the settings are spelled elsewhere.
+    key=$(printf '%s' "$key" | tr '_' '-')
+    case "$key" in
+    '' | *[!a-z0-9-]*)
+      bashunit::suites::_abort "$file" "a suite option must be a long flag name" "$raw"
+      ;;
+    esac
+
+    case "$val" in
+    false) continue ;;
+    true) bashunit::suites::_append "$index" "--$key" ;;
+    *) bashunit::suites::_append "$index" "--$key" "$val" ;;
+    esac
+  done <"$file"
+}
+
+##
+# Appends argv entries to a suite's newline-separated list.
+# Arguments: $1 - suite index, $@ - argv entries
+##
+function bashunit::suites::_append() {
+  local index=$1
+  shift
+  local current=${_BASHUNIT_SUITE_ARGS[index]}
+  local entry
+  for entry in "$@"; do
+    if [ -z "$current" ]; then
+      current="$entry"
+    else
+      current="$current
+$entry"
+    fi
+  done
+  _BASHUNIT_SUITE_ARGS[index]="$current"
+}
+
+##
+# Prints the defined suite names, one per line.
+##
+function bashunit::suites::names() {
+  local i=0
+  local total=${#_BASHUNIT_SUITE_NAMES[@]}
+  while [ "$i" -lt "$total" ]; do
+    printf '%s\n' "${_BASHUNIT_SUITE_NAMES[i]}"
+    i=$((i + 1))
+  done
+}
+
+##
+# Resolves a suite into _BASHUNIT_SUITE_PATHS_OUT and _BASHUNIT_SUITE_ARGS_OUT
+# (newline-separated argv). An unknown name aborts, listing what is defined:
+# running the whole suite instead would look like the name had worked.
+# Arguments: $1 - suite name
+##
+function bashunit::suites::resolve() {
+  local wanted=$1
+  local i=0
+  local total=${#_BASHUNIT_SUITE_NAMES[@]}
+
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_SUITE_NAMES[i]}" = "$wanted" ]; then
+      _BASHUNIT_SUITE_PATHS_OUT="${_BASHUNIT_SUITE_PATHS[i]}"
+      _BASHUNIT_SUITE_ARGS_OUT="${_BASHUNIT_SUITE_ARGS[i]}"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+
+  local defined
+  defined=$(bashunit::suites::names | tr '\n' ' ')
+  defined=${defined%" "}
+  if [ -z "$defined" ]; then
+    defined="none defined in .bashunitrc"
+  fi
+  printf "%sError: unknown suite '%s'. Defined: %s.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED:-}" "$wanted" "$defined" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+  exit 1
+}

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -121,6 +121,8 @@ Options:
   -e, --env, --boot <file>    Load a custom env/bootstrap file  (supports args)
   -f, --filter <name>         Only run tests matching the name
   --exclude-filter <name>     Skip tests whose name matches (repeatable)
+  --suite <name>              Run a [suite:<name>] from .bashunitrc (repeatable)
+  --list-suites               Print the suites defined in .bashunitrc and exit
   --tag <expr>                Only run tests with matching @tag (repeatable, OR logic).
                               Supports 'a&&b' (AND) and '!a' (NOT)
   --exclude-tag <name>        Skip tests with matching @tag (repeatable, exclude wins)

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -2,6 +2,90 @@
 
 # Flag parsing for the default 'test' subcommand.
 
+# The argv the suite pre-scan produces, read by cmd_test below.
+_BASHUNIT_MAIN_SUITE_ARGV=()
+
+##
+# Resolves `--suite <name>` (repeatable) and `--list-suites` before the main
+# parse loop and rewrites argv into _BASHUNIT_MAIN_SUITE_ARGV.
+#
+# The suites' own options are placed FIRST, so a flag the caller typed is
+# parsed later and wins -- the documented precedence is
+# CLI flags > suite settings > global .bashunitrc > .env > defaults. An
+# explicit path argument likewise replaces the suites' paths rather than
+# adding to them.
+#
+# `--list-suites` prints and exits here: it is a query about the config file,
+# and nothing below it in the run has anything to add.
+##
+function bashunit::main::apply_suites() {
+  local -a suite_names=()
+  local -a rest=()
+  local -a cli_paths=()
+  local has_suite=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    --suite)
+      if [ -z "${2:-}" ]; then
+        printf "%sError: --suite requires a name.%s\n" \
+          "${_BASHUNIT_COLOR_FAILED:-}" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+        exit 1
+      fi
+      has_suite=true
+      suite_names[${#suite_names[@]}]="$2"
+      shift
+      ;;
+    --list-suites)
+      bashunit::suites::load ".bashunitrc"
+      bashunit::suites::names
+      exit 0
+      ;;
+    -*)
+      rest[${#rest[@]}]="$1"
+      ;;
+    *)
+      cli_paths[${#cli_paths[@]}]="$1"
+      rest[${#rest[@]}]="$1"
+      ;;
+    esac
+    shift
+  done
+
+  if [ "$has_suite" = false ]; then
+    _BASHUNIT_MAIN_SUITE_ARGV=(${rest[@]+"${rest[@]}"})
+    return 0
+  fi
+
+  bashunit::suites::load ".bashunitrc"
+
+  local -a expanded=()
+  local -a suite_paths=()
+  local name entry path
+  for name in ${suite_names[@]+"${suite_names[@]}"}; do
+    bashunit::suites::resolve "$name"
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      expanded[${#expanded[@]}]="$entry"
+    done <<EOF
+$_BASHUNIT_SUITE_ARGS_OUT
+EOF
+    for path in $_BASHUNIT_SUITE_PATHS_OUT; do
+      suite_paths[${#suite_paths[@]}]="$path"
+    done
+  done
+
+  # Only when the caller named no path of their own: an explicit path is the
+  # more specific instruction, the same way an explicit flag is.
+  if [ "${#cli_paths[@]}" -eq 0 ]; then
+    for path in ${suite_paths[@]+"${suite_paths[@]}"}; do
+      expanded[${#expanded[@]}]="$path"
+    done
+  fi
+
+  _BASHUNIT_MAIN_SUITE_ARGV=(${expanded[@]+"${expanded[@]}"} ${rest[@]+"${rest[@]}"})
+}
+
 function bashunit::main::cmd_test() {
   local filter=""
   local tag_filter=""
@@ -13,6 +97,11 @@ function bashunit::main::cmd_test() {
   local args_count=0
   local assert_fn=""
   local _bashunit_coverage_opt_set=false
+
+  # Named suites are resolved into plain flags and paths before anything is
+  # parsed, so the loop below never has to know about them.
+  bashunit::main::apply_suites "$@"
+  set -- ${_BASHUNIT_MAIN_SUITE_ARGV[@]+"${_BASHUNIT_MAIN_SUITE_ARGV[@]}"}
 
   # Parse test-specific options.
   #

--- a/tests/acceptance/bashunit_suites_test.sh
+++ b/tests/acceptance/bashunit_suites_test.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+# Named suites in .bashunitrc: a project with several tiers of tests had to
+# keep the paths and their flags in a Makefile.
+
+function set_up() {
+  BIN="$PWD/bashunit"
+  # The outer run exports it; clear it so the project's own config decides.
+  unset BASHUNIT_SHOW_HEADER
+  WORKDIR="$(bashunit::temp_dir)/suites_project"
+  mkdir -p "$WORKDIR/tests/unit" "$WORKDIR/tests/acceptance"
+  cat >"$WORKDIR/tests/unit/a_test.sh" <<'TEST'
+function test_unit_one() { assert_same 1 1; }
+TEST
+  cat >"$WORKDIR/tests/acceptance/b_test.sh" <<'TEST'
+function test_acceptance_one() { assert_same 1 1; }
+TEST
+  cat >"$WORKDIR/.bashunitrc" <<'RC'
+BASHUNIT_SHOW_HEADER=false
+
+[suite:unit]
+paths = tests/unit
+parallel = true
+
+[suite:acceptance]
+paths = tests/acceptance
+no-parallel = true
+test-timeout = 60
+
+[suite:all]
+paths = tests/unit tests/acceptance
+RC
+}
+
+function run_in_project() { # $@ = bashunit arguments
+  (cd "$WORKDIR" && "$BIN" --no-color "$@" 2>&1) || true
+}
+
+function test_a_suite_runs_only_its_own_paths() {
+  local output
+  output=$(run_in_project --suite unit)
+
+  assert_contains "Unit one" "$output"
+  assert_not_contains "Acceptance one" "$output"
+}
+
+function test_repeated_suites_run_the_union_of_their_paths() {
+  local output
+  output=$(run_in_project --suite unit --suite acceptance)
+
+  assert_contains "Unit one" "$output"
+  assert_contains "Acceptance one" "$output"
+}
+
+function test_a_cli_flag_beats_the_suite_setting() {
+  local output
+  # The suite asks for --parallel; the explicit flag must win, which the
+  # summary shows by rendering the sequential per-test lines.
+  output=$(run_in_project --suite unit --no-parallel --verbose)
+
+  local line
+  line=$(printf '%s\n' "$output" | "$GREP" "BASHUNIT_PARALLEL_RUN:")
+  assert_contains "false" "$line"
+}
+
+function test_an_unknown_suite_lists_the_defined_ones() {
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BIN" --no-color --suite nope tests/unit 2>&1) ) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "unknown suite 'nope'" "$output"
+  assert_contains "unit" "$output"
+  assert_contains "acceptance" "$output"
+}
+
+function test_list_suites_prints_the_names_and_exits_zero() {
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BIN" --no-color --list-suites 2>&1) ) || ec=$?
+
+  assert_successful_code "" "" "$ec"
+  assert_contains "unit" "$output"
+  assert_contains "acceptance" "$output"
+  assert_contains "all" "$output"
+}
+
+# Documented precedence: an explicit path replaces the suite's paths, the same
+# way an explicit flag replaces a suite option.
+function test_an_explicit_path_replaces_the_suite_paths() {
+  local output
+  output=$(run_in_project --suite unit tests/acceptance)
+
+  assert_contains "Acceptance one" "$output"
+  assert_not_contains "Unit one" "$output"
+}
+
+function test_a_bashunitrc_without_suites_behaves_as_before() {
+  printf 'BASHUNIT_SHOW_HEADER=false\n' >"$WORKDIR/.bashunitrc"
+
+  local output
+  output=$(run_in_project tests/unit)
+
+  assert_contains "Unit one" "$output"
+  assert_not_contains "bashunit -" "$output"
+}
+
+function test_a_malformed_suite_section_quotes_the_offending_line() {
+  cat >"$WORKDIR/.bashunitrc" <<'RC'
+[suite:broken]
+paths = tests/unit
+this line has no equals sign
+RC
+
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BIN" --no-color --suite broken 2>&1) ) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "this line has no equals sign" "$output"
+}
+
+function test_an_unknown_suite_option_is_rejected() {
+  cat >"$WORKDIR/.bashunitrc" <<'RC'
+[suite:broken]
+paths = tests/unit
+not-a-real-flag = true
+RC
+
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BIN" --no-color --suite broken 2>&1) ) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "not-a-real-flag" "$output"
+}
+
+function test_suite_options_carry_values_with_spaces() {
+  cat >"$WORKDIR/.bashunitrc" <<'RC'
+[suite:spaced]
+paths = tests/unit
+report-md = a report with spaces.md
+RC
+
+  run_in_project --suite spaced >/dev/null
+
+  assert_file_exists "$WORKDIR/a report with spaces.md"
+}

--- a/tests/unit/config/suites_test.sh
+++ b/tests/unit/config/suites_test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# The parser behind `--suite`: [suite:<name>] sections of a .bashunitrc.
+
+function set_up() {
+  RC="$(bashunit::temp_file)"
+  # load() memoizes by path, and every test writes a different file into the
+  # same one, so the cache key has to be cleared between them.
+  _BASHUNIT_SUITES_LOADED_FILE=""
+}
+
+function load_rc() { # $1 = file content
+  printf '%s\n' "$1" >"$RC"
+  _BASHUNIT_SUITES_LOADED_FILE=""
+  bashunit::suites::load "$RC"
+}
+
+function test_a_section_collects_its_paths_and_options() {
+  load_rc '[suite:unit]
+paths = tests/unit tests/functional
+parallel = true
+test-timeout = 60'
+
+  bashunit::suites::resolve "unit"
+
+  assert_same "tests/unit tests/functional" "$_BASHUNIT_SUITE_PATHS_OUT"
+  assert_same "--parallel
+--test-timeout
+60" "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_underscores_read_as_dashes() {
+  load_rc '[suite:unit]
+test_timeout = 60'
+
+  bashunit::suites::resolve "unit"
+
+  assert_contains "--test-timeout" "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_a_false_value_leaves_the_flag_out() {
+  load_rc '[suite:unit]
+paths = tests/unit
+parallel = false'
+
+  bashunit::suites::resolve "unit"
+
+  assert_empty "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_a_value_may_contain_spaces() {
+  load_rc '[suite:unit]
+report-md = a report.md'
+
+  bashunit::suites::resolve "unit"
+
+  assert_same "--report-md
+a report.md" "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_names_lists_every_section_in_order() {
+  load_rc '[suite:unit]
+paths = tests/unit
+
+[suite:acceptance]
+paths = tests/acceptance'
+
+  assert_same "unit
+acceptance" "$(bashunit::suites::names)"
+}
+
+function test_global_settings_outside_a_section_are_ignored_here() {
+  load_rc 'BASHUNIT_SHOW_HEADER=false
+
+[suite:unit]
+paths = tests/unit'
+
+  bashunit::suites::resolve "unit"
+
+  assert_same "tests/unit" "$_BASHUNIT_SUITE_PATHS_OUT"
+  assert_empty "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_a_non_suite_section_closes_the_previous_one() {
+  load_rc '[suite:unit]
+paths = tests/unit
+
+[other]
+parallel = true'
+
+  bashunit::suites::resolve "unit"
+
+  assert_empty "$_BASHUNIT_SUITE_ARGS_OUT"
+}
+
+function test_a_file_without_sections_defines_no_suite() {
+  load_rc 'BASHUNIT_SHOW_HEADER=false'
+
+  assert_empty "$(bashunit::suites::names)"
+}
+
+function test_comments_are_skipped() {
+  load_rc '[suite:unit]
+# a comment
+; another comment
+paths = tests/unit'
+
+  bashunit::suites::resolve "unit"
+
+  assert_same "tests/unit" "$_BASHUNIT_SUITE_PATHS_OUT"
+}

--- a/tests/unit/main/completions_test.sh
+++ b/tests/unit/main/completions_test.sh
@@ -9,8 +9,14 @@ BASH_COMPLETION_FILE="completions/bashunit.bash"
 ZSH_COMPLETION_FILE="completions/_bashunit"
 
 # Flags accepted by cmd_test, straight from the option-parsing case arms.
+#
+# Two sources, because --suite and --list-suites are resolved by the pre-scan
+# in apply_suites and removed from argv before the loop below ever sees them.
 function completions_expected_test_flags() {
-  awk '/# Parse test-specific options/,/^  done$/' src/main/test.sh |
+  {
+    awk '/# Parse test-specific options/,/^  done$/' src/main/test.sh
+    awk '/^function bashunit::main::apply_suites\(\)/,/^}$/' src/main/test.sh
+  } |
     grep -E '^[[:space:]]+--?[a-zA-Z][a-zA-Z0-9-]*( \| --?[a-zA-Z][a-zA-Z0-9-]*)*\)' |
     sed 's/)$//' | tr -d ' ' | tr '|' '\n' |
     LC_ALL=C sort -u


### PR DESCRIPTION
## 🤔 Background

Related #1021

A project with several tiers of tests — `tests/unit`, `tests/acceptance`, each wanting different options — had nowhere to name them. `.bashunitrc` only set global defaults, so the tiers lived in a Makefile plus remembered flags.

## 💡 Changes

- `[suite:<name>]` sections in `.bashunitrc` group `paths` with options; every other key is a long flag without its dashes (`= true` is the bare flag, `= false` leaves it out), so there is no second vocabulary to learn.
- `--suite <name>` (repeatable, union of paths) and `--list-suites`. The pre-scan rewrites argv with the suite's options first, so the documented precedence — CLI flags > suite settings > global `.bashunitrc` > `.env` > defaults — falls out of the existing parser; an explicit path likewise replaces the suite's `paths`.
- An unknown suite lists the defined ones; a malformed section line or a non-flag option aborts quoting it, instead of quietly running something else.
- Dogfooded: this repo's `.bashunitrc` defines the `parallel` and `strict` option sets and the `Makefile` targets use them (plus a new `make test/strict` mirroring CI's strict job).