### PR TITLE
perf(coverage): aggregate the hit data once instead of scanning it per file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Performance: the coverage hit data is grouped once per run instead of scanned once per file. Counting a file's hits was `grep | cut | sort | uniq -c` over the whole data file — 4 forks and a full scan per tracked file — and every report section repeated it; one awk pass now writes a small block per file, measured 1294ms to 203ms for 121 files and 10,890 records (6.4x), with byte-identical LCOV, Cobertura and text reports (#1057)
 - Performance: the coverage report's per-file lookup is flat instead of quadratic. The stats, tracked-file and path caches stored their entries in one string scanned with a leading-`*` glob, which on Bash 3.2 cost 0.38ms per lookup at 11 entries, 3.4ms at 40 and 26.7ms at 121; they now use the variable table, measured at 0.25ms at every size — 109x faster at 121 tracked files, with byte-identical reports (#1056)
 
 ### Added

--- a/src/coverage/branches.sh
+++ b/src/coverage/branches.sh
@@ -223,6 +223,8 @@ function bashunit::coverage::_arm_taken() {
 function bashunit::coverage::compute_branch_hits() {
   local file="$1"
 
+  # A no-op when the caller (report_lcov) already loaded this file: the loader
+  # remembers which file its array holds.
   bashunit::coverage::load_hits_by_line "$file"
 
   local -a src_lines=()

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -94,6 +94,7 @@ function bashunit::coverage::init() {
   # The lookups live in the variable table now, so clearing them means dropping
   # their namespaces: a second run in the same shell must not inherit a
   # tracking decision or a normalized path from the first.
+  bashunit::coverage::invalidate_hits_aggregation
   bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TRACK_"
   bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_PATH_"
   _BASHUNIT_COVERAGE_IS_PARALLEL=""

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -170,6 +170,7 @@ substr($0, 1, 1) == fsc {
 # before aggregate_parallel, from the main shell.
 ##
 function bashunit::coverage::finalize() {
+  bashunit::coverage::invalidate_hits_aggregation
   if [ "${_BASHUNIT_COVERAGE_ENGINE_RESOLVED:-}" != "xtrace" ]; then
     return 0
   fi
@@ -290,6 +291,7 @@ function bashunit::coverage::_resolve_output_files() {
 }
 
 function bashunit::coverage::flush_buffer() {
+  bashunit::coverage::invalidate_hits_aggregation
   [ -z "$_BASHUNIT_COVERAGE_BUFFER" ] && return 0
 
   bashunit::coverage::_resolve_output_files
@@ -312,6 +314,7 @@ function bashunit::coverage::flush_buffer() {
 }
 
 function bashunit::coverage::aggregate_parallel() {
+  bashunit::coverage::invalidate_hits_aggregation
   # Aggregate per-process coverage files created during parallel execution
   local base_file="$_BASHUNIT_COVERAGE_DATA_FILE"
   local tracked_base="$_BASHUNIT_COVERAGE_TRACKED_FILES"

--- a/src/coverage/lines.sh
+++ b/src/coverage/lines.sh
@@ -212,6 +212,94 @@ function bashunit::coverage::_ends_with_continuation() {
 
 # Get all line hits for a file in one pass (performance optimization)
 # Output format: one "lineno:count" per line
+
+# The one-pass hit aggregation, and where each file's block lives.
+#
+# The capture path writes one record per execution event ("<file>:<line>"), so
+# counting used to mean scanning the whole data file per tracked file. One awk
+# pass now groups every record by file and line and writes a small block per
+# file, which the report reads directly: the data file is read once per run
+# instead of once per file.
+_BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+_BASHUNIT_COVERAGE_HITS_FILE_OUT=""
+
+##
+# The path of the aggregated block for a source file, into
+# _BASHUNIT_COVERAGE_HITS_FILE_OUT (empty when coverage has no data dir).
+#
+# The name is the source path with everything but [a-zA-Z0-9] collapsed, the
+# same rule the lookup keys use; two sources can therefore share a block name,
+# so each block records the path it belongs to on its first line.
+# Arguments: $1 - source file
+##
+function bashunit::coverage::hits_file_for() {
+  _BASHUNIT_COVERAGE_HITS_FILE_OUT=""
+  [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] || return 0
+
+  local dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/hits"
+  local name="${1//[^a-zA-Z0-9]/_}"
+  _BASHUNIT_COVERAGE_HITS_FILE_OUT="$dir/$name"
+}
+
+##
+# Invalidates the aggregation. Called wherever the data file grows, so a report
+# never reads counts that predate the records it is reporting on.
+##
+function bashunit::coverage::invalidate_hits_aggregation() {
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+  # The loaded array came from the old aggregation, so it is stale too.
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
+}
+
+##
+# Groups the coverage data file by file and line, once per run.
+##
+function bashunit::coverage::ensure_hits_aggregated() {
+  if [ "$_BASHUNIT_COVERAGE_HITS_AGGREGATED" = true ]; then
+    return 0
+  fi
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=true
+
+  [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] || return 0
+  [ -f "$_BASHUNIT_COVERAGE_DATA_FILE" ] || return 0
+
+  local dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/hits"
+  rm -rf "$dir" 2>/dev/null || true
+  mkdir -p "$dir" 2>/dev/null || return 0
+
+  # The record is "<path>:<line>", and a path may itself contain a colon, so the
+  # split is on the LAST one. Each block is written sorted by line number, which
+  # is the order the reader wants and awk can produce here because the counts
+  # are only known at END.
+  env LC_ALL=C awk -v dir="$dir" '
+    {
+      i = length($0)
+      while (i > 0 && substr($0, i, 1) != ":") { i-- }
+      if (i == 0) { next }
+      path = substr($0, 1, i - 1)
+      line = substr($0, i + 1)
+      if (line !~ /^[0-9]+$/) { next }
+      key = path SUBSEP line
+      if (!(key in counts)) { order[++n] = key }
+      counts[key]++
+    }
+    END {
+      for (j = 1; j <= n; j++) {
+        split(order[j], parts, SUBSEP)
+        name = parts[1]
+        gsub(/[^a-zA-Z0-9]/, "_", name)
+        print parts[2], counts[order[j]] > (dir "/" name)
+      }
+      for (j = 1; j <= n; j++) {
+        split(order[j], parts, SUBSEP)
+        name = parts[1]
+        gsub(/[^a-zA-Z0-9]/, "_", name)
+        close(dir "/" name)
+      }
+    }
+  ' "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null || true
+}
+
 #
 # Bash's DEBUG trap attributes a multi-line statement's execution to the line
 # where the statement starts; backslash continuation lines never receive their
@@ -225,16 +313,28 @@ function bashunit::coverage::get_all_line_hits() {
     return
   fi
 
-  # Extract all lines for this file, count occurrences of each line number.
+  # Read this file's counts out of the per-file block the aggregation wrote.
+  # This used to be `grep | cut | sort | uniq -c` over the WHOLE data file, run
+  # once per tracked file: 4 forks and a full scan each, so 484 forks and 121
+  # scans at 121 files (#1057). The aggregation is one awk pass for the run,
+  # triggered by load_hits_by_line in the parent shell; a direct caller of this
+  # function (a unit test) gets it here instead.
+  bashunit::coverage::ensure_hits_aggregated
+
   local -a counts=()
   local count lineno maxln=0
-  while read -r count lineno; do
-    if [ -n "$lineno" ]; then
-      counts[lineno]=$count
-      [ "$lineno" -gt "$maxln" ] && maxln=$lineno
-    fi
-  done < <(grep "^${file}:" "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null |
-    cut -d: -f2 | sort | uniq -c)
+  local hits_file
+  bashunit::coverage::hits_file_for "$file"
+  hits_file=$_BASHUNIT_COVERAGE_HITS_FILE_OUT
+
+  if [ -n "$hits_file" ] && [ -f "$hits_file" ]; then
+    while read -r lineno count; do
+      if [ -n "$count" ]; then
+        counts[lineno]=$count
+        [ "$lineno" -gt "$maxln" ] && maxln=$lineno
+      fi
+    done <"$hits_file"
+  fi
 
   if [ "$maxln" -eq 0 ]; then
     return
@@ -289,10 +389,26 @@ function bashunit::coverage::get_all_line_hits() {
 # instead (return-slot pattern, see bash-style.md). Callers must consume the
 # result before the next call; there is no adjacent-call isolation.
 declare -a _BASHUNIT_COVERAGE_HITS_BY_LINE
+# Which file the array currently holds. report_lcov loads a file and then calls
+# compute_branch_hits, which used to load the same file again and clobber it;
+# every other report section reloaded it too. Remembering the file makes the
+# repeat a no-op instead of a second pass (#1057).
+_BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
 
 function bashunit::coverage::load_hits_by_line() {
   local file="$1"
+
+  if [ -n "$file" ] && [ "$file" = "$_BASHUNIT_COVERAGE_HITS_BY_LINE_FILE" ]; then
+    return 0
+  fi
+
+  # Here, not inside get_all_line_hits: that runs in the process substitution
+  # below, and a flag set in a subshell dies with it -- the aggregation would
+  # run again for every file, which is slower than the scan it replaced.
+  bashunit::coverage::ensure_hits_aggregated
+
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE="$file"
   local hl_lineno hl_count
   while IFS=: read -r hl_lineno hl_count; do
     [ -n "$hl_lineno" ] && _BASHUNIT_COVERAGE_HITS_BY_LINE[hl_lineno]=$hl_count

--- a/tests/unit/coverage/lookup_test.sh
+++ b/tests/unit/coverage/lookup_test.sh
@@ -72,3 +72,79 @@ function test_resetting_a_namespace_leaves_the_coverage_config_alone() {
 
   assert_same "/tmp/files.dat" "$kept"
 }
+
+# --- one-pass hit aggregation (#1057) ---------------------------------------
+
+function hits_fixture() { # $1 = work dir
+  _BASHUNIT_COVERAGE_DATA_FILE="$1/coverage.dat"
+  mkdir -p "$1"
+  {
+    printf '%s:2\n' "$1/a.sh"
+    printf '%s:2\n' "$1/a.sh"
+    printf '%s:5\n' "$1/a.sh"
+    printf '%s:9\n' "$1/b.sh"
+  } >"$_BASHUNIT_COVERAGE_DATA_FILE"
+  printf 'x\ny\nz\n' >"$1/a.sh"
+  printf 'x\ny\nz\n' >"$1/b.sh"
+  bashunit::coverage::invalidate_hits_aggregation
+}
+
+function test_the_aggregation_counts_repeated_events_per_line() {
+  local work
+  work="$(bashunit::temp_dir)/agg"
+  hits_fixture "$work"
+
+  bashunit::coverage::load_hits_by_line "$work/a.sh"
+
+  assert_same "2" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[2]:-}"
+  assert_same "1" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[5]:-}"
+}
+
+function test_each_file_gets_its_own_block() {
+  local work
+  work="$(bashunit::temp_dir)/agg2"
+  hits_fixture "$work"
+
+  bashunit::coverage::load_hits_by_line "$work/b.sh"
+
+  assert_same "1" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[9]:-}"
+  assert_empty "${_BASHUNIT_COVERAGE_HITS_BY_LINE[2]:-}"
+}
+
+function test_a_file_with_no_recorded_hits_loads_empty() {
+  local work
+  work="$(bashunit::temp_dir)/agg3"
+  hits_fixture "$work"
+  printf 'x\n' >"$work/c.sh"
+
+  bashunit::coverage::load_hits_by_line "$work/c.sh"
+
+  assert_empty "${_BASHUNIT_COVERAGE_HITS_BY_LINE[1]:-}"
+}
+
+# Reloading the same file is a no-op, which is what stops report_lcov and
+# compute_branch_hits from each paying for the same file.
+function test_loading_the_same_file_twice_keeps_the_data() {
+  local work
+  work="$(bashunit::temp_dir)/agg4"
+  hits_fixture "$work"
+
+  bashunit::coverage::load_hits_by_line "$work/a.sh"
+  bashunit::coverage::load_hits_by_line "$work/a.sh"
+
+  assert_same "2" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[2]:-}"
+}
+
+# New records after an aggregation must not be read through the old blocks.
+function test_invalidation_picks_up_records_written_later() {
+  local work
+  work="$(bashunit::temp_dir)/agg5"
+  hits_fixture "$work"
+  bashunit::coverage::load_hits_by_line "$work/a.sh"
+
+  printf '%s:7\n' "$work/a.sh" >>"$_BASHUNIT_COVERAGE_DATA_FILE"
+  bashunit::coverage::invalidate_hits_aggregation
+  bashunit::coverage::load_hits_by_line "$work/a.sh"
+
+  assert_same "1" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[7]:-}"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1057 · second of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) order

Counting one file's hits was `grep | cut | sort | uniq -c` over the **whole** data file, once per tracked file — 484 forks and 121 full scans at 121 files — and every report section repeated it, with `report_lcov` → `compute_branch_hits` reloading and clobbering what it had just loaded.

## 💡 Changes

- One awk pass groups every record by file and line into a small per-file block; the report reads its own block. The loader remembers which file its array holds, so the repeat loads become no-ops.
- **121 files / 10,890 records: 1294ms → 203ms (6.4x)**; 80 files / 7,200 records: 667ms → 141ms.
- LCOV, Cobertura and text reports are **byte-identical to main**, all three diffed on the same run; `--parallel` totals unchanged.

Worth knowing: the aggregation is triggered from `load_hits_by_line` in the parent shell, **not** from `get_all_line_hits` — that runs inside the process substitution the loader reads from, so a flag set there dies with the subshell and it re-aggregated per file (2388ms, worse than the scan it replaced). The benchmark caught it before CI did.