### PR TITLE
perf(coverage): the string-scan caches cost 26ms per lookup at 121 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Performance: the coverage report's per-file lookup is flat instead of quadratic. The stats, tracked-file and path caches stored their entries in one string scanned with a leading-`*` glob, which on Bash 3.2 cost 0.38ms per lookup at 11 entries, 3.4ms at 40 and 26.7ms at 121; they now use the variable table, measured at 0.25ms at every size — 109x faster at 121 tracked files, with byte-identical reports (#1056)
+
 ### Added
 - `--snapshot-prune` deletes the snapshot files no test resolved, printing every path; like `--snapshot-report-unused` it is a full-run-only flag, and it additionally refuses to delete anything on a run with failures, where an unresolved snapshot only means the test never got there (#1030)
 - `bashunit bench --baseline <file>` fails a run when a benchmark is more than `--baseline-tolerance` percent (default 10) slower than the recorded run, comparing medians and printing a per-benchmark delta; `--baseline-update <file>` records the new reference, a new benchmark is reported rather than failed, and a missing or malformed baseline exits non-zero instead of quietly passing (#1029)

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -91,8 +91,11 @@ function bashunit::coverage::init() {
   _BASHUNIT_COVERAGE_BUFFER=""
   _BASHUNIT_COVERAGE_BUFFER_COUNT=0
   _BASHUNIT_COVERAGE_HITS_BUFFER=""
-  _BASHUNIT_COVERAGE_TRACK_CACHE=""
-  _BASHUNIT_COVERAGE_PATH_CACHE=""
+  # The lookups live in the variable table now, so clearing them means dropping
+  # their namespaces: a second run in the same shell must not inherit a
+  # tracking decision or a normalized path from the first.
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TRACK_"
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_PATH_"
   _BASHUNIT_COVERAGE_IS_PARALLEL=""
   _BASHUNIT_COVERAGE_STATS_FILES=()
   _BASHUNIT_COVERAGE_STATS_EXEC=()
@@ -100,7 +103,7 @@ function bashunit::coverage::init() {
   _BASHUNIT_COVERAGE_STATS_PCT=()
   _BASHUNIT_COVERAGE_STATS_CLASS=()
   _BASHUNIT_COVERAGE_STATS_COUNT=0
-  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_STATS_"
 
   _BASHUNIT_COVERAGE_ENGINE_RESOLVED=$(bashunit::coverage::resolve_engine)
 

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -223,33 +223,29 @@ function bashunit::coverage::record_line() {
   [ -z "$_BASHUNIT_COVERAGE_DATA_FILE" ] && return 0
 
   # Fast in-memory should_track cache (avoids grep + file I/O per line)
-  case "$_BASHUNIT_COVERAGE_TRACK_CACHE" in
-  *"|${file}:0|"*) return 0 ;;
-  *"|${file}:1|"*) ;;
-  *)
-    # Not cached yet — run full check and cache result
+  local decision=""
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TRACK_" "$file"; then
+    decision="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+  else
     if bashunit::coverage::should_track "$file"; then
-      _BASHUNIT_COVERAGE_TRACK_CACHE="${_BASHUNIT_COVERAGE_TRACK_CACHE}|${file}:1|"
+      decision=1
     else
-      _BASHUNIT_COVERAGE_TRACK_CACHE="${_BASHUNIT_COVERAGE_TRACK_CACHE}|${file}:0|"
-      return 0
+      decision=0
     fi
-    ;;
-  esac
+    bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TRACK_" "$file" "$decision"
+  fi
+  if [ "$decision" = "0" ]; then
+    return 0
+  fi
 
   # Fast in-memory path normalization cache (avoids cd + pwd subshell per line)
   local normalized_file=""
-  case "$_BASHUNIT_COVERAGE_PATH_CACHE" in
-  *"|${file}="*)
-    # Extract cached value
-    normalized_file="${_BASHUNIT_COVERAGE_PATH_CACHE#*"|${file}="}"
-    normalized_file="${normalized_file%%"|"*}"
-    ;;
-  *)
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_PATH_" "$file"; then
+    normalized_file="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+  else
     normalized_file=$(bashunit::coverage::normalize_path "$file")
-    _BASHUNIT_COVERAGE_PATH_CACHE="${_BASHUNIT_COVERAGE_PATH_CACHE}|${file}=${normalized_file}|"
-    ;;
-  esac
+    bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_PATH_" "$file" "$normalized_file"
+  fi
 
   # Buffer the coverage data in memory
   _BASHUNIT_COVERAGE_BUFFER="${_BASHUNIT_COVERAGE_BUFFER}${normalized_file}:${lineno}

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -2,9 +2,77 @@
 
 # Which files coverage tracks, and the hot-path caches behind that decision.
 
