### PR TITLE
feat(doubles): mock sequences and an assert_have_never_been_called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ### Added
+- `bashunit::mock_sequence <cmd> <answer>…` answers each call with the next entry, so retry loops and polling can be doubled without a hand-rolled counter file; the last entry repeats once exhausted, and a spy over the sequence still records every call (#1023)
+- `assert_have_never_been_called <cmd>` asserts a spied command never ran, printing the recorded calls when it did (#1023)
 - `assert_json_key_not_exists` checks that a JSON path is absent, while `assert_json_length` checks the size of an array, object, or string (#1025)
 - `--output <text|tap|json|junit>` prints the JSON and JUnit reports on stdout, suppressing every console rendering so a pipeline needs no temp file; `--report-json` still writes its file alongside (#1018)
 - `bashunit::skip_if`, `bashunit::skip_unless`, `bashunit::skip_unless_command <cmd>` and `bashunit::skip_on <windows|macos|linux>` mark a test skipped **and** end it, replacing `bashunit::skip && return`, whose missing `return` silently kept the body running (#1019)

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -126,6 +126,56 @@ test_example() {
 ```
 :::
 
+## bashunit::mock_sequence
+> `bashunit::mock_sequence "command" <answer> [<answer>…]`
+
+A `bashunit::mock` gives the same answer forever, which cannot express the code
+that most needs a double: retry loops, polling and backoff. A sequence answers
+each call with the next entry.
+
+Entries follow the same rule as `bashunit::mock`: an all-digits entry is an
+**exit code**, anything else is a **body**, and the two can be mixed.
+
+::: code-group
+```bash [Example]
+function test_retries_until_the_service_answers() {
+  bashunit::mock_sequence curl 1 1 0
+
+  assert_successful_code "$(fetch_with_retries 5)"
+}
+
+function test_mixes_codes_and_bodies() {
+  bashunit::mock_sequence status 1 "echo ready"
+
+  assert_general_error "$(status)"
+  assert_same "ready" "$(status)"
+}
+```
+:::
+
+The **last entry repeats** once the sequence is exhausted, so a loop that runs
+one iteration more than the test planned keeps the final answer instead of
+falling off a cliff:
+
+```bash
+bashunit::mock_sequence flaky 1 0
+flaky   # 1
+flaky   # 0
+flaky   # 0, and so on
+```
+
+Sequences live in the same registry as every other double, so they are undone
+after the test and never leak into the next one — including under `--parallel`.
+Declaring a sequence over a [spy](#bashunit-spy) keeps the recording, so the
+calls can still be asserted:
+
+```bash
+bashunit::spy curl
+bashunit::mock_sequence curl 1 0
+
+assert_have_been_called_times 2 curl
+```
+
 ## bashunit::unmock
 > `bashunit::unmock "function"`
 
@@ -416,6 +466,37 @@ function test_failure() {
 }
 ```
 :::
+
+## assert_have_never_been_called
+> `assert_have_never_been_called "command"`
+
+Asserts a spied command was **never** called. Same check as
+`assert_have_been_called_times 0`, written the way the case that matters reads:
+a destructive command that must not run.
+
+::: code-group
+```bash [Example]
+function test_a_dry_run_deletes_nothing() {
+  bashunit::spy rm
+
+  deploy --dry-run
+
+  assert_have_never_been_called rm
+}
+```
+```[Output]
+✗ Failed: A dry run deletes nothing
+    Expected 'rm'
+    to have never been called
+    actual '1 time'
+    Recorded calls to 'rm' (1):
+      1: -rf /tmp/build
+```
+:::
+
+Failing prints the recorded calls, so the report says *what* ran rather than
+only that something did. As with every assertion in this family, a command that
+was never spied fails the assertion instead of passing vacuously.
 
 ## assert_not_called
 > `assert_not_called "spy"`

--- a/src/doubles/assertions.sh
+++ b/src/doubles/assertions.sh
@@ -263,6 +263,46 @@ function assert_have_been_called_nth_with() {
 }
 
 
+##
+# Asserts a spied command was never called. The counterpart of
+# assert_have_been_called: `assert_have_been_called_times 0 rm` reads backwards
+# for the case that matters most -- a destructive command that must not run.
+##
+function assert_have_never_been_called() {
+  local command=$1
+  bashunit::spy::times_to_slot "$command"
+  local times=$_BASHUNIT_SPY_TIMES_OUT
+  local label="${2:-}"
+  if [ -z "$label" ]; then
+    bashunit::helper::normalize_test_function_name_to_slot "${FUNCNAME[1]}"
+    label=$_BASHUNIT_HELPER_NORMALIZED_OUT
+  fi
+
+  # #895: a command nobody spied is a broken test, not a vacuous pass -- and
+  # this assertion is the one where a vacuous pass is most reassuring and most
+  # wrong.
+  if [ "$_BASHUNIT_SPY_REGISTERED_OUT" = false ]; then
+    bashunit::spy::fail_unregistered "$command" "$label"
+    return
+  fi
+
+  if [ "$times" -ne 0 ]; then
+    bashunit::state::add_assertions_failed
+    bashunit::spy::call_log_to_slot "$command"
+    local unit="times"
+    if [ "$times" -eq 1 ]; then
+      unit="time"
+    fi
+    bashunit::console_results::print_failed_test "${label}" "${command}" \
+      "to have never been called" "" \
+      "actual" "${times} ${unit}" "$_BASHUNIT_SPY_CALL_LOG_OUT"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+
 function assert_not_called() {
   local command=$1
   local label="${2:-}"

--- a/src/doubles/mock.sh
+++ b/src/doubles/mock.sh
@@ -142,6 +142,10 @@ function bashunit::mock_sequence() {
   }"
 
   export -f "${command?}"
+  # The recorder travels with the double: an exported spy that reaches an
+  # external script (bash 4+) would otherwise call a function the child has
+  # never heard of.
+  export -f bashunit::doubles::record_call
 
   _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
 }

--- a/src/doubles/mock.sh
+++ b/src/doubles/mock.sh
@@ -23,6 +23,9 @@ function bashunit::unmock() {
       variable="$(bashunit::helper::normalize_variable_name "$command")"
       local times_file_var="_BASHUNIT_SPY_${variable}_TIMES_FILE"
       local params_file_var="_BASHUNIT_SPY_${variable}_PARAMS_FILE"
+      local sequence_file_var="_BASHUNIT_MOCK_${variable}_SEQUENCE_FILE"
+      [ -f "${!sequence_file_var-}" ] && rm -f "${!sequence_file_var}"
+      unset "$sequence_file_var"
       [ -f "${!times_file_var-}" ] && rm -f "${!times_file_var}"
       [ -f "${!params_file_var-}" ] && rm -f "${!params_file_var}"
       unset "$times_file_var"
@@ -62,3 +65,83 @@ function bashunit::mock() {
   _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
 }
 
+
+##
+# Replaces a command with a sequence of answers: each call consumes the next
+# entry, and the last entry repeats once the sequence is exhausted (so a loop
+# that runs one iteration more than the test planned keeps the final answer
+# rather than falling off a cliff).
+#
+# Entries follow the same convention as bashunit::mock -- an all-digits entry
+# is an exit code, anything else is a body -- which is also what keeps the
+# generated `return N` free of anything but a number.
+#
+# Defining a sequence over an existing spy keeps the recording: the generated
+# body calls the same recorder the spy's does.
+# Arguments: $1 - command, $@ - the answers, in order
+##
+function bashunit::mock_sequence() {
+  local command=$1
+  shift
+
+  if [ $# -eq 0 ]; then
+    bashunit::assert::usage_error_detail "bashunit::mock_sequence" \
+      "expects at least one answer after the command"
+    return 2
+  fi
+
+  local variable
+  bashunit::helper::normalize_variable_name_to_slot "$command"
+  variable=$_BASHUNIT_HELPER_VARNAME_OUT
+
+  local test_id="${BASHUNIT_CURRENT_TEST_ID:-global}"
+  local step_file
+  step_file=$(bashunit::temp_file "${test_id}_${variable}_sequence")
+  builtin echo 1 >"$step_file"
+  export "_BASHUNIT_MOCK_${variable}_SEQUENCE_FILE"="$step_file"
+
+  local times_file_var="_BASHUNIT_SPY_${variable}_TIMES_FILE"
+  local params_file_var="_BASHUNIT_SPY_${variable}_PARAMS_FILE"
+  local record=""
+  if [ -n "${!times_file_var-}" ]; then
+    record="bashunit::doubles::record_call '${!params_file_var}' '${!times_file_var}' \"\$@\""
+  fi
+
+  local total=$#
+  local index=0
+  local arms=""
+  local entry body
+  for entry in "$@"; do
+    index=$((index + 1))
+    if bashunit::doubles::is_exit_code "$entry"; then
+      body="return $entry"
+    else
+      body="$entry \"\$@\""
+    fi
+    # The last arm is the default one, which is what makes the final answer
+    # repeat instead of the sequence running out.
+    if [ "$index" -eq "$total" ]; then
+      arms="$arms
+    *) $body ;;"
+    else
+      arms="$arms
+    $index) $body ;;"
+    fi
+  done
+
+  eval "function $command() {
+    $record
+    local _step=1
+    read -r _step < '$step_file' 2>/dev/null || _step=1
+    case \"\$_step\" in '' | *[!0-9]*) _step=1 ;; esac
+    if [ \"\$_step\" -lt $total ]; then
+      builtin echo \"\$((_step + 1))\" > '$step_file'
+    fi
+    case \"\$_step\" in$arms
+    esac
+  }"
+
+  export -f "${command?}"
+
+  _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
+}

--- a/src/doubles/spy.sh
+++ b/src/doubles/spy.sh
@@ -222,6 +222,10 @@ function bashunit::spy() {
   }"
 
   export -f "${command?}"
+  # The recorder travels with the double: an exported spy that reaches an
+  # external script (bash 4+) would otherwise call a function the child has
+  # never heard of.
+  export -f bashunit::doubles::record_call
 
   _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
 }

--- a/src/doubles/spy.sh
+++ b/src/doubles/spy.sh
@@ -164,6 +164,33 @@ function bashunit::spy::serialize_args_to_slot() {
 }
 
 
+##
+# Records one call of a double: the raw and per-argument forms in the params
+# file, and the incremented count in the times file. Shared by the spy and by
+# a sequenced mock defined over one, so the two record identically.
+# Arguments: $1 - params file, $2 - times file, $@ - the call's arguments
+##
+function bashunit::doubles::record_call() {
+  local params_file=$1
+  local times_file=$2
+  shift 2
+
+  local raw="$*"
+  local serialized=""
+  local arg
+  for arg in "$@"; do
+    serialized="$serialized$(builtin printf '%q' "$arg")"$'\x1f'
+  done
+  serialized=${serialized%$'\x1f'}
+  builtin printf '%s\x1e%s\n' "$raw" "$serialized" >>"$params_file"
+
+  local count=""
+  read -r count <"$times_file" 2>/dev/null || count=""
+  case "$count" in '' | *[!0-9]*) count=0 ;; esac
+  builtin echo "$((count + 1))" >"$times_file"
+}
+
+
 function bashunit::spy() {
   local command=$1
   local exit_code_or_impl="${2:-}"
@@ -190,19 +217,7 @@ function bashunit::spy() {
   fi
 
   eval "function $command() {
-    local raw=\"\$*\"
-    local serialized=\"\"
-    local arg
-    for arg in \"\$@\"; do
-      serialized=\"\$serialized\$(builtin printf '%q' \"\$arg\")\"$'\\x1f'
-    done
-    serialized=\${serialized%$'\\x1f'}
-    builtin printf '%s\x1e%s\\n' \"\$raw\" \"\$serialized\" >> '$params_file'
-    local _c=\"\"
-    read -r _c < '$times_file' 2>/dev/null || _c=\"\"
-    case \"\$_c\" in '' | *[!0-9]*) _c=0 ;; esac
-    _c=\$((_c+1))
-    builtin echo \"\$_c\" > '$times_file'
+    bashunit::doubles::record_call '$params_file' '$times_file' \"\$@\"
     $body_suffix
   }"
 

--- a/tests/functional/doubles_test.sh
+++ b/tests/functional/doubles_test.sh
@@ -311,3 +311,42 @@ function test_spy_on_printf_does_not_hang() {
 
   assert_have_been_called printf
 }
+
+# Retry logic is the code that most needs a double and could not be doubled:
+# "fail twice, then succeed" used to mean a hand-rolled counter file per test.
+function retry_until_success() { # $1 = attempts
+  local attempts=$1
+  local i=0
+  while [ "$i" -lt "$attempts" ]; do
+    i=$((i + 1))
+    if an_unreliable_service; then
+      builtin echo "$i"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function test_a_sequence_drives_a_retry_loop() {
+  bashunit::mock_sequence an_unreliable_service 1 1 0
+
+  assert_same "3" "$(retry_until_success 5)"
+}
+
+function test_a_retry_loop_gives_up_when_the_sequence_never_succeeds() {
+  bashunit::mock_sequence an_unreliable_service 1
+
+  local code=0
+  retry_until_success 3 >/dev/null || code=$?
+
+  assert_same "1" "$code"
+}
+
+function test_a_destructive_command_is_never_reached() {
+  bashunit::spy a_destructive_command
+  bashunit::mock_sequence an_unreliable_service 0
+
+  retry_until_success 3 >/dev/null
+
+  assert_have_never_been_called a_destructive_command
+}

--- a/tests/unit/doubles/mock_sequence_test.sh
+++ b/tests/unit/doubles/mock_sequence_test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# bashunit::mock returns one fixed answer forever, which cannot express the
+# code that most needs a double: retry loops, polling and backoff.
+
+function test_a_sequence_of_exit_codes_is_consumed_in_order() {
+  bashunit::mock_sequence a_flaky_command 1 1 0
+
+  local first=0 second=0 third=0
+  a_flaky_command || first=$?
+  a_flaky_command || second=$?
+  a_flaky_command || third=$?
+
+  assert_same "1 1 0" "$first $second $third"
+}
+
+function test_bodies_and_exit_codes_mix_in_one_sequence() {
+  bashunit::mock_sequence a_mixed_command 1 "echo recovered"
+
+  local code=0
+  a_mixed_command >/dev/null || code=$?
+
+  assert_same "1" "$code"
+  assert_same "recovered" "$(a_mixed_command)"
+}
+
+# Documented: the last entry repeats once the sequence is exhausted, so a test
+# that calls one more time than it planned does not get a surprise.
+function test_the_last_entry_repeats_once_the_sequence_is_exhausted() {
+  bashunit::mock_sequence an_exhausted_command 1 0
+
+  local codes=""
+  local remaining=4
+  while [ "$remaining" -gt 0 ]; do
+    remaining=$((remaining - 1))
+    local code=0
+    an_exhausted_command || code=$?
+    codes="$codes$code"
+  done
+
+  assert_same "1000" "$codes"
+}
+
+function test_a_single_entry_sequence_behaves_like_a_plain_mock() {
+  bashunit::mock_sequence a_single_command 3
+
+  local first=0 second=0
+  a_single_command || first=$?
+  a_single_command || second=$?
+
+  assert_same "3 3" "$first $second"
+}
+
+function test_arguments_reach_a_body_entry() {
+  bashunit::mock_sequence an_echoing_command "echo called with"
+
+  assert_same "called with a b" "$(an_echoing_command a b)"
+}
+
+function test_unmock_clears_a_sequenced_mock() {
+  bashunit::mock_sequence an_unmocked_command 1 0
+  bashunit::unmock an_unmocked_command
+
+  local defined="no"
+  if declare -F an_unmocked_command >/dev/null 2>&1; then
+    defined="yes"
+  fi
+
+  assert_same "no" "$defined"
+}
+
+function test_a_spy_over_a_sequenced_mock_records_every_call() {
+  bashunit::spy a_spied_command
+  bashunit::mock_sequence a_spied_command 1 0
+
+  a_spied_command first || true
+  a_spied_command second || true
+
+  assert_have_been_called_times 2 a_spied_command
+  assert_have_been_called_with a_spied_command "second"
+}
+
+function test_a_sequence_does_not_leak_into_the_next_test() {
+  # The counterpart of the test below: this one arms the sequence, the next
+  # one asserts the runner unwound it.
+  bashunit::mock_sequence a_leaking_command 1 0
+
+  local code=0
+  a_leaking_command || code=$?
+
+  assert_same "1" "$code"
+}
+
+function test_z_the_previous_sequence_is_gone() {
+  local defined="no"
+  if declare -F a_leaking_command >/dev/null 2>&1; then
+    defined="yes"
+  fi
+
+  assert_same "no" "$defined"
+}

--- a/tests/unit/doubles/test_doubles_test.sh
+++ b/tests/unit/doubles/test_doubles_test.sh
@@ -354,3 +354,40 @@ function test_spy_with_impl_records_calls_and_delegates() {
   assert_have_been_called_nth_with 1 ps "first"
   assert_have_been_called_nth_with 2 ps "second"
 }
+
+function expected_call_log() {
+  bashunit::spy::call_log_to_slot "$1"
+  printf '%s' "$_BASHUNIT_SPY_CALL_LOG_OUT"
+}
+
+function test_assert_have_never_been_called_passes_for_a_spy_that_never_ran() {
+  bashunit::spy a_never_called_command
+
+  assert_have_never_been_called a_never_called_command
+}
+
+function test_assert_have_never_been_called_fails_when_the_command_ran() {
+  bashunit::spy a_called_command
+  a_called_command "danger"
+
+  assert_same \
+    "$(bashunit::console_results::print_failed_test \
+      "Assert have never been called fails when the command ran" \
+      "a_called_command" "to have never been called" "" \
+      "actual" "1 time" "$(expected_call_log a_called_command)")" \
+    "$(assert_have_never_been_called a_called_command)"
+}
+
+# #895: a command nobody spied fails the assertion instead of passing. Compared
+# against the renderer rather than the captured text, because --simple mode
+# prints a one-char marker and would make an assert_contains here vacuous.
+function test_assert_have_never_been_called_fails_for_a_command_that_was_never_spied() {
+  local expected
+  expected="$(bashunit::console_results::print_failed_test \
+    "Assert have never been called fails for a command that was never spied" \
+    "a_command_nobody_spied" \
+    "was never registered as a spy; call it first with" \
+    "bashunit::spy a_command_nobody_spied")"
+
+  assert_same "$expected" "$(assert_have_never_been_called a_command_nobody_spied)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1023

`bashunit::mock` answers the same way forever, so the code that most needs a double — retry loops, polling, backoff — could not be doubled at all: "fail the first time, succeed the second" meant hand-rolling a counter file in every test. Separately, "this destructive command must never run" had to be written as `assert_have_been_called_times 0 rm`, which reads backwards.

## 💡 Changes

- `bashunit::mock_sequence <cmd> <answer>…` consumes one entry per call, mixing exit codes and bodies by the same rule `bashunit::mock` already uses; the last entry repeats once the sequence is exhausted (documented and tested).
- Sequences live in the registry the runner unwinds per test, so nothing leaks — including under `--parallel` — and `bashunit::unmock` clears the sequence file with the function.
- A sequence declared over a spy keeps recording: both doubles now emit through one `bashunit::doubles::record_call`, extracted from the spy's generated body.
- `assert_have_never_been_called <cmd>` prints the recorded calls on failure, and fails for a command nobody spied (#895) instead of passing vacuously.