### PR TITLE
perf(coverage): reject untracked files inside the DEBUG trap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Performance: `--coverage` rejects a line from an untracked file inside the DEBUG trap instead of inside the recorder it used to call. A run where nothing matches the coverage paths went from 2609ms to 497ms on the same test file — the no-coverage baseline is 480ms — and a run tracking `src` from 9604ms to 7624ms (#1060)
 - Performance: the coverage hit data is grouped once per run instead of scanned once per file. Counting a file's hits was `grep | cut | sort | uniq -c` over the whole data file — 4 forks and a full scan per tracked file — and every report section repeated it; one awk pass now writes a small block per file, measured 1294ms to 203ms for 121 files and 10,890 records (6.4x), with byte-identical LCOV, Cobertura and text reports (#1057)
 - Performance: the coverage report's per-file lookup is flat instead of quadratic. The stats, tracked-file and path caches stored their entries in one string scanned with a leading-`*` glob, which on Bash 3.2 cost 0.38ms per lookup at 11 entries, 3.4ms at 40 and 26.7ms at 121; they now use the variable table, measured at 0.25ms at every size — 109x faster at 121 tracked files, with byte-identical reports (#1056)
 

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -94,6 +94,8 @@ function bashunit::coverage::init() {
   # The lookups live in the variable table now, so clearing them means dropping
   # their namespaces: a second run in the same shell must not inherit a
   # tracking decision or a normalized path from the first.
+  bashunit::coverage::build_trap_glob
+  export _BASHUNIT_COVERAGE_TRAP_GLOB
   bashunit::coverage::invalidate_hits_aggregation
   bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TRACK_"
   bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_PATH_"

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -51,7 +51,26 @@ function bashunit::coverage::enable_trap() {
 
   # Set DEBUG trap to record line execution
   # Use ${VAR:-} to handle unset variables when set -u is active (in subshells)
-  trap 'bashunit::coverage::record_line "${BASH_SOURCE[0]:-}" "${LINENO:-}"' DEBUG
+  #
+  # The `case` runs inside the trap, before any function call: a line from a
+  # file no coverage path can admit is rejected there instead of paying a call
+  # into record_line to be rejected inside it (#1060).
+  # shellcheck disable=SC2064  # the body is built here on purpose: what must
+  # survive to trap time is the ${BASH_SOURCE}/${LINENO} inside the
+  # single-quoted string, and the glob has to be baked in as syntax.
+  local record='bashunit::coverage::record_line "${BASH_SOURCE[0]:-}" "${LINENO:-}"'
+  if [ -n "${_BASHUNIT_COVERAGE_TRAP_GLOB:-}" ]; then
+    # The alternation has to reach the trap as syntax, not as an expanded
+    # variable: `case $x in $pattern)` does not split a `|` that arrived
+    # through a parameter.
+    local guarded='case "${BASH_SOURCE[0]:-}" in '
+    guarded="$guarded${_BASHUNIT_COVERAGE_TRAP_GLOB}) $record ;; esac"
+    # shellcheck disable=SC2064
+    trap "$guarded" DEBUG
+  else
+    # shellcheck disable=SC2064
+    trap "$record" DEBUG
+  fi
 }
 
 function bashunit::coverage::disable_trap() {

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -94,6 +94,62 @@ function bashunit::coverage::get_tracked_files() {
   sort -u "$_BASHUNIT_COVERAGE_TRACKED_FILES"
 }
 
+##
+# The `case` pattern the DEBUG trap uses to reject a file before calling into
+# the recorder, built once per run from BASHUNIT_COVERAGE_PATHS.
+#
+# The trap fires for every executed line, including every line of bashunit's
+# own code running inside the test body and the hooks; most of those events
+# used to pay a function call, two locals and a cache lookup only to be
+# rejected (#1060). This pattern is a pre-filter, deliberately a SUPERSET of
+# what should_track admits -- exclusions and the real decision stay there.
+#
+# Each configured path contributes four alternatives, because the trap sees
+# ${BASH_SOURCE[0]} exactly as the source wrote it: resolved absolute, as
+# given, and the two forms of "somewhere under a directory of that name",
+# which is what keeps a test that `cd`s (issue #529) from losing coverage.
+#
+# Writes _BASHUNIT_COVERAGE_TRAP_GLOB; empty means "no filtering", which is
+# what an unset BASHUNIT_COVERAGE_PATHS must produce so behaviour cannot change.
+##
+_BASHUNIT_COVERAGE_TRAP_GLOB=""
+
+function bashunit::coverage::build_trap_glob() {
+  _BASHUNIT_COVERAGE_TRAP_GLOB=""
+
+  [ -n "${BASHUNIT_COVERAGE_PATHS:-}" ] || return 0
+
+  local glob=""
+  local cwd
+  cwd=$(pwd)
+  local old_ifs="$IFS"
+  IFS=','
+  local path resolved relative
+  for path in $BASHUNIT_COVERAGE_PATHS; do
+    [ -n "$path" ] || continue
+    case "$path" in
+    /*) resolved="$path" ;;
+    *) resolved="$cwd/$path" ;;
+    esac
+
+    # An absolute coverage path still has to admit the relative spellings: the
+    # trap sees ${BASH_SOURCE[0]} as the source wrote it, and a file sourced as
+    # "src/util/str.sh" never matches "/repo/src/util*".
+    relative="$path"
+    case "$relative" in
+    "$cwd"/*) relative="${relative#"$cwd"/}" ;;
+    esac
+
+    if [ -n "$glob" ]; then
+      glob="$glob|"
+    fi
+    glob="$glob${resolved}*|${relative}*|./${relative}*|*/${relative}/*|*/${relative}"
+  done
+  IFS="$old_ifs"
+
+  _BASHUNIT_COVERAGE_TRAP_GLOB="$glob"
+}
+
 function bashunit::coverage::should_track() {
   local file="$1"
 

--- a/tests/unit/coverage/lookup_test.sh
+++ b/tests/unit/coverage/lookup_test.sh
@@ -148,3 +148,74 @@ function test_invalidation_picks_up_records_written_later() {
 
   assert_same "1" "${_BASHUNIT_COVERAGE_HITS_BY_LINE[7]:-}"
 }
+
+# --- DEBUG trap pre-filter (#1060) ------------------------------------------
+
+function glob_matches() { # $1 = glob, $2 = candidate
+  local matched="no"
+  eval "case \"\$2\" in $1) matched=yes ;; esac"
+  printf '%s' "$matched"
+}
+
+function test_the_trap_glob_admits_a_relative_coverage_path() {
+  local original="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS="src/util"
+  bashunit::coverage::build_trap_glob
+  local glob="$_BASHUNIT_COVERAGE_TRAP_GLOB"
+  BASHUNIT_COVERAGE_PATHS="$original"
+
+  assert_contains "src/util*" "$glob"
+  assert_contains "*/src/util/*" "$glob"
+}
+
+# An absolute coverage path still has to admit the relative spellings: the trap
+# sees ${BASH_SOURCE[0]} as the source wrote it.
+function test_the_trap_glob_of_an_absolute_path_admits_the_relative_form() {
+  local original="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS="$(pwd)/src/util"
+  bashunit::coverage::build_trap_glob
+  local glob="$_BASHUNIT_COVERAGE_TRAP_GLOB"
+  BASHUNIT_COVERAGE_PATHS="$original"
+
+  assert_contains "$(pwd)/src/util*" "$glob"
+  assert_contains "|src/util*" "$glob"
+}
+
+function test_the_trap_glob_covers_every_configured_path() {
+  local original="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS="src/util,src/system"
+  bashunit::coverage::build_trap_glob
+  local glob="$_BASHUNIT_COVERAGE_TRAP_GLOB"
+  BASHUNIT_COVERAGE_PATHS="$original"
+
+  assert_contains "*/src/util/*" "$glob"
+  assert_contains "*/src/system/*" "$glob"
+}
+
+# No configured path means no filtering, so the trap keeps its old shape and
+# behaviour cannot change.
+function test_no_coverage_path_produces_no_glob() {
+  local original="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS=""
+  bashunit::coverage::build_trap_glob
+  local glob="$_BASHUNIT_COVERAGE_TRAP_GLOB"
+  BASHUNIT_COVERAGE_PATHS="$original"
+
+  assert_empty "$glob"
+}
+
+function test_the_glob_matches_the_paths_the_trap_will_see() {
+  local original="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS="src/util"
+  bashunit::coverage::build_trap_glob
+  local glob="$_BASHUNIT_COVERAGE_TRAP_GLOB"
+  BASHUNIT_COVERAGE_PATHS="$original"
+
+  # eval, because `|` is alternation only when the pattern is parsed as
+  # syntax -- which is exactly how the trap uses it, and is not what a `case`
+  # against an expanded variable would do.
+  assert_same "yes" "$(glob_matches "$glob" "$(pwd)/src/util/str.sh")"
+  assert_same "yes" "$(glob_matches "$glob" "src/util/str.sh")"
+  assert_same "yes" "$(glob_matches "$glob" "./src/util/str.sh")"
+  assert_same "no" "$(glob_matches "$glob" "/somewhere/else/tests/foo_test.sh")"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1060 · third of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) order

The DEBUG trap calls into `record_line` for every executed line — including every line of bashunit's own code inside the test body and the hooks — which then decides the file was never tracked, after a function call, two locals and a cache lookup.

## 💡 Changes

- A `case` built from `BASHUNIT_COVERAGE_PATHS` guards the call inside the trap. On `tests/unit/assert/basic_test.sh`:

  | run | before | after |
  |---|---|---|
  | no coverage | 480 ms | 480 ms |
  | `--coverage`, nothing tracked | 2609 ms | **497 ms** |
  | `--coverage --coverage-paths src` | 9604 ms | **7624 ms** |

- The pattern is a pre-filter and a deliberate superset — exclusions and the real decision stay in `should_track`. Each path contributes its absolute form, relative form, `./form`, `*/form/*` and `*/form`: an absolute `--coverage-paths` must still admit `src/util/str.sh`, since the trap sees `${BASH_SOURCE[0]}` as the source wrote it. Without that, an absolute path reported `0/0` — caught before pushing, and pinned by a test.
- The alternation is baked into the trap body as syntax: `case $x in $pattern)` does not split a `|` that arrived through a parameter.
- LCOV and text reports identical to main.