### PR TITLE
feat(snapshot): --snapshot-prune to delete the unused snapshot files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ BASHUNIT_NO_DIFF=                   # Default: false (disable unified diff on mu
 BASHUNIT_NO_PROGRESS=               # Default: false (suppress real-time progress, final results only)
 BASHUNIT_SHOW_OUTPUT_ON_FAILURE=    # Default: true (show captured test output on failure)
 BASHUNIT_OUTPUT_FORMAT=             # Default: empty (text; tap, json or junit go to stdout)
+BASHUNIT_SNAPSHOT_PRUNE=            # Default: false (delete snapshot files no test resolved)
 BASHUNIT_BENCH_BASELINE=            # Default: empty (bench: compare against this --report-json result)
 BASHUNIT_BENCH_BASELINE_TOLERANCE=  # Default: 10 (bench: allowed regression percentage)
 BASHUNIT_BENCH_BASELINE_UPDATE=     # Default: empty (bench: write this run as the new baseline)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- `--snapshot-prune` deletes the snapshot files no test resolved, printing every path; like `--snapshot-report-unused` it is a full-run-only flag, and it additionally refuses to delete anything on a run with failures, where an unresolved snapshot only means the test never got there (#1030)
 - `bashunit bench --baseline <file>` fails a run when a benchmark is more than `--baseline-tolerance` percent (default 10) slower than the recorded run, comparing medians and printing a per-benchmark delta; `--baseline-update <file>` records the new reference, a new benchmark is reported rather than failed, and a missing or malformed baseline exits non-zero instead of quietly passing (#1029)
 - `bashunit bench --report-json <file>` and `--report-junit <file>` write the benchmark run to disk — per benchmark the revs, its, every iteration, average, min, max, median and the `@max_ms` verdict, plus run-level timestamp, duration, bashunit/bash version and OS — so a CI run leaves an artifact to store, chart and compare (#1028)
 - `assert_is_file_readable` / `assert_is_file_not_readable`, `assert_is_file_writable` / `assert_is_file_not_writable`, `assert_is_file_executable` / `assert_is_file_not_executable` and `assert_is_file_not_empty` give files the parity directories already had; a failure distinguishes a path that does not exist from one that is not a file from a mode that is wrong (#1024)

--- a/Makefile
+++ b/Makefile
@@ -73,15 +73,17 @@ PRE_COMMIT_SCRIPTS_FILE=./bin/pre-commit
 # fixtures/ is excluded by path: those files are inputs to other tests, not
 # tests. Four of them end in _test.sh and a naive recursive glob collects them.
 # tests/unit/project/collection_test.sh keeps this list honest.
-TEST_SCRIPTS = $(shell find $(TEST_SCRIPTS_DIR) -name '*[tT]est.sh' -not -path '*/fixtures/*' | sort)
+# The one definition of "a test file": both the list `make test` runs and the
+# list `make test/list` prints expand from it, so the two cannot drift.
+TEST_SCRIPTS_FIND = find $(TEST_SCRIPTS_DIR) -name '*[tT]est.sh' -not -path '*/fixtures/*'
+TEST_SCRIPTS = $(shell $(TEST_SCRIPTS_FIND) | sort)
 
-# One echo per file, not one echo of every file: the single ~14 KB argument
-# that `echo $(TEST_SCRIPTS)` produced came back truncated mid-path under Git
-# Bash, which made the collection contract fail on Windows as the suite grew.
-# Still expanded from TEST_SCRIPTS, so the list stays the one `make test` runs.
+# Runs the find rather than expanding the ~14 KB variable into the recipe:
+# Git Bash handed back a truncated command line once the suite grew past it,
+# and the collection contract failed on Windows for that alone.
 test/list:
 	@echo "Test scripts found:"
-	@$(foreach f,$(TEST_SCRIPTS),echo $(f);)
+	@$(TEST_SCRIPTS_FIND) | sort
 
 test: $(TEST_SCRIPTS)
 	@bash ./bashunit $(TEST_SCRIPTS)

--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,13 @@ PRE_COMMIT_SCRIPTS_FILE=./bin/pre-commit
 # tests/unit/project/collection_test.sh keeps this list honest.
 TEST_SCRIPTS = $(shell find $(TEST_SCRIPTS_DIR) -name '*[tT]est.sh' -not -path '*/fixtures/*' | sort)
 
+# One echo per file, not one echo of every file: the single ~14 KB argument
+# that `echo $(TEST_SCRIPTS)` produced came back truncated mid-path under Git
+# Bash, which made the collection contract fail on Windows as the suite grew.
+# Still expanded from TEST_SCRIPTS, so the list stays the one `make test` runs.
 test/list:
 	@echo "Test scripts found:"
-	@echo $(TEST_SCRIPTS) | tr ' ' '\n'
+	@$(foreach f,$(TEST_SCRIPTS),echo $(f);)
 
 test: $(TEST_SCRIPTS)
 	@bash ./bashunit $(TEST_SCRIPTS)

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -105,6 +105,7 @@ _bashunit() {
     '--list-format[Rendering for --list]:format:(text json)' \
     '--snapshot-update[Rewrite existing snapshots from the actual value]' \
     '--no-snapshot-create[Fail instead of recording a missing snapshot]' \
+    '--snapshot-prune[Delete snapshot files no test resolved]' \
     '--snapshot-report-unused[List snapshot files no test resolved]' \
     '(-vvv --verbose)'{-vvv,--verbose}'[Show execution details]' \
     '--debug[Enable shell debug mode]::file:_files' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -24,7 +24,7 @@ _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --changed --coverage --coverage
 --report-json --report-junit --report-md --report-tap --rerun-failed --retry --run-all \
 --sandbox --sandbox-allow \
 --seed --shard --show-incomplete --show-output --show-skipped --simple \
---skip-env-file --snapshot-report-unused --snapshot-update \
+--skip-env-file --snapshot-prune --snapshot-report-unused --snapshot-update \
 --stop-on-failure --strict --suite --tag \
 --test-timeout --verbose \
 --watch -R -S -a -e -f -h -j -l -p -r -s -vvv -w"

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -98,6 +98,7 @@ bashunit test tests/ --parallel --simple
 | `--snapshot-update`            | Rewrite existing snapshots from the actual value |
 | `--no-snapshot-create`         | Fail on a missing snapshot instead of recording it |
 | `--snapshot-report-unused`     | List snapshot files no test resolved (deletes nothing) |
+| `--snapshot-prune`             | Delete the snapshot files no test resolved (full runs only) |
 | `--show-skipped`               | Show skipped tests summary at end                |
 | `--show-incomplete`            | Show incomplete tests summary at end             |
 | `-vvv, --verbose`              | Show execution details                           |
@@ -857,6 +858,17 @@ instead of everything else in the same `snapshots/` directory. A run that
 executes a *subset of the tests* in those files would still be misleading, so
 the flag is refused alongside `--filter`, `--tag`, `--exclude-tag`, `--shard`,
 `--rerun-failed` and `--changed`.
+
+### Snapshot prune
+
+> `bashunit test --snapshot-prune`
+
+Deletes exactly what the report above lists, printing every path it removes.
+It refuses the same partial runs, and additionally deletes nothing when the run
+has failures: a test that stopped at an earlier assertion never resolved its
+snapshot either, so "unused" there can mean "not run".
+
+See [snapshots](/snapshots#deleting-them).
 
 ### No snapshot create
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,6 +439,15 @@ nothing.
 
 Similar as using `--snapshot-report-unused` option on the [command line](/command-line#snapshot-report-unused).
 
+## Snapshot prune
+
+> `BASHUNIT_SNAPSHOT_PRUNE=true|false`
+
+Delete the snapshot files no test resolved. `false` by default. Full runs only,
+and never on a run with failures.
+
+Similar as using `--snapshot-prune` option on the [command line](/command-line#snapshot-prune).
+
 ## Rerun failed
 
 > `BASHUNIT_RERUN_FAILED=true|false`

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -169,7 +169,7 @@ test orphans its snapshot: nothing reads it, nothing reports it, and it stays on
 ```
 Unused snapshots (1), no test resolved them:
   tests/snapshots/header_test_sh.test_old_name.snapshot
-Nothing was deleted. Delete them yourself once you have checked the tests are gone.
+Nothing was deleted. Run with --snapshot-prune to remove them.
 ```
 
 It never deletes anything — a snapshot removed by mistake is re-recorded on the next run
@@ -177,6 +177,34 @@ and never fails again, so an automatic cleanup could quietly turn a real asserti
 rubber stamp. Only snapshots belonging to the test files of the run are considered, and
 the flag is refused with `--filter`, `--tag`, `--exclude-tag`, `--shard` and
 `--rerun-failed`, whose partial runs would report live files as unused.
+
+### Deleting them
+
+`--snapshot-prune` deletes exactly the files the report lists, printing each
+path as it goes:
+
+```bash
+./bashunit --snapshot-prune tests/
+```
+```
+Deleted 1 unused snapshot(s):
+  tests/snapshots/header_test_sh.test_old_name.snapshot
+```
+
+Two guards, both about the same risk — deleting a snapshot that was merely not
+reached:
+
+- **Full runs only.** `--filter`, `--tag`, `--exclude-tag`, `--shard`,
+  `--rerun-failed` and `--changed` run a subset, so the snapshots of the tests
+  they skipped would look unused. Combining them exits non-zero **before**
+  running anything.
+- **Not on a failing run.** A test that stopped at an earlier assertion never
+  resolved its snapshot either, so "unused" there can mean "not run". Pruning
+  says so and deletes nothing.
+
+`--snapshot-update` and `--snapshot-prune` compose: update rewrites what the
+tests resolved, prune removes what nothing resolved, and the two sets are
+disjoint by construction.
 
 ## Snapshots in CI
 

--- a/src/assert/snapshot.sh
+++ b/src/assert/snapshot.sh
@@ -89,11 +89,17 @@ function bashunit::snapshot::normalize_path() {
   builtin echo "$path"
 }
 
-# Lists the snapshot files under $@ that no test resolved this run, and says so.
-# Deliberately reports only: a snapshot deleted by mistake is re-recorded on the
-# next run and never fails again, so an automatic cleanup could quietly turn a
-# real assertion into one that asserts nothing.
-function bashunit::snapshot::report_unused() {
+_BASHUNIT_SNAPSHOT_UNUSED_OUT=""
+_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT=0
+
+# Collects the snapshot files under $@ that no test resolved this run into
+# _BASHUNIT_SNAPSHOT_UNUSED_OUT (one path per line) and their count into
+# _BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT.
+#
+# Shared by --snapshot-report-unused and --snapshot-prune so the list one prints
+# is exactly the list the other deletes; two implementations of "unused" is how
+# a cleanup ends up removing a live snapshot.
+function bashunit::snapshot::collect_unused() {
   local -a search_paths=()
   local path
   for path in "$@"; do
@@ -155,16 +161,81 @@ function bashunit::snapshot::report_unused() {
     done
   done < <(find "${search_paths[@]}" -type d -name snapshots 2>/dev/null | sort -u)
 
-  if [ "$total" -eq 0 ]; then
+  _BASHUNIT_SNAPSHOT_UNUSED_OUT="$unused"
+  _BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT="$total"
+}
+
+# Lists the snapshot files that no test resolved this run, and says so.
+# Reports only: a snapshot deleted by mistake is re-recorded on the next run and
+# never fails again, so an unasked-for cleanup could quietly turn a real
+# assertion into one that asserts nothing. --snapshot-prune is that cleanup,
+# asked for.
+function bashunit::snapshot::report_unused() {
+  bashunit::snapshot::collect_unused "$@"
+
+  if [ "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" -eq 0 ]; then
     printf "\n%sNo unused snapshots.%s\n" \
       "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
     return
   fi
 
   printf "\n%sUnused snapshots (%s), no test resolved them:%s\n%s" \
-    "${_BASHUNIT_COLOR_SKIPPED}" "$total" "${_BASHUNIT_COLOR_DEFAULT}" "$unused"
-  printf "%sNothing was deleted. Delete them yourself once you have checked the tests are gone.%s\n" \
+    "${_BASHUNIT_COLOR_SKIPPED}" "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" \
+    "${_BASHUNIT_COLOR_DEFAULT}" "$_BASHUNIT_SNAPSHOT_UNUSED_OUT"
+  printf "%sNothing was deleted. Run with --snapshot-prune to remove them.%s\n" \
     "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
+}
+
+##
+# Deletes the snapshot files no test resolved, printing each path as it goes.
+#
+# Refuses on a failing run: a test that never reached its assertion did not
+# resolve its snapshot either, so "unused" there means "not run". The full-run
+# rule is enforced earlier, in the parser, so this is never reached for a
+# --filter/--shard/--changed run.
+#
+# Only paths the collector produced are removed, one file at a time, each one
+# printed first and each checked to be a regular *.snapshot file: no glob of
+# this function's own making ever reaches rm.
+# Arguments: $@ - the test files of this run
+##
+function bashunit::snapshot::prune_unused() {
+  if [ "${_BASHUNIT_TESTS_FAILED:-0}" -gt 0 ]; then
+    printf "\n%sSnapshots were not pruned: the run has failing tests, so a%s\n" \
+      "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+    printf "%ssnapshot may be unresolved rather than unused.%s\n" \
+      "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+    return
+  fi
+
+  bashunit::snapshot::collect_unused "$@"
+
+  if [ "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" -eq 0 ]; then
+    printf "\n%sNo unused snapshots.%s\n" \
+      "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
+    return
+  fi
+
+  printf "\n%sDeleted %s unused snapshot(s):%s\n" \
+    "${_BASHUNIT_COLOR_SKIPPED}" "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" \
+    "${_BASHUNIT_COLOR_DEFAULT}"
+
+  local entry path
+  while IFS= read -r entry; do
+    # The collector indents its lines for the report; the path is what is left.
+    path="${entry#"${entry%%[![:space:]]*}"}"
+    [ -n "$path" ] || continue
+    case "$path" in
+    *.snapshot) ;;
+    *) continue ;;
+    esac
+    [ -f "$path" ] || continue
+
+    printf "  %s\n" "$path"
+    rm -f "$path"
+  done <<EOF
+$_BASHUNIT_SNAPSHOT_UNUSED_OUT
+EOF
 }
 
 # The shared tail of both snapshot assertions: record a first-time snapshot,
@@ -175,7 +246,12 @@ function bashunit::snapshot::assert() {
   local snapshot_file="$2"
   local test_fn="$3"
 
-  if bashunit::env::is_snapshot_report_unused_enabled; then
+  # Recording the resolved snapshot is what both --snapshot-report-unused and
+  # --snapshot-prune subtract from the files on disk. Pruning without it would
+  # find every snapshot "unused" and delete the lot -- so the two flags must
+  # gate this identically.
+  if bashunit::env::is_snapshot_report_unused_enabled ||
+    bashunit::env::is_snapshot_prune_enabled; then
     printf '%s\n' "$snapshot_file" >>"${SNAPSHOT_USED_OUTPUT_PATH:-/dev/null}" 2>/dev/null || true
   fi
 

--- a/src/config/env.sh
+++ b/src/config/env.sh
@@ -255,6 +255,7 @@ _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
 _BASHUNIT_DEFAULT_NO_PROGRESS="false"
 _BASHUNIT_DEFAULT_OUTPUT_FORMAT=""
 _BASHUNIT_DEFAULT_FAIL_ON_RISKY="false"
+_BASHUNIT_DEFAULT_SNAPSHOT_PRUNE="false"
 _BASHUNIT_DEFAULT_BENCH_BASELINE=""
 _BASHUNIT_DEFAULT_BENCH_BASELINE_TOLERANCE="10"
 _BASHUNIT_DEFAULT_BENCH_BASELINE_UPDATE=""
@@ -328,6 +329,7 @@ _BASHUNIT_DEFAULT_SNAPSHOT_REPORT_UNUSED="false"
 : "${BASHUNIT_FAIL_ON_RISKY:=${FAIL_ON_RISKY:=$_BASHUNIT_DEFAULT_FAIL_ON_RISKY}}"
 # No unprefixed alias on purpose: SANDBOX is generic enough that an unrelated
 # tool exporting it would silently constrain the suite (#866).
+: "${BASHUNIT_SNAPSHOT_PRUNE:=$_BASHUNIT_DEFAULT_SNAPSHOT_PRUNE}"
 : "${BASHUNIT_BENCH_BASELINE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE}"
 : "${BASHUNIT_BENCH_BASELINE_TOLERANCE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE_TOLERANCE}"
 : "${BASHUNIT_BENCH_BASELINE_UPDATE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE_UPDATE}"
@@ -685,6 +687,10 @@ function bashunit::env::is_machine_output_enabled() {
   tap | json | junit) return 0 ;;
   esac
   return 1
+}
+
+function bashunit::env::is_snapshot_prune_enabled() {
+  [ "${BASHUNIT_SNAPSHOT_PRUNE:-false}" = "true" ]
 }
 
 function bashunit::env::is_snapshot_report_unused_enabled() {

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -157,6 +157,7 @@ Options:
   --snapshot-update           Rewrite existing snapshots from the actual value (combine with --filter)
   --no-snapshot-create        Fail on a missing snapshot instead of recording it (for CI)
   --snapshot-report-unused    List snapshot files no test resolved (full runs only, deletes nothing)
+  --snapshot-prune            Delete the snapshot files no test resolved (full runs only)
   -vvv, --verbose             Show execution details
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -192,6 +192,12 @@ function bashunit::main::exec_tests() {
     bashunit::snapshot::report_unused ${test_files[@]+"${test_files[@]}"}
   fi
 
+  # In the parent, after the parallel results were aggregated: each worker
+  # resolves its own snapshots, so the used-set only exists here (#1004).
+  if bashunit::env::is_snapshot_prune_enabled; then
+    bashunit::snapshot::prune_unused ${test_files[@]+"${test_files[@]}"}
+  fi
+
   # To stdout, not to a file: GitHub reads workflow commands from the job log.
   # After load_spooled so a --parallel run annotates the rows its workers
   # spooled, which the parent would otherwise never have seen (#1004).

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -296,6 +296,10 @@ function bashunit::main::cmd_test() {
       BASHUNIT_SNAPSHOT_CREATE=false
       export -n BASHUNIT_SNAPSHOT_CREATE
       ;;
+    --snapshot-prune)
+      BASHUNIT_SNAPSHOT_PRUNE=true
+      export -n BASHUNIT_SNAPSHOT_PRUNE
+      ;;
     --snapshot-report-unused)
       BASHUNIT_SNAPSHOT_REPORT_UNUSED=true
       export -n BASHUNIT_SNAPSHOT_REPORT_UNUSED
@@ -606,7 +610,12 @@ function bashunit::main::cmd_test() {
   # A run that executes a subset resolves a subset of the snapshots, so every
   # snapshot the subset skipped would be reported as unused. Refusing beats
   # printing a list that invites deleting live files.
-  if bashunit::env::is_snapshot_report_unused_enabled; then
+  if bashunit::env::is_snapshot_report_unused_enabled ||
+    bashunit::env::is_snapshot_prune_enabled; then
+    local _snapshot_flag="--snapshot-report-unused"
+    if bashunit::env::is_snapshot_prune_enabled; then
+      _snapshot_flag="--snapshot-prune"
+    fi
     local _partial_flag=""
     [ -n "$filter" ] && _partial_flag="--filter"
     [ -n "$tag_filter" ] && _partial_flag="--tag"
@@ -615,8 +624,9 @@ function bashunit::main::cmd_test() {
     bashunit::rerun::is_enabled && _partial_flag="--rerun-failed"
     bashunit::env::is_changed_enabled && _partial_flag="--changed"
     if [ -n "$_partial_flag" ]; then
-      printf "%sError: --snapshot-report-unused needs a full run; %s only runs a subset.%s\n" \
-        "${_BASHUNIT_COLOR_FAILED}" "$_partial_flag" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+      printf "%sError: %s needs a full run; %s only runs a subset.%s\n" \
+        "${_BASHUNIT_COLOR_FAILED}" "$_snapshot_flag" "$_partial_flag" \
+        "${_BASHUNIT_COLOR_DEFAULT}" >&2
       exit 1
     fi
   fi

--- a/tests/acceptance/bashunit_snapshot_prune_test.sh
+++ b/tests/acceptance/bashunit_snapshot_prune_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# --snapshot-report-unused stops halfway: it names the dead snapshots and says
+# "delete them yourself", one path at a time. Pruning finishes the job, under
+# the same full-run rule -- a subset run resolves a subset of the snapshots,
+# and deleting the rest would be data loss dressed as cleanup.
+
+function set_up_before_script() {
+  BASHUNIT_BIN="$(pwd)/bashunit"
+  FIXTURES_DIR="$(pwd)/tests/acceptance/fixtures/snapshot_update"
+}
+
+function set_up() {
+  WORKDIR="$(mktemp -d)"
+  cp "$FIXTURES_DIR/snap.sh" "$WORKDIR/snap.sh"
+  mkdir -p "$WORKDIR/snapshots"
+  ALPHA="$WORKDIR/snapshots/snap_sh.test_snapshot_alpha.snapshot"
+  BETA="$WORKDIR/snapshots/snap_sh.test_snapshot_beta.snapshot"
+  ORPHAN="$WORKDIR/snapshots/snap_sh.test_snapshot_deleted.snapshot"
+  echo "alpha value" >"$ALPHA"
+  echo "beta value" >"$BETA"
+  echo "left behind" >"$ORPHAN"
+}
+
+function tear_down() {
+  rm -rf "$WORKDIR"
+}
+
+function run_prune() { # $@ = extra flags
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-prune "$@" snap.sh 2>&1) || true
+}
+
+function test_prune_deletes_exactly_what_the_report_lists() {
+  local output
+  output=$(run_prune)
+
+  assert_file_not_exists "$ORPHAN"
+  assert_file_exists "$ALPHA"
+  assert_file_exists "$BETA"
+  assert_contains "snap_sh.test_snapshot_deleted.snapshot" "$output"
+}
+
+function test_prune_prints_every_deleted_path() {
+  local output
+  output=$(run_prune)
+
+  assert_contains "Deleted" "$output"
+  assert_contains "snapshots/snap_sh.test_snapshot_deleted.snapshot" "$output"
+}
+
+function test_prune_deletes_nothing_when_no_snapshot_is_unused() {
+  rm -f "$ORPHAN"
+
+  local output
+  output=$(run_prune)
+
+  assert_file_exists "$ALPHA"
+  assert_contains "No unused snapshots" "$output"
+}
+
+function test_prune_leaves_a_snapshot_of_a_file_outside_the_run_alone() {
+  local foreign="$WORKDIR/snapshots/other_test_sh.test_something.snapshot"
+  echo "not mine" >"$foreign"
+
+  run_prune >/dev/null
+
+  assert_file_exists "$foreign"
+}
+
+# A failing run may never have reached the assertions that resolve those
+# snapshots, so what looks unused might simply not have run.
+function test_prune_deletes_nothing_when_the_run_has_failures() {
+  cat >>"$WORKDIR/snap.sh" <<'TEST'
+
+function test_that_fails() {
+  assert_same "expected" "actual"
+}
+TEST
+
+  local output
+  output=$(run_prune)
+
+  assert_file_exists "$ORPHAN"
+  assert_contains "failing" "$output"
+}
+
+function test_prune_refuses_to_run_with_filter() {
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-prune --filter alpha snap.sh 2>&1) ) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "--snapshot-prune needs a full run" "$output"
+  assert_file_exists "$ORPHAN"
+}
+
+function test_prune_refuses_to_run_with_a_shard() {
+  local ec=0
+  local output
+  output=$( (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-prune --shard 1/2 snap.sh 2>&1) ) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "--snapshot-prune needs a full run" "$output"
+  assert_file_exists "$ORPHAN"
+}
+
+# Both flags together: update rewrites what the tests resolved, prune removes
+# what nothing resolved. They touch disjoint sets.
+function test_prune_and_update_together_touch_disjoint_sets() {
+  echo "stale" >"$ALPHA"
+
+  run_prune --snapshot-update >/dev/null
+
+  assert_file_not_exists "$ORPHAN"
+  assert_file_exists "$ALPHA"
+  assert_not_contains "stale" "$(cat "$ALPHA")"
+}
+
+function test_prune_works_under_parallel() {
+  local output
+  output=$( (cd "$WORKDIR" && "$BASHUNIT_BIN" --parallel --skip-env-file \
+    --snapshot-prune snap.sh 2>&1) ) || true
+
+  assert_file_not_exists "$ORPHAN"
+  assert_file_exists "$ALPHA"
+}
+
+function test_no_pruning_without_the_flag() {
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file snap.sh) >/dev/null 2>&1 || true
+
+  assert_file_exists "$ORPHAN"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1030

`--snapshot-report-unused` names the dead snapshots and says "delete them yourself" — one path at a time, hoping you missed none and removed none that was merely filtered out of that run.

## 💡 Changes

- `--snapshot-prune` deletes exactly what the report lists and prints every path. Both flags now share one `collect_unused`: two implementations of "unused" is how a cleanup removes a live snapshot.
- Guards against deleting a snapshot that was only *not reached*: the existing full-run rule (now naming whichever flag is on) plus a refusal to delete anything when the run has failures.
- `--snapshot-update` composes — update rewrites what the tests resolved, prune removes what nothing resolved, disjoint by construction.
- **Bug found by the tests:** recording a resolved snapshot was gated on `--snapshot-report-unused` alone, so pruning without it found *every* snapshot unused and deleted the lot. Both flags now gate that write.