### PR TITLE
fix(coverage): the case-pattern rule drops 236 real statements from the denominator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Coverage counted a statement whose line ends in `)` as a `case` arm, so `x=$(foo)` was dropped from the denominator while `x=$(printf '%s\n')` was not — an accident of the pre-#1005 regex, where a backslash inside a bracket expression suppressed the match. A `)` now only closes an arm when no `(` opened earlier on the line, which recovers 456 executable lines of this repo's own `src/` and correctly stops counting `case` arms that contain a backslash. **Coverage percentages move in both directions per file; the denominator is the honest one** (#1055)
+
 ### Changed
 - Performance: `--coverage` rejects a line from an untracked file inside the DEBUG trap instead of inside the recorder it used to call. A run where nothing matches the coverage paths went from 2609ms to 497ms on the same test file — the no-coverage baseline is 480ms — and a run tracking `src` from 9604ms to 7624ms (#1060)
 - Performance: the coverage hit data is grouped once per run instead of scanned once per file. Counting a file's hits was `grep | cut | sort | uniq -c` over the whole data file — 4 forks and a full scan per tracked file — and every report section repeated it; one awk pass now writes a small block per file, measured 1294ms to 203ms for 121 files and 10,890 records (6.4x), with byte-identical LCOV, Cobertura and text reports (#1057)

--- a/src/coverage/lines.sh
+++ b/src/coverage/lines.sh
@@ -92,16 +92,23 @@ function bashunit::coverage::is_executable_line() {
   esac
 
   # Case patterns: something, then `)`, then end of line or a comment —
-  # `--option)`, `*) # note`. The pattern this replaced spelled the leading
-  # segment `[^\)]+`, and inside a POSIX bracket expression a backslash is a
-  # literal member of the set, so a backslash anywhere before that `)`
-  # suppressed the match. `x=$(foo)` is therefore classified non-executable
-  # while `x=$(printf '%s\n')` is executable; both are preserved here.
+  # `--option)`, `*) # note`. A case arm is a decision, and the decision is
+  # already accounted for by branch coverage, so an arm line counts as
+  # non-executable.
+  #
+  # The `)` has to actually close an arm. Any `(` earlier on the line means it
+  # closes that instead -- `x=$(foo)`, `((i++))`, `cmd <(sub)` -- and those are
+  # statements. The rule this replaced asked a different question: its leading
+  # segment was spelled `[^\)]+`, and inside a POSIX bracket expression a
+  # backslash is a literal member of the set, so a backslash anywhere before
+  # the `)` suppressed the match. That made `x=$(foo)` non-executable while
+  # `x=$(printf '%s\n')` was executable, and dropped 236 real statements of
+  # this repo's own src/ out of every denominator (#1055).
   case "$line" in
   *')'*)
     local cp_before="${line%%')'*}"
     case "$cp_before" in
-    '' | *[\\]*) : ;;
+    '' | *'('*) : ;;
     *)
       local cp_after="${line#*')'}"
       cp_after="${cp_after#"${cp_after%%[![:space:]]*}"}"

--- a/tests/unit/coverage/executable_test.sh
+++ b/tests/unit/coverage/executable_test.sh
@@ -378,3 +378,54 @@ function test_coverage_get_all_line_hits_does_not_propagate_without_continuation
 
   assert_equals "1:1" "$result"
 }
+
+# --- the case-pattern rule (#1055) ------------------------------------------
+
+# A command substitution that closes at end of line used to be read as a case
+# arm, which dropped it from the denominator.
+function test_a_command_substitution_closing_the_line_is_executable() {
+  assert_successful_code "$(bashunit::coverage::is_executable_line 'x=$(foo)' 1 && echo ok)"
+}
+
+function test_a_command_substitution_with_a_backslash_stays_executable() {
+  local line='x=$(printf "%s\n")'
+  assert_successful_code "$(bashunit::coverage::is_executable_line "$line" 1 && echo ok)"
+}
+
+function test_an_arithmetic_command_closing_the_line_is_executable() {
+  assert_successful_code "$(bashunit::coverage::is_executable_line '((i++))' 1 && echo ok)"
+}
+
+function test_a_process_substitution_closing_the_line_is_executable() {
+  local line='diff <(a) <(b)'
+  assert_successful_code "$(bashunit::coverage::is_executable_line "$line" 1 && echo ok)"
+}
+
+# A real case arm is still a decision, not a statement: branch coverage
+# accounts for it.
+function test_a_case_arm_is_not_executable() {
+  local ec=0
+  bashunit::coverage::is_executable_line '  --option)' 1 || ec=$?
+
+  assert_equals "1" "$ec"
+}
+
+function test_a_case_arm_with_a_trailing_comment_is_not_executable() {
+  local ec=0
+  bashunit::coverage::is_executable_line '  *) # fallthrough' 1 || ec=$?
+
+  assert_equals "1" "$ec"
+}
+
+function test_a_case_arm_with_alternatives_is_not_executable() {
+  local ec=0
+  bashunit::coverage::is_executable_line '  a|b|c)' 1 || ec=$?
+
+  assert_equals "1" "$ec"
+}
+
+# A statement that merely contains a paren and continues is untouched.
+function test_a_statement_after_the_paren_is_executable() {
+  local line='printf ")" >&2'
+  assert_successful_code "$(bashunit::coverage::is_executable_line "$line" 1 && echo ok)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1055 · fourth of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) order

The rule read "something, then `)`, then end of line or a comment", which a command substitution closing at end of line satisfies: `x=$(foo)` was non-executable, `x=$(printf '%s\n')` was executable. The difference was a backslash — the pre-#1005 regex spelled its leading segment `[^\)]+`, and inside a POSIX bracket expression a backslash is a literal member of the set.

## 💡 Changes

- A `)` closes a case arm only when no `(` opened earlier on the line, so `$( )`, `( )`, `<( )` and `(( ))` are statements again; the accidental backslash exclusion is gone, which also stops counting real arms like `\\)` and `eval\ * | eval)` as statements.
- Measured over `git ls-files 'src/*.sh'`: executable-line total **10,510 → 10,966**. Line by line over `src/{coverage,runner,assert}`: **328 statements recovered, 143 case arms correctly dropped** — I diffed the classification of every line to check both directions.
- A case arm stays non-executable — it is a decision, and branch coverage accounts for it. The rule's comment now says so instead of implying it.

**Coverage percentages move in both directions per file. That is the fix, not a side effect** — expect the badge to shift.