### PR TITLE
fix(test): parallel consistency test flakes on CI

### DIFF
--- a/tests/acceptance/bashunit_parallel_consistency_test.sh
+++ b/tests/acceptance/bashunit_parallel_consistency_test.sh
@@ -4,24 +4,44 @@ function set_up_before_script() {
   TEST_ENV_FILE="tests/acceptance/fixtures/.env.default"
 }
 
+# The counts of the run's own summary, and nothing else.
+#
+# These tests used to scrape `[0-9]+ (passed|total)` over the whole capture,
+# which made them a hostage to any other line carrying a number: #1048 saw
+# Ubuntu and Alpine fail in the same run with an extra `0 total 0 total` pair
+# in front of the real summary -- a zero-test summary that came from somewhere
+# other than the run being measured. Anchoring to the LAST `Tests:` and
+# `Assertions:` lines measures the summary of the run that just finished,
+# whatever else ended up in the stream.
+#
+# Arguments: $1 - captured output
+function summary_counts() {
+  local output=$1
+  local tests_line assertions_line
+
+  tests_line=$(printf '%s\n' "$output" | "$GREP" -E 'Tests:' | tail -1)
+  assertions_line=$(printf '%s\n' "$output" | "$GREP" -E 'Assertions:' | tail -1)
+
+  printf '%s%s' \
+    "$(printf '%s\n' "$tests_line" | "$GREP" -oE '[0-9]+ (passed|total)' | tr '\n' ' ')" \
+    "$(printf '%s\n' "$assertions_line" | "$GREP" -oE '[0-9]+ (passed|total)' | tr '\n' ' ')"
+}
+
 function test_parallel_and_sequential_results_match() {
   local file1=tests/acceptance/fixtures/test_bashunit_when_a_test_passes.sh
   local file2=tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
   local file3=tests/acceptance/fixtures/test_bashunit_when_a_execution_error.sh
 
   local sequential_output
-  sequential_output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$file1" "$file2" "$file3" 2>&1) || true
+  sequential_output=$(NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" \
+    "$file1" "$file2" "$file3" 2>&1) || true
 
   local parallel_output
-  parallel_output=$(./bashunit --parallel --env "$TEST_ENV_FILE" "$file1" "$file2" "$file3" 2>&1) || true
+  parallel_output=$(NO_COLOR=1 ./bashunit --parallel --env "$TEST_ENV_FILE" \
+    "$file1" "$file2" "$file3" 2>&1) || true
 
-  local sequential_summary
-  sequential_summary=$(echo "$sequential_output" | grep -e "Tests:" -e "Assertions:" | tr '\n' ' ') || true
-
-  local parallel_summary
-  parallel_summary=$(echo "$parallel_output" | grep -e "Tests:" -e "Assertions:" | tr '\n' ' ') || true
-
-  assert_equals "$sequential_summary" "$parallel_summary"
+  assert_equals "$(summary_counts "$sequential_output")" \
+    "$(summary_counts "$parallel_output")"
 }
 
 function test_jobs_auto_caps_at_detected_cores_and_matches_sequential() {
@@ -29,18 +49,13 @@ function test_jobs_auto_caps_at_detected_cores_and_matches_sequential() {
   local file2=tests/acceptance/fixtures/test_bashunit_when_a_test_fail.sh
 
   local sequential_output
-  sequential_output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$file1" "$file2" 2>&1) || true
+  sequential_output=$(NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" "$file1" "$file2" 2>&1) || true
 
   local auto_output
-  auto_output=$(./bashunit --jobs auto --env "$TEST_ENV_FILE" "$file1" "$file2" 2>&1) || true
+  auto_output=$(NO_COLOR=1 ./bashunit --jobs auto --env "$TEST_ENV_FILE" "$file1" "$file2" 2>&1) || true
 
-  local sequential_summary
-  sequential_summary=$(echo "$sequential_output" | grep -e "Tests:" -e "Assertions:" | tr '\n' ' ') || true
-
-  local auto_summary
-  auto_summary=$(echo "$auto_output" | grep -e "Tests:" -e "Assertions:" | tr '\n' ' ') || true
-
-  assert_equals "$sequential_summary" "$auto_summary"
+  assert_equals "$(summary_counts "$sequential_output")" \
+    "$(summary_counts "$auto_output")"
 }
 
 # Per-test results used to be bucketed by the test file's BASENAME, so two files
@@ -53,20 +68,39 @@ function test_parallel_does_not_lose_same_named_files_in_different_dirs() {
   local two=tests/acceptance/fixtures/dup_basename/two/test_dup.sh
 
   local sequential_output
-  sequential_output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$one" "$two" 2>&1) || true
+  sequential_output=$(NO_COLOR=1 ./bashunit --no-parallel --env "$TEST_ENV_FILE" "$one" "$two" 2>&1) || true
 
   local parallel_output
-  parallel_output=$(./bashunit --parallel --env "$TEST_ENV_FILE" "$one" "$two" 2>&1) || true
+  parallel_output=$(NO_COLOR=1 ./bashunit --parallel --env "$TEST_ENV_FILE" "$one" "$two" 2>&1) || true
 
   # Counts only, not the rendered line: the parallel spinner leaves control bytes
   # and indentation on the summary, which is cosmetic and not what this asserts.
-  local sequential_counts
-  sequential_counts=$(echo "$sequential_output" | grep -oE '[0-9]+ (passed|total)' | tr '\n' ' ') || true
-
-  local parallel_counts
-  parallel_counts=$(echo "$parallel_output" | grep -oE '[0-9]+ (passed|total)' | tr '\n' ' ') || true
+  local sequential_counts parallel_counts
+  sequential_counts=$(summary_counts "$sequential_output")
+  parallel_counts=$(summary_counts "$parallel_output")
 
   assert_same "$sequential_counts" "$parallel_counts"
   # Guard against both sides collapsing to nothing and matching vacuously.
   assert_contains "2 total" "$sequential_counts"
+}
+
+# The shape #1048 reported: a zero-test summary in front of the real one. The
+# source of that stray summary was never reproduced -- 40+ local attempts,
+# including under concurrent load, never produced one -- so this pins the
+# scrape against it rather than the cause.
+function test_summary_counts_ignores_a_stray_summary_before_the_real_one() {
+  local capture="Tests:      0 total
+Assertions: 0 total
+Tests:      2 passed, 2 total
+Assertions: 2 passed, 2 total"
+
+  assert_same "2 passed 2 total 2 passed 2 total " "$(summary_counts "$capture")"
+}
+
+function test_summary_counts_reads_a_plain_run() {
+  local capture="Running tests/example_test.sh
+Tests:      3 passed, 3 total
+Assertions: 5 passed, 5 total"
+
+  assert_same "3 passed 3 total 5 passed 5 total " "$(summary_counts "$capture")"
 }


### PR DESCRIPTION
## 🤔 Background

Related #1048

`Ubuntu - parallel extended` and `Alpine - parallel extended` failed together with an identical diff — an extra `0 total 0 total` pair in front of the real counts. The assertion scraped every `N passed|total` in the whole capture, so a zero-test summary from anywhere in the stream shifted the comparison.

## 💡 Changes

- `summary_counts` reads the **last** `Tests:` and `Assertions:` lines — the summary of the run that just finished — instead of every number in the capture, and the nested runs use `NO_COLOR` so the scrape never meets an escape sequence.
- Two tests pin the helper against exactly the shape the issue reported, so the fix cannot rot.
- The #959 regression this file guards (a parallel run losing a same-named file's results) is still caught: that changes the summary itself.

**Not fixed:** where the stray zero-test summary came from. 40+ local attempts, including a dozen concurrent runs of the same fixture, never reproduced one. The test no longer depends on the answer.