-# In-memory caches for hot-path lookups (avoids grep + subshells)
-_BASHUNIT_COVERAGE_TRACK_CACHE=""
-_BASHUNIT_COVERAGE_PATH_CACHE=""
+# In-memory lookups for the hot paths.
+#
+# These used to be one long string per cache, scanned with a leading-`*` glob.
+# That scan is quadratic in the number of entries on Bash 3.2: measured at
+# 0.38ms per lookup at 11 entries, 3.4ms at 40 and 26.7ms at 121 -- the cache
+# cost more than the work it replaced (#1056).
+#
+# Bash's own variable table is the associative array this repo cannot declare,
+# the same trick the spy state uses (_BASHUNIT_SPY_${variable}_TIMES_FILE).
+# The key is the path with everything but [a-zA-Z0-9] collapsed to `_`, so two
+# different paths can produce the same key; the original path is stored beside
+# the value and compared on read, which makes a collision a miss rather than a
+# wrong answer.
+_BASHUNIT_COVERAGE_LOOKUP_OUT=""
+
+_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT=""
+
+##
+# The variable-name-safe key for a path, into
+# _BASHUNIT_COVERAGE_LOOKUP_KEY_OUT.
+#
+# A return slot, not a `$(...)`: lookup_get runs once per traced line on the
+# capture path, and a command substitution there would be a fork per line --
+# exactly what the fork budget forbids.
+# Arguments: $1 - namespace prefix, $2 - path
+##
+function bashunit::coverage::lookup_key_to_slot() {
+  _BASHUNIT_COVERAGE_LOOKUP_KEY_OUT="$1${2//[^a-zA-Z0-9]/_}"
+}
+
+##
+# Stores a value under a path key.
+# Arguments: $1 - namespace prefix, $2 - path, $3 - value
+##
+function bashunit::coverage::lookup_put() {
+  bashunit::coverage::lookup_key_to_slot "$1" "$2"
+  local key=$_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT
+  eval "${key}_PATH=\$2"
+  eval "${key}_VALUE=\$3"
+}
+
+##
+# Reads the value stored for a path into _BASHUNIT_COVERAGE_LOOKUP_OUT.
+# Returns 1 when absent, or when the slot holds a different path (a key
+# collision, which must read as a miss).
+# Arguments: $1 - namespace prefix, $2 - path
+##
+function bashunit::coverage::lookup_get() {
+  bashunit::coverage::lookup_key_to_slot "$1" "$2"
+  local path_var="${_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT}_PATH"
+  local value_var="${_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT}_VALUE"
+
+  _BASHUNIT_COVERAGE_LOOKUP_OUT=""
+  if [ "${!path_var:-}" != "$2" ]; then
+    return 1
+  fi
+  _BASHUNIT_COVERAGE_LOOKUP_OUT="${!value_var:-}"
+  return 0
+}
+
+##
+# Drops every entry of one namespace, so a second run in the same shell cannot
+# inherit a stale decision.
+# Arguments: $1 - namespace prefix
+##
+function bashunit::coverage::reset_lookup_namespace() {
+  local name
+  for name in $(compgen -v "$1" 2>/dev/null || true); do
+    unset "$name"
+  done
+}
 
 # Normalize file path to absolute
 function bashunit::coverage::normalize_path() {

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -70,7 +70,6 @@ _BASHUNIT_COVERAGE_STATS_HIT=()
 _BASHUNIT_COVERAGE_STATS_PCT=()
 _BASHUNIT_COVERAGE_STATS_CLASS=()
 _BASHUNIT_COVERAGE_STATS_COUNT=0
-_BASHUNIT_COVERAGE_STATS_LOOKUP=""
 
 
 # Pre-compute stats for all tracked files (call once before reports)
@@ -81,7 +80,7 @@ function bashunit::coverage::precompute_file_stats() {
   _BASHUNIT_COVERAGE_STATS_PCT=()
   _BASHUNIT_COVERAGE_STATS_CLASS=()
   _BASHUNIT_COVERAGE_STATS_COUNT=0
-  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_STATS_"
 
   local file
   while IFS= read -r file; do
@@ -96,22 +95,21 @@ function bashunit::coverage::precompute_file_stats() {
     _BASHUNIT_COVERAGE_STATS_PCT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT"
     _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT"
     _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
-    _BASHUNIT_COVERAGE_STATS_LOOKUP="${_BASHUNIT_COVERAGE_STATS_LOOKUP}|${file}=${idx}|"
+    bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_STATS_" "$file" "$idx"
   done < <(bashunit::coverage::get_tracked_files)
 }
 
 # Look up cached stats for a file, returns "executable:hit:pct:class"
 function bashunit::coverage::get_cached_stats() {
   local file="$1"
-  case "$_BASHUNIT_COVERAGE_STATS_LOOKUP" in
-  *"|${file}="*)
-    local idx="${_BASHUNIT_COVERAGE_STATS_LOOKUP#*"|${file}="}"
-    idx="${idx%%"|"*}"
+
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_STATS_" "$file"; then
+    local idx="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
     echo "${_BASHUNIT_COVERAGE_STATS_EXEC[idx]}:${_BASHUNIT_COVERAGE_STATS_HIT[idx]}\
 :${_BASHUNIT_COVERAGE_STATS_PCT[idx]}:${_BASHUNIT_COVERAGE_STATS_CLASS[idx]}"
     return 0
-    ;;
-  esac
+  fi
+
   bashunit::coverage::get_file_stats "$file"
 }
 

--- a/tests/unit/coverage/lookup_test.sh
+++ b/tests/unit/coverage/lookup_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# The hot-path lookups behind should_track, path normalization and the stats
+# cache. They used to be one long string scanned with a leading-`*` glob, which
+# is quadratic on Bash 3.2: 0.38ms per lookup at 11 entries, 26.7ms at 121 --
+# the cache cost more than the work it replaced (#1056).
+
+function tear_down() {
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TEST_"
+}
+
+function test_a_stored_value_is_read_back() {
+  bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh" "1"
+
+  bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh"
+
+  assert_same "1" "$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+}
+
+function test_an_absent_key_is_a_miss() {
+  local ec=0
+  bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TEST_" "/src/never.sh" || ec=$?
+
+  assert_equals "1" "$ec"
+  assert_empty "$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+}
+
+# The key collapses everything but [a-zA-Z0-9] to `_`, so these two paths share
+# one key. The stored path is compared on read, which turns a collision into a
+# miss instead of the previous file's answer.
+function test_two_paths_sharing_a_key_do_not_answer_for_each_other() {
+  bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TEST_" "/src/a-b.sh" "1"
+
+  local ec=0
+  bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TEST_" "/src/a_b.sh" || ec=$?
+
+  assert_equals "1" "$ec"
+}
+
+function test_a_value_with_spaces_survives() {
+  bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh" "/tmp/a dir/a.sh"
+
+  bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh"
+
+  assert_same "/tmp/a dir/a.sh" "$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+}
+
+function test_resetting_a_namespace_drops_its_entries() {
+  bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh" "1"
+
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TEST_"
+
+  local ec=0
+  bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TEST_" "/src/a.sh" || ec=$?
+  assert_equals "1" "$ec"
+}
+
+# The namespaces are deliberately _BASHUNIT_COVLOOKUP_*, not
+# _BASHUNIT_COVERAGE_*: `compgen -v` matches by prefix, so resetting
+# "_BASHUNIT_COVERAGE_TRACKED_" would also unset _BASHUNIT_COVERAGE_TRACKED_FILES
+# -- the real config value the report and the cleanup both read.
+function test_resetting_a_namespace_leaves_the_coverage_config_alone() {
+  local original="${_BASHUNIT_COVERAGE_TRACKED_FILES:-}"
+  _BASHUNIT_COVERAGE_TRACKED_FILES="/tmp/files.dat"
+
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TRACK_"
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_PATH_"
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_STATS_"
+
+  local kept="$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  _BASHUNIT_COVERAGE_TRACKED_FILES="$original"
+
+  assert_same "/tmp/files.dat" "$kept"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1056 · first of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) coverage order

Three coverage caches stored entries in one string scanned with a leading-`*` glob — quadratic on Bash 3.2. Measured on this machine, confirming the issue's numbers: **0.38 ms per lookup at 11 entries, 3.4 ms at 40, 26.7 ms at 121**.

## 💡 Changes

- The stats, tracked-file and path lookups now use Bash's variable table (the same emulation the spy state uses): **0.25 ms at every size — 109x faster at 121 files**, and faster even at 11.
- Key collisions read as a miss, not as another file's answer: the path is stored beside the value and compared on read.
- `lookup_key` writes a return slot rather than returning through `$(...)` — `lookup_get` runs once per traced line, where a command substitution would be a fork per line.
- **Reports are byte-identical to main**, verified by diffing both the LCOV file and the text report of the same run.

One trap the tests now pin: the namespaces are `_BASHUNIT_COVLOOKUP_*`, not `_BASHUNIT_COVERAGE_*`. `compgen -v` matches by prefix, so resetting `_BASHUNIT_COVERAGE_TRACKED_` also unset `_BASHUNIT_COVERAGE_TRACKED_FILES` — the real config value.