### PR TITLE
feat(cli): --sandbox to fail tests that call unmocked external commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ BASHUNIT_NO_DIFF=                   # Default: false (disable unified diff on mu
 BASHUNIT_NO_PROGRESS=               # Default: false (suppress real-time progress, final results only)
 BASHUNIT_SHOW_OUTPUT_ON_FAILURE=    # Default: true (show captured test output on failure)
 BASHUNIT_OUTPUT_FORMAT=             # Default: empty (text; tap, json or junit go to stdout)
+BASHUNIT_SANDBOX=                   # Default: false (fail tests that run unmocked external commands)
+BASHUNIT_SANDBOX_ALLOW=             # Default: empty (extra commands the sandbox allows, comma separated)
 
 #───────────────────────────────────────────────────────────────────────────────
 # Test Execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `--sandbox` fails a test that runs an external command it did not mock, naming the command; `--sandbox-allow <cmd,...>` widens the baseline allowlist of what bashunit itself needs. Builtins are unaffected, `bashunit::unmock` puts the block back, and the mechanism is recorded in ADR-012 (#1022)
 - Named suites: a `[suite:<name>]` section in `.bashunitrc` groups paths and options, `--suite <name>` runs one (repeatable, union of their paths) and `--list-suites` prints the defined names; precedence is CLI flags > suite settings > global `.bashunitrc` > `.env` > defaults, and an explicit path replaces the suite's `paths` (#1021)
 - Per-test `# @timeout <seconds>`, `# @retry <n>` and `# @skip [reason]` annotations in the comment block above a test, overriding the run-wide `--test-timeout` and `--retry` in both directions (`@timeout 0` opts a test out of a global timeout); a malformed value aborts the run, and the scan rides on the existing per-file pass so it costs no extra fork (#1020)
 - `bashunit::skip_if`, `bashunit::skip_unless`, `bashunit::skip_unless_command` and `bashunit::skip_on <windows|macos|linux>` mark the test skipped **and** end it, replacing the `bashunit::skip && return` idiom whose missing `return` silently kept the body running; an unknown OS name is a usage error, not a test that never skips (#1019)

--- a/adrs/adr-011-source-layout-and-build-pipeline.md
+++ b/adrs/adr-011-source-layout-and-build-pipeline.md
@@ -61,7 +61,7 @@ Seventeen, in load order. The order is the dependency layering: leaves first.
 | 11 | `assert/` | 11 | 2326 | every assertion |
 | 12 | `doubles/` | 4 | 505 | spies and mocks — **sourced by `assert/index.sh`, not the entrypoint** |
 | 13 | `reports/` | 8 | 738 | JUnit, TAP, JSON, GHA, HTML and Markdown writers |
-| 14 | `runner/` | 12 | 2434 | the file loop, per-test execution, retry, result parsing, `--list` |
+| 14 | `runner/` | 13 | 2664 | the file loop, per-test execution, retry, result parsing, `--list` |
 | 15 | `benchmark/` | 4 | 219 | the bench implementation (`runner/bench.sh` is its loop) |
 | 16 | `learn/` | 14 | 1296 | the interactive tutorial (9 of those files are `learn/lessons/`) |
 | 17 | `main/` | 8 | 1473 | flag parsing per subcommand and the run lifecycle |

--- a/adrs/adr-012-sandbox-mode.md
+++ b/adrs/adr-012-sandbox-mode.md
@@ -1,0 +1,121 @@
+# Sandbox mode: how an unmocked external command is blocked
+
+* Status: accepted
+* Deciders: bashunit maintainers
+* Date: 2026-08-11
+
+Technical Story: https://github.com/TypedDevs/bashunit/issues/1022
+
+## Context and Problem Statement
+
+Nothing stopped a test from calling a real command. A test that means to
+exercise a mocked `curl`, but has a typo in the mock name — or whose mock a
+previous `bashunit::unmock` removed — hits the network and **passes**: slowly,
+non-deterministically, and differently in CI. The same holds for `git`, `aws`,
+`docker` and `rm`.
+
+`--sandbox` has to make that a failure. The question is by what mechanism, in a
+framework whose floor is Bash 3.0 and whose own code shells out to `awk`, `sed`
+and friends *while a test runs*.
+
+## Decision Drivers
+
+* The failure must name the command, or the report sends the reader hunting.
+* It must hold when the test redirects stderr or ignores an exit status —
+  `curl … 2>/dev/null` followed by a passing assertion is the exact case that
+  motivated the feature.
+* Bash 3.0: no `command_not_found_handle` (4.0+), no `declare -A`.
+* The suite runs under Spanish, Japanese and Brazilian locales in CI, so no
+  mechanism may depend on the wording of a shell diagnostic.
+* The framework must keep working while a test is sandboxed.
+* Cost is paid only by runs that ask for it, but must not be absurd there.
+
+## Considered Options
+
+* Empty (or narrowed) `PATH`, the way shellspec does it
+* A `command_not_found_handle` hook
+* A shell function per blocked command
+* A `DEBUG` trap inspecting `$BASH_COMMAND`
+
+## Decision Outcome
+
+Chosen: **a shell function per blocked command, plus a narrowed `PATH`** — the
+two cover different halves of the problem.
+
+1. **Function shims.** `prepare` walks `PATH` once in the main shell and
+    defines, for every executable the run does not allow, a function that
+    records the command in a per-test file, prints a message naming it, and
+    returns 127. Bash resolves functions before `PATH`, so a direct call from
+    a test body lands there. A mock is itself a function, so mocking a command
+    simply replaces the shim, and `bashunit::unmock` puts the shim back rather
+    than handing the test the real command.
+2. **Narrowed `PATH`.** Inside the capture subshell, `PATH` becomes a directory
+    of symlinks to the allowed commands. Functions do not survive into a child
+    process, so `bash -c 'curl …'` would escape layer 1; the environment does
+    not.
+
+The verdict crosses the fork through the payload: `cleanup_on_exit` sets the
+test's exit code to 127 when the violation file is non-empty, because a
+`--parallel` worker's counters never reach the parent — only its encoded
+result does.
+
+### Positive Consequences
+
+* The message names the command and is the framework's own text, so it is
+  identical in every locale.
+* A blocked call is caught even when the test swallows both the output and the
+  status: the record is a file, written before either can be discarded.
+* `--sandbox` composes with `--coverage`, which owns the `DEBUG` trap.
+* Nothing changes for a run without the flag: `prepare` returns immediately.
+
+### Negative Consequences
+
+* A run with `--sandbox` pays one `PATH` walk (~1800 entries, ~50 ms on a
+  developer machine, no fork) plus one symlink per allowed command.
+* A command invoked by absolute path (`/usr/bin/curl`) is not blocked. Neither
+  mechanism can see it; documented rather than pretended away.
+* A command that appears in `PATH` only after the run started is not shimmed.
+* The allowlist is a baseline of what bashunit itself needs, so a test using
+  `sed` directly is not blocked. The goal is to constrain the test body's
+  reach to *services*, not to sandbox coreutils away from it.
+
+## Pros and Cons of the Options
+
+### Empty PATH alone (shellspec's approach)
+
+* Good, because it is two lines and follows a test into child processes.
+* Good, because the framework's own pinned binaries (`$GREP`, `$MKTEMP`,
+  `$CAT`) are absolute and unaffected.
+* Bad, because the only signal is bash's own `command not found`, whose text is
+  translated — the locale jobs would report nothing.
+* Bad, because a test that redirects stderr and ignores the status hides the
+  violation entirely.
+
+### command_not_found_handle
+
+* Good, because it names the command precisely and fires on every miss.
+* Bad, because it does not exist before Bash 4.0, and the floor is 3.0 — the
+  Bash 3.0 CI job is where it would silently do nothing.
+
+### DEBUG trap on $BASH_COMMAND
+
+* Good, because it sees a call before it happens, and can block builtins too.
+* Bad, because `--coverage` already owns the `DEBUG` trap: the two features
+  would become mutually exclusive.
+* Bad, because it fires on every command of every test, not only on the misses.
+
+### Function shims (chosen, with narrowed PATH)
+
+* Good, because the failure is produced by our code: precise, translated
+  nowhere, recorded in a file that redirection cannot reach.
+* Good, because mocks and shims are the same kind of object, which is what
+  makes the `unmock` semantics obvious.
+* Bad, because ~1800 function definitions cost ~50 ms at startup and live in
+  the shell for the rest of the run.
+* Bad, because functions do not cross into child processes — hence layer 2.
+
+## Links
+
+* Implemented in `src/runner/sandbox.sh`
+* Related: [ADR-009](adr-009-coverage-tracing-engine.md) — the other feature
+  that would have wanted the `DEBUG` trap

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -69,6 +69,8 @@ _bashunit() {
     '--exclude-filter[Skip tests whose name matches]:name:' \
     '--suite[Run a named suite from .bashunitrc]:suite:' \
     '--list-suites[Print the suites defined in .bashunitrc and exit]' \
+    '--sandbox[Fail a test that runs an unmocked external command]' \
+    '--sandbox-allow[Commands the sandbox still allows]:commands:' \
     '--exclude-tag[Skip tests with matching @tag]:tag:' \
     '--log-junit[Write JUnit XML report]:file:_files' \
     '--gha-annotations[GitHub Actions annotations on stdout]:mode:(auto always never)' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -22,6 +22,7 @@ _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --changed --coverage --coverage
 --no-progress --no-snapshot-create --order-by --output --parallel --profile \
 --random-order --repeat --report-html \
 --report-json --report-junit --report-md --report-tap --rerun-failed --retry --run-all \
+--sandbox --sandbox-allow \
 --seed --shard --show-incomplete --show-output --show-skipped --simple \
 --skip-env-file --snapshot-report-unused --snapshot-update \
 --stop-on-failure --strict --suite --tag \
@@ -88,7 +89,7 @@ _bashunit_completions() {
     COMPREPLY=($(compgen -W "auto always never" -- "$cur"))
     return 0
     ;;
-  -f | --filter | --exclude-filter | --suite | --tag | --exclude-tag | --repeat | --retry | --seed | --shard | --test-timeout)
+  -f | --filter | --exclude-filter | --sandbox-allow | --suite | --tag | --exclude-tag | --repeat | --retry | --seed | --shard | --test-timeout)
     return 0
     ;;
   esac

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -63,6 +63,8 @@ bashunit test tests/ --parallel --simple
 | `-f, --filter <name>`          | Only run tests matching name                     |
 | `--exclude-filter <name>`      | Skip tests whose name matches (repeatable)       |
 | `--suite <name>`               | Run a `[suite:<name>]` from `.bashunitrc` (repeatable) |
+| `--sandbox`                    | Fail a test that runs an external command it did not mock |
+| `--sandbox-allow <cmd,...>`    | Commands the sandbox still allows (repeatable)   |
 | `--list-suites`                | Print the suites defined in `.bashunitrc` and exit |
 | `--tag <expr>`                 | Only run tests with matching `@tag`; supports `a&&b` and `!a` |
 | `--exclude-tag <name>`         | Skip tests with matching `@tag` (repeatable)     |
@@ -239,6 +241,20 @@ Use [`--list`](#list) to check what an expression actually selects:
 
 ```bash
 bashunit --list --tag 'db&&!slow' tests/
+```
+
+### Sandbox
+
+> `bashunit test --sandbox [--sandbox-allow <cmd,...>]`
+
+Fails any test that reaches an external command it did not mock, so a typo in a
+mock name shows up as a failure instead of a real network call. Builtins and
+the commands bashunit itself needs are unaffected. Full description in
+[test doubles](/test-doubles#sandbox-mode).
+
+```bash
+bashunit tests/ --sandbox
+bashunit tests/ --sandbox --sandbox-allow curl,jq
 ```
 
 ### Suites

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,24 @@ The two files are read differently, which is why they behave differently: `.env`
 empty entry is unconditional (hence the preservation rule above), while `.bashunitrc` is
 parsed as literal `KEY=value` lines and only fills names that are not already set.
 
+## Sandbox
+
+> `BASHUNIT_SANDBOX=true|false`
+> `BASHUNIT_SANDBOX_ALLOW=cmd,cmd`
+
+Fail any test that runs an external command it did not mock. `false` by
+default. `BASHUNIT_SANDBOX_ALLOW` widens the baseline allowlist with a
+comma-separated list of commands.
+
+Same as the [`--sandbox`](/command-line#sandbox) option on the command line;
+see [test doubles](/test-doubles#sandbox-mode) for what the sandbox does and
+does not cover.
+
+```bash [.bashunitrc]
+BASHUNIT_SANDBOX=true
+BASHUNIT_SANDBOX_ALLOW=curl,jq
+```
+
 ## Named suites
 
 A project with more than one tier of tests can name each tier in `.bashunitrc`

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -155,6 +155,55 @@ Each test runs in its own subshell, so `bashunit::unmock` only affects the test 
 
 Reach for it when a single test needs the real command back after exercising the mocked path, or when it needs a spy's recorded calls to start over mid-test. Re-declaring a double does not require it: a second `bashunit::mock` or `bashunit::spy` on the same command replaces the first.
 
+## Sandbox mode
+
+> `bashunit test --sandbox`
+> `bashunit test --sandbox-allow <cmd,...>`
+
+A double only protects the command you remembered to double. A typo in the
+mock name, or a `bashunit::unmock` earlier in the file, and the test reaches
+the real `curl` — and passes, slowly and differently in CI.
+
+Under `--sandbox` a test may only run commands it **mocked** or the run
+**allowed**. Anything else fails the test with a message naming it:
+
+::: code-group
+```bash [Example]
+function test_fetches_the_user() {
+  curl "https://api.example.com/user/1"   # not mocked
+}
+```
+```[Output]
+✗ Error: Fetches the user
+    Sandbox: 'curl' is not mocked and not allowed. Mock it with
+    bashunit::mock, or run with --sandbox-allow curl.
+```
+:::
+
+Mock it and the same test passes, because a mock is a shell function and
+functions win over anything on `PATH`:
+
+```bash
+bashunit::mock curl echo '{"id":1}'
+```
+
+Notes:
+
+- **Shell builtins are unaffected** (`echo`, `printf`, `[`, `test`, `read`),
+  and so is everything bashunit itself needs while a test runs — the baseline
+  allowlist covers `awk`, `sed`, `grep`, `cat`, `date`, `mktemp`, `git` and
+  friends. The point is to constrain the test's reach to *services*, not to
+  take coreutils away from it.
+- `--sandbox-allow curl,jq` widens the allowlist; the flag is repeatable.
+- `bashunit::unmock curl` inside a sandboxed test puts the block back, rather
+  than handing the test the real command.
+- A command invoked by **absolute path** (`/usr/bin/curl`) is not blocked, and
+  neither is one that appears in `PATH` after the run started. See
+  [ADR-012](https://github.com/TypedDevs/bashunit/blob/main/adrs/adr-012-sandbox-mode.md)
+  for the mechanism and what it cannot see.
+- Off by default. Enable it per run, or with `BASHUNIT_SANDBOX=true` in
+  `.bashunitrc`.
+
 ## bashunit::spy
 > `bashunit::spy "function"`
 

--- a/src/config/env.sh
+++ b/src/config/env.sh
@@ -255,6 +255,8 @@ _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
 _BASHUNIT_DEFAULT_NO_PROGRESS="false"
 _BASHUNIT_DEFAULT_OUTPUT_FORMAT=""
 _BASHUNIT_DEFAULT_FAIL_ON_RISKY="false"
+_BASHUNIT_DEFAULT_SANDBOX="false"
+_BASHUNIT_DEFAULT_SANDBOX_ALLOW=""
 _BASHUNIT_DEFAULT_PROFILE="false"
 _BASHUNIT_DEFAULT_PROFILE_COUNT="10"
 # Per-test timeout in seconds (0 = disabled)
@@ -319,6 +321,10 @@ _BASHUNIT_DEFAULT_SNAPSHOT_REPORT_UNUSED="false"
 : "${BASHUNIT_NO_PROGRESS:=${NO_PROGRESS:=$_BASHUNIT_DEFAULT_NO_PROGRESS}}"
 : "${BASHUNIT_OUTPUT_FORMAT:=${OUTPUT_FORMAT:=$_BASHUNIT_DEFAULT_OUTPUT_FORMAT}}"
 : "${BASHUNIT_FAIL_ON_RISKY:=${FAIL_ON_RISKY:=$_BASHUNIT_DEFAULT_FAIL_ON_RISKY}}"
+# No unprefixed alias on purpose: SANDBOX is generic enough that an unrelated
+# tool exporting it would silently constrain the suite (#866).
+: "${BASHUNIT_SANDBOX:=$_BASHUNIT_DEFAULT_SANDBOX}"
+: "${BASHUNIT_SANDBOX_ALLOW:=$_BASHUNIT_DEFAULT_SANDBOX_ALLOW}"
 : "${BASHUNIT_PROFILE:=${PROFILE:=$_BASHUNIT_DEFAULT_PROFILE}}"
 : "${BASHUNIT_PROFILE_COUNT:=${PROFILE_COUNT:=$_BASHUNIT_DEFAULT_PROFILE_COUNT}}"
 : "${BASHUNIT_TEST_TIMEOUT:=${TEST_TIMEOUT:=$_BASHUNIT_DEFAULT_TEST_TIMEOUT}}"
@@ -689,6 +695,13 @@ function bashunit::env::is_list_enabled() {
 
 function bashunit::env::is_fail_on_risky_enabled() {
   [ "$BASHUNIT_FAIL_ON_RISKY" = "true" ]
+}
+
+##
+# Whether a test may only reach commands it mocked or the run allowed.
+##
+function bashunit::env::is_sandbox_enabled() {
+  [ "${BASHUNIT_SANDBOX:-false}" = "true" ]
 }
 
 ##

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -126,6 +126,8 @@ Options:
   --tag <expr>                Only run tests with matching @tag (repeatable, OR logic).
                               Supports 'a&&b' (AND) and '!a' (NOT)
   --exclude-tag <name>        Skip tests with matching @tag (repeatable, exclude wins)
+  --sandbox                   Fail a test that runs an external command it did not mock
+  --sandbox-allow <cmd,...>   Commands the sandbox still allows (repeatable)
   --log-junit, --report-junit <file>  Write JUnit XML report
   --log-gha <file>            Write GitHub Actions annotations to a file
   --gha-annotations <mode>    Annotations on stdout: auto (in GitHub Actions), always or never

--- a/src/doubles/mock.sh
+++ b/src/doubles/mock.sh
@@ -16,6 +16,9 @@ function bashunit::unmock() {
     if [ "${_BASHUNIT_MOCKED_FUNCTIONS[$i]:-}" = "$command" ]; then
       unset "_BASHUNIT_MOCKED_FUNCTIONS[$i]"
       unset -f "$command"
+      # Under --sandbox the command was a blocking shim before it was mocked;
+      # dropping the mock must not hand the test the real thing.
+      bashunit::sandbox::restore_shim "$command"
       local variable
       variable="$(bashunit::helper::normalize_variable_name "$command")"
       local times_file_var="_BASHUNIT_SPY_${variable}_TIMES_FILE"

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -84,6 +84,10 @@ function bashunit::main::exec_tests() {
     bashunit::parallel::init
   fi
 
+  # Builds the allowed-command directory once, in this shell: every test
+  # subshell (and every --parallel worker) inherits its path.
+  bashunit::sandbox::prepare
+
   # --list is a query: stdout must be nothing but test ids, so the banner and
   # the seed line are suppressed and the run header never prints (#1007).
   if bashunit::env::is_list_enabled; then

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -163,6 +163,20 @@ function bashunit::main::cmd_test() {
       fi
       shift
       ;;
+    --sandbox)
+      BASHUNIT_SANDBOX=true
+      export -n BASHUNIT_SANDBOX
+      ;;
+    --sandbox-allow)
+      # Repeatable and comma separated; both forms end up in one list.
+      if [ -z "$BASHUNIT_SANDBOX_ALLOW" ]; then
+        BASHUNIT_SANDBOX_ALLOW="$2"
+      else
+        BASHUNIT_SANDBOX_ALLOW="$BASHUNIT_SANDBOX_ALLOW,$2"
+      fi
+      export -n BASHUNIT_SANDBOX_ALLOW
+      shift
+      ;;
     -s | --simple)
       BASHUNIT_SIMPLE_OUTPUT=true
       export -n BASHUNIT_SIMPLE_OUTPUT

--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -194,6 +194,17 @@ function bashunit::main::validate_config_or_exit() {
     ;;
   esac
 
+  # A typo'd allowlist silently narrows the sandbox instead of widening it, so
+  # the shape is checked here rather than discovered as a blocked command.
+  case "${BASHUNIT_SANDBOX_ALLOW:-}" in
+  '') ;;
+  *[!A-Za-z0-9_.+,-]*)
+    printf "%sError: invalid --sandbox-allow value '%s'. Expected a comma-separated list of commands.%s\n" \
+      "${_BASHUNIT_COLOR_FAILED}" "${BASHUNIT_SANDBOX_ALLOW}" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+    exit 1
+    ;;
+  esac
+
   # Same shape as --output above: an unrecognised mode would otherwise fall back
   # to auto and look like it was honoured.
   case "${BASHUNIT_GHA_ANNOTATIONS:-auto}" in

--- a/src/runner/diagnostics.sh
+++ b/src/runner/diagnostics.sh
@@ -165,6 +165,22 @@ $usage_after"
   127) _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="command not found (exit code 127)" ;;
   126) _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="not executable (exit code 126)" ;;
   esac
+
+  # Under --sandbox the shim recorded the blocked command in a file, so this
+  # holds even mid-test -- the scans above only see the LAST command's exit
+  # code, and a test that redirects stderr hides the message entirely. Without
+  # it, `curl …` followed by a passing assertion is a green test that never
+  # reached the network it believed it did.
+  if bashunit::sandbox::violation_of_test; then
+    local blocked=$_BASHUNIT_SANDBOX_COMMAND_OUT
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="Sandbox: '$blocked' is not mocked and"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT not"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT allowed."
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT Mock it with"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT bashunit::mock,"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT or run with"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT --sandbox-allow $blocked."
+  fi
 }
 
 ##

--- a/src/runner/exec.sh
+++ b/src/runner/exec.sh
@@ -217,6 +217,10 @@ function bashunit::runner::execute_test_body() {
     exit 0
   fi
 
+  # From here on the test may only reach what it mocked or the run allowed.
+  # Placed before set_up so a hook cannot smuggle a real command in either.
+  bashunit::sandbox::activate
+
   # Run set_up and capture exit code without || to preserve errexit behavior
   _BASHUNIT_SETUP_COMPLETED=false
 
@@ -369,6 +373,10 @@ function bashunit::runner::run_test() {
   if [ -n "$_BASHUNIT_ANNOT_TIMEOUT_OUT" ]; then
     _BASHUNIT_RUNNER_TIMEOUT_SECS=$_BASHUNIT_ANNOT_TIMEOUT_OUT
   fi
+
+  # Names this test's violation file before the body forks, so the shims and
+  # the check below agree on where it is.
+  bashunit::sandbox::begin_test
 
   bashunit::env::resolve_retry_count
   local retry_max=$_BASHUNIT_RETRY_VALIDATED

--- a/src/runner/hooks.sh
+++ b/src/runner/hooks.sh
@@ -45,6 +45,13 @@ function bashunit::runner::cleanup_on_exit() {
     bashunit::state::set_test_exit_code "$exit_code"
   fi
 
+  # A command the sandbox blocked fails the test even when the body swallowed
+  # its status. The code travels in the payload, which is the only channel a
+  # --parallel worker has to the parent.
+  if bashunit::sandbox::peek_violation; then
+    bashunit::state::set_test_exit_code 127
+  fi
+
   bashunit::state::export_subshell_context
 }
 

--- a/src/runner/index.sh
+++ b/src/runner/index.sh
@@ -4,9 +4,10 @@
 # for the reason recorded in adrs/adr-011-source-layout-and-build-pipeline.md.
 #
 # Sourced in dependency layers, leaves first:
-#   context · payload · diagnostics → parallel · hooks · result → provider · exec
+#   context · sandbox · payload · diagnostics → parallel · hooks · result → provider · exec
 #   → list → discovery · bench
 source "$BASHUNIT_ROOT_DIR/src/runner/context.sh"
+source "$BASHUNIT_ROOT_DIR/src/runner/sandbox.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner/payload.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner/diagnostics.sh"
 source "$BASHUNIT_ROOT_DIR/src/runner/parallel.sh"

--- a/src/runner/sandbox.sh
+++ b/src/runner/sandbox.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+# --sandbox: fail a test that reaches an external command it did not mock.
+#
+# Two layers, for the reasons recorded in adrs/adr-012-sandbox-mode.md:
+#
+#   1. A shell function per blocked command, defined once in the main shell.
+#      Functions are resolved before PATH, so a direct call lands in ours: it
+#      records the violation in a file the runner reads, prints a message that
+#      names the command, and returns 127. This is what makes the failure
+#      precise, locale-independent and immune to the test redirecting stderr.
+#      A mock is itself a function, so mocking simply replaces the shim.
+#
+#   2. PATH narrowed, inside the capture subshell, to a directory of symlinks
+#      to the allowed commands. Layer 1 cannot follow a test into a child
+#      process (`bash -c 'curl …'`); the environment does.
+#
+# The allowlist is what bashunit itself shells out to while a test runs -- the
+# goal is to constrain the test body, not to break the framework -- plus
+# whatever --sandbox-allow adds.
+
+# Kept in the same order as the docs table so the two can be diffed by eye.
+_BASHUNIT_SANDBOX_BASELINE="awk sed grep cat cut tr sort uniq head tail wc
+date mktemp mkdir rm rmdir mv cp ln touch chmod stat find dirname basename
+base64 cksum od diff sleep env printf test true false expr id getconf
+bc perl python3 uname tput git kill ps sh bash"
+
+_BASHUNIT_SANDBOX_DIR=""
+# Per-test file the shims append to; set by the runner before each test.
+_BASHUNIT_SANDBOX_VIOLATION_FILE=""
+_BASHUNIT_SANDBOX_VIOLATION_SEQ=0
+_BASHUNIT_SANDBOX_ALLOWED=""
+# Space-delimited list of shell builtins, filled by prepare. A builtin named
+# like an executable (echo, printf, test, read, kill) must never be shimmed:
+# the function would shadow the builtin for the framework as well, and the
+# sandbox is about external commands.
+_BASHUNIT_SANDBOX_BUILTINS=""
+
+##
+# The allowed set as a space-delimited string, baseline plus --sandbox-allow.
+##
+function bashunit::sandbox::_allowed_list() {
+  local allowed="$_BASHUNIT_SANDBOX_BASELINE"
+  if [ -n "${BASHUNIT_SANDBOX_ALLOW:-}" ]; then
+    # The flag is repeatable and comma separated; both forms arrive as one list.
+    allowed="$allowed $(printf '%s' "$BASHUNIT_SANDBOX_ALLOW" | tr ',' ' ')"
+  fi
+  # Normalise the newlines in the baseline literal into single spaces.
+  printf ' %s ' "$(printf '%s' "$allowed" | tr '\n' ' ')"
+}
+
+##
+# Whether a command stays reachable under the sandbox.
+# Arguments: $1 - command name
+##
+function bashunit::sandbox::is_allowed() {
+  case "$_BASHUNIT_SANDBOX_ALLOWED" in
+  *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+##
+# Defines the blocking function for one command, unless it is allowed.
+# Arguments: $1 - command name
+##
+function bashunit::sandbox::shim() {
+  local name=$1
+
+  case "$name" in
+  '' | *[!A-Za-z0-9_.+-]*) return 0 ;;
+  esac
+  case "$_BASHUNIT_SANDBOX_BUILTINS" in
+  *" $name "*) return 0 ;;
+  esac
+  bashunit::sandbox::is_allowed "$name" && return 0
+
+  eval "function $name() { bashunit::sandbox::blocked '$name'; }"
+}
+
+##
+# Puts the shim back after a mock for that command is removed. Without it,
+# `bashunit::unmock curl` inside a sandboxed test would hand the test the real
+# curl -- the opposite of what removing a double should mean.
+# Arguments: $1 - command name
+##
+function bashunit::sandbox::restore_shim() {
+  bashunit::env::is_sandbox_enabled || return 0
+  bashunit::sandbox::shim "$1"
+}
+
+##
+# What a blocked command does: record it where the runner will find it however
+# the test redirects its output, say so, and answer with the shell's own code
+# for "could not find it".
+# Arguments: $1 - command name
+##
+function bashunit::sandbox::blocked() {
+  local name=$1
+
+  if [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ]; then
+    printf '%s\n' "$name" >>"$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+  fi
+
+  bashunit::sandbox::violation_message "$name" >&2
+  return 127
+}
+
+##
+# The failure message for a blocked command.
+# Arguments: $1 - command
+##
+function bashunit::sandbox::violation_message() {
+  printf "Sandbox: '%s' is not mocked and not allowed. %s\n" \
+    "$1" "Mock it with bashunit::mock, or run with --sandbox-allow $1."
+}
+
+##
+# Builds both layers, once per run, in the main shell: the symlink directory
+# PATH will point at, and a blocking function for every executable currently
+# reachable through PATH that the run does not allow.
+#
+# Enumerating PATH costs no fork (globs and builtins only) and takes ~50ms for
+# the ~1800 entries of a developer machine, which only a --sandbox run pays.
+##
+function bashunit::sandbox::prepare() {
+  bashunit::env::is_sandbox_enabled || return 0
+
+  _BASHUNIT_SANDBOX_ALLOWED=$(bashunit::sandbox::_allowed_list)
+  # compgen is a builtin, so the whole list costs no fork.
+  _BASHUNIT_SANDBOX_BUILTINS=" $(compgen -b | tr '\n' ' ') "
+
+  local dir="${_BASHUNIT_RUN_OUTPUT_DIR:-${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}}/sandbox"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  _BASHUNIT_SANDBOX_DIR="$dir"
+  export _BASHUNIT_SANDBOX_DIR
+
+  local entry name target
+  local path_dir
+  local IFS=':'
+  for path_dir in $PATH; do
+    [ -n "$path_dir" ] || continue
+    [ -d "$path_dir" ] || continue
+    for entry in "$path_dir"/*; do
+      [ -f "$entry" ] || continue
+      [ -x "$entry" ] || continue
+      name=${entry##*/}
+      if bashunit::sandbox::is_allowed "$name"; then
+        if [ ! -e "$dir/$name" ]; then
+          ln -s "$entry" "$dir/$name" 2>/dev/null || true
+        fi
+        continue
+      fi
+      bashunit::sandbox::shim "$name"
+    done
+  done
+
+  # An allowed command that PATH does not currently reach (a shell builtin, or
+  # one this machine simply lacks) needs no link; `command -v` settles it
+  # without another directory walk.
+  unset IFS
+  for name in $_BASHUNIT_SANDBOX_ALLOWED; do
+    [ -e "$dir/$name" ] && continue
+    target=$(command -v "$name" 2>/dev/null) || continue
+    case "$target" in
+    /*) ln -s "$target" "$dir/$name" 2>/dev/null || true ;;
+    esac
+  done
+}
+
+##
+# Points the test at the per-test violation file and narrows PATH. Called
+# inside the capture subshell, so the main shell keeps its own PATH.
+##
+function bashunit::sandbox::activate() {
+  bashunit::env::is_sandbox_enabled || return 0
+  [ -n "$_BASHUNIT_SANDBOX_DIR" ] || return 0
+
+  PATH="$_BASHUNIT_SANDBOX_DIR"
+  export PATH
+}
+
+##
+# Names the per-test violation file, before the test runs. The name needs no
+# fork: the parent's pid plus a counter is unique per test in both run modes,
+# and every worker inherits the value its parent set for it.
+##
+function bashunit::sandbox::begin_test() {
+  bashunit::env::is_sandbox_enabled || return 0
+  [ -n "$_BASHUNIT_SANDBOX_DIR" ] || return 0
+
+  _BASHUNIT_SANDBOX_VIOLATION_SEQ=$((_BASHUNIT_SANDBOX_VIOLATION_SEQ + 1))
+  _BASHUNIT_SANDBOX_VIOLATION_FILE="$_BASHUNIT_SANDBOX_DIR/violation-$$-$_BASHUNIT_SANDBOX_VIOLATION_SEQ"
+  export _BASHUNIT_SANDBOX_VIOLATION_FILE
+  rm -f "$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+}
+
+##
+# Whether the running test has been blocked from a command, without consuming
+# the record. Called inside the capture subshell: forcing the test's exit code
+# to 127 there is what carries the verdict across the fork, since a --parallel
+# worker's counters never reach the parent -- only its encoded payload does.
+##
+function bashunit::sandbox::peek_violation() {
+  bashunit::env::is_sandbox_enabled || return 1
+  [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+  [ -s "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ]
+}
+
+##
+# The command the test being finished was blocked from running, into
+# _BASHUNIT_SANDBOX_COMMAND_OUT. Returns 1 when there was none.
+##
+_BASHUNIT_SANDBOX_COMMAND_OUT=""
+function bashunit::sandbox::violation_of_test() {
+  _BASHUNIT_SANDBOX_COMMAND_OUT=""
+
+  bashunit::env::is_sandbox_enabled || return 1
+  [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+  [ -s "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+
+  local first=""
+  while IFS= read -r first; do
+    [ -n "$first" ] && break
+  done <"$_BASHUNIT_SANDBOX_VIOLATION_FILE"
+  rm -f "$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+
+  [ -n "$first" ] || return 1
+  _BASHUNIT_SANDBOX_COMMAND_OUT=$first
+  return 0
+}

--- a/tests/acceptance/bashunit_sandbox_test.sh
+++ b/tests/acceptance/bashunit_sandbox_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+# Nothing stopped a test from reaching a real command: a typo in a mock name
+# means the test hits the network and passes, slowly and differently in CI.
+
+function set_up_before_script() {
+  TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
+  FIXTURE="tests/acceptance/fixtures/test_bashunit_sandbox.sh"
+}
+
+function set_up() {
+  # A real executable named like the thing a test should never reach for real.
+  PROBE_DIR="$(bashunit::temp_dir)/probe_bin"
+  mkdir -p "$PROBE_DIR"
+  printf '#!/usr/bin/env bash\necho "the real command ran"\n' >"$PROBE_DIR/bashunit_sandbox_probe"
+  chmod +x "$PROBE_DIR/bashunit_sandbox_probe"
+  PROBE_LOG="$(bashunit::temp_file)"
+  : >"$PROBE_LOG"
+  export SANDBOX_PROBE_LOG="$PROBE_LOG"
+}
+
+function run_fixture() { # $1 = extra flags, $2 = filter
+  # shellcheck disable=SC2086
+  PATH="$PROBE_DIR:$PATH" NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" $1 \
+    --filter "$2" "$FIXTURE" 2>&1 || true
+}
+
+function test_an_unmocked_command_fails_the_test_naming_it() {
+  local output
+  output=$(run_fixture "--sandbox" "test_sandbox_calls_an_unmocked_command")
+
+  assert_contains "bashunit_sandbox_probe" "$output"
+  assert_contains "1 failed" "$output"
+  assert_empty "$(cat "$PROBE_LOG")"
+}
+
+function test_a_mocked_command_passes_under_sandbox() {
+  local output
+  output=$(run_fixture "--sandbox" "test_sandbox_calls_a_mocked_command")
+
+  assert_contains "1 passed" "$output"
+}
+
+function test_an_allowed_command_passes_under_sandbox() {
+  local output
+  output=$(run_fixture "--sandbox --sandbox-allow bashunit_sandbox_probe" \
+    "test_sandbox_calls_an_unmocked_command")
+
+  assert_contains "the real command ran" "$(cat "$PROBE_LOG")"
+  assert_contains "1 passed" "$output"
+}
+
+function test_builtins_are_unaffected_by_the_sandbox() {
+  local output
+  output=$(run_fixture "--sandbox" "test_sandbox_uses_builtins_only")
+
+  assert_contains "1 passed" "$output"
+}
+
+function test_unmocking_puts_the_command_back_behind_the_sandbox() {
+  local output
+  output=$(run_fixture "--sandbox" "test_sandbox_after_unmock")
+
+  assert_contains "1 failed" "$output"
+  assert_empty "$(cat "$PROBE_LOG")"
+}
+
+function test_without_the_flag_the_command_runs_for_real() {
+  local output
+  output=$(run_fixture "" "test_sandbox_calls_an_unmocked_command")
+
+  assert_contains "the real command ran" "$(cat "$PROBE_LOG")"
+  assert_contains "1 passed" "$output"
+}
+
+function test_the_sandbox_holds_under_parallel() {
+  local output
+  output=$(PATH="$PROBE_DIR:$PATH" NO_COLOR=1 ./bashunit --parallel --env "$TEST_ENV_FILE" \
+    --sandbox --filter "test_sandbox_calls_an_unmocked_command" "$FIXTURE" 2>&1 || true)
+
+  assert_contains "1 failed" "$output"
+  assert_empty "$(cat "$PROBE_LOG")"
+}
+
+# The framework itself must keep working: its own suite is full of tests that
+# use assertions, temp files, snapshots and hooks.
+function test_the_framework_is_not_sandboxed_against_itself() {
+  local output
+  output=$(NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" --sandbox \
+    tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh 2>&1 || true)
+
+  assert_contains "4 passed" "$output"
+  assert_not_contains "failed" "$output"
+}
+
+function test_an_invalid_sandbox_allow_value_is_rejected() {
+  local ec=0
+  local output
+  output=$(NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" --sandbox \
+    --sandbox-allow "curl;rm -rf" "$FIXTURE" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "invalid --sandbox-allow value" "$output"
+}

--- a/tests/acceptance/fixtures/test_bashunit_sandbox.sh
+++ b/tests/acceptance/fixtures/test_bashunit_sandbox.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Fixture for --sandbox. `bashunit_sandbox_probe` stands in for curl/git/aws:
+# a real executable on PATH that no test should reach unmocked. What it printed
+# (if it ran at all) is left in $SANDBOX_PROBE_LOG for the acceptance test.
+
+function test_sandbox_calls_an_unmocked_command() {
+  bashunit_sandbox_probe >"${SANDBOX_PROBE_LOG:?log required}" 2>/dev/null
+  assert_same "ok" "ok"
+}
+
+function test_sandbox_calls_a_mocked_command() {
+  bashunit::mock bashunit_sandbox_probe echo "mocked"
+
+  assert_same "mocked" "$(bashunit_sandbox_probe)"
+}
+
+function test_sandbox_uses_builtins_only() {
+  local value="abc"
+
+  echo "$value" >/dev/null
+  printf '%s' "$value" >/dev/null
+  if [ -n "$value" ]; then
+    assert_same "abc" "$value"
+  fi
+}
+
+function test_sandbox_after_unmock_the_command_is_blocked_again() {
+  bashunit::mock bashunit_sandbox_probe echo "mocked"
+  bashunit::unmock bashunit_sandbox_probe
+
+  bashunit_sandbox_probe >"${SANDBOX_PROBE_LOG:?log required}" 2>/dev/null
+  assert_same "ok" "ok"
+}

--- a/tests/unit/project/build_test.sh
+++ b/tests/unit/project/build_test.sh
@@ -323,8 +323,9 @@ function test_built_binary_contains_no_source_lines() {
 
 # The budget is a guard against the artifact growing without anyone noticing,
 # not a hard product limit. It was raised from 512000 to 557056 (544 KiB) in
-# #1045, after a run of features crossed the old line by 0.3%: the alternatives
-# to raising it were both worse.
+# #1045, and from there to 589824 (576 KiB) in #1022, after --output json/junit,
+# the per-test annotations, named suites and sandbox mode together added ~11 KiB
+# (559865 bytes measured). The #1045 alternatives to raising it were both worse:
 #
 #   as-is                518493 bytes   over
 #   strip blank lines    515249 bytes   still over — and unsafe, because a blank
@@ -335,7 +336,7 @@ function test_built_binary_contains_no_source_lines() {
 # So: keep the artifact readable and move the line, with headroom for a few more
 # features. Raise it deliberately and record the number again when it is hit —
 # do not silence it.
-function test_built_binary_stays_below_544_kib() {
+function test_built_binary_stays_below_576_kib() {
   if ! build_optimizer_is_available; then
     bashunit::skip "shfmt and jq are required for standalone optimization"
     return
@@ -348,7 +349,7 @@ function test_built_binary_stays_below_544_kib() {
 
   local bytes
   bytes=$(wc -c <"$build_dir/bashunit" | tr -d ' ')
-  assert_less_or_equal_than 557056 "$bytes"
+  assert_less_or_equal_than 589824 "$bytes"
 }
 
 function test_build_assert_valid_syntax_rejects_broken_file() {


### PR DESCRIPTION
## 🤔 Background

Related #1022

Nothing stopped a test from calling a real command: a typo in a mock name, or a mock an earlier `bashunit::unmock` removed, and the test hits the network — and passes, slowly and differently in CI. #895 closed the equivalent hole for spies.

## 💡 Changes

- `--sandbox` fails any test that runs an external command it did not mock, with a message naming the command; `--sandbox-allow <cmd,...>` widens the baseline allowlist of what bashunit itself needs while a test runs.
- Two layers (weighed in the new **ADR-012**): a shell function per blocked command — functions resolve before `PATH`, so mocks simply replace the shim and `unmock` puts it back — plus a narrowed `PATH` inside the capture subshell, since functions cannot follow a test into `bash -c '…'`.
- Builtins are never shimmed, and the verdict travels in the result payload (exit 127), so it survives `--parallel` and a test that redirects stderr and ignores the status.
- Off by default and byte-identical without the flag; `BASHUNIT_SANDBOX` / `BASHUNIT_SANDBOX_ALLOW` settable in `.bashunitrc`. Binary size budget raised to 576 KiB (this plus the three previous features added ~11 KiB).