### PR TITLE
fix(coverage): files that never ran are missing from the report, so 0% code is invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- Coverage now reports every file under `--coverage-paths`, not only the files a test happened to execute: a file nothing reached shows as `0/N (0%)` instead of being absent, in the text, LCOV, Cobertura and HTML reports, and `--coverage-min` gates on that denominator. This repo reported 11 of its own 121 files and a denominator of 2,200 against a real 9,285. **Percentages drop, because the old ones were measured over the files that ran** (#1053)
 - Coverage counted a statement whose line ends in `)` as a `case` arm, so `x=$(foo)` was dropped from the denominator while `x=$(printf '%s\n')` was not — an accident of the pre-#1005 regex, where a backslash inside a bracket expression suppressed the match. A `)` now only closes an arm when no `(` opened earlier on the line, which recovers 456 executable lines of this repo's own `src/` and correctly stops counting `case` arms that contain a backslash. **Coverage percentages move in both directions per file; the denominator is the honest one** (#1055)
 
 ### Changed

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -45,13 +45,17 @@ bashunit records which lines ran, then classifies and reports them:
 1. **Capture**: every executed line's file path and line number is recorded, either from a `DEBUG` trap or from `xtrace` — see [Tracing engine](#tracing-engine)
 2. **Filtering**: a recorded file is tracked only when it matches your coverage paths and no exclude pattern
 3. **Aggregation**: after tests complete, hit data is aggregated
-4. **Reporting**: each source line is classified as executable or not, and the executable ones are matched against the hits
+4. **Seeding**: every file under your coverage paths joins the report, whether or not a test reached it
+5. **Reporting**: each source line is classified as executable or not, and the executable ones are matched against the hits
 
-::: warning Only executed files are reported
-A file enters the report the first time one of its lines runs. A source file that no test
-touched at all is **absent** from the report rather than shown at 0%, so the percentage is
-measured over the files that ran, not over everything under `BASHUNIT_COVERAGE_PATHS`.
-Tracked in [#1053](https://github.com/TypedDevs/bashunit/issues/1053).
+::: tip A file no test touched is reported at 0%
+The denominator is every non-excluded file under `BASHUNIT_COVERAGE_PATHS`, not only the
+files that happened to run — so untested code lowers the percentage instead of being
+invisible. Before [#1053](https://github.com/TypedDevs/bashunit/issues/1053) this repo
+reported 11 files of its own 121 and a denominator of 2,200 against a real 9,285.
+
+Seeding happens once, when the report is built, so a capture-only run pays nothing for it.
+A file created *after* that point is not seeded, though it is still tracked if it executes.
 :::
 
 ::: tip Performance

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -84,6 +84,7 @@ function bashunit::coverage::init() {
   # Initialize empty files
   : >"$_BASHUNIT_COVERAGE_DATA_FILE"
   : >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  _BASHUNIT_COVERAGE_SEEDED=false
   : >"$_BASHUNIT_COVERAGE_TRACKED_CACHE_FILE"
   : >"$_BASHUNIT_COVERAGE_TEST_HITS_FILE"
 

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -150,6 +150,104 @@ function bashunit::coverage::build_trap_glob() {
   _BASHUNIT_COVERAGE_TRAP_GLOB="$glob"
 }
 
+##
+# Writes every file under BASHUNIT_COVERAGE_PATHS into the tracked list, before
+# a single test runs.
+#
+# A file entered that list the first time one of its lines executed, so a file
+# no test ever reached was absent from the report and could not lower the
+# percentage: coverage was measured over the files that ran, not over the files
+# the user asked about. On this repo that was 11 files of 121, and a
+# denominator of 2,200 against a real 9,285 (#1053).
+#
+# The capture path still adds files as it sees them, so nothing changes for
+# executed code; get_tracked_files already sorts and dedupes. Cost is one find
+# per run, bounded by the project rather than by the test count. A file created
+# after this point is not seeded -- it is still tracked if it executes.
+##
+_BASHUNIT_COVERAGE_SEEDED=false
+
+function bashunit::coverage::seed_tracked_files() {
+  # Once per run, and at report time rather than at init: the denominator is a
+  # reporting concern, and seeding in init made every capture-only run -- and
+  # every unit test that calls init -- walk the whole project for nothing.
+  if [ "$_BASHUNIT_COVERAGE_SEEDED" = true ]; then
+    return 0
+  fi
+  _BASHUNIT_COVERAGE_SEEDED=true
+
+  [ -n "${BASHUNIT_COVERAGE_PATHS:-}" ] || return 0
+  [ -n "${_BASHUNIT_COVERAGE_TRACKED_FILES:-}" ] || return 0
+
+  local old_ifs="$IFS"
+  IFS=','
+  local path
+  for path in $BASHUNIT_COVERAGE_PATHS; do
+    [ -n "$path" ] || continue
+    IFS="$old_ifs"
+    bashunit::coverage::_seed_one_path "$path"
+    IFS=','
+  done
+  IFS="$old_ifs"
+}
+
+##
+# Seeds one configured path.
+#
+# The exclusion test is inlined rather than delegated to should_track: that
+# normalizes every path it is given, which is a subshell per file, and seeding
+# walks the whole project. `find` is given an absolute root, so what it prints
+# is already normalized, and the patterns are applied with a `case` -- the same
+# `*pattern*` match should_track uses, so the seeded set and the captured set
+# agree.
+# Arguments: $1 - configured path
+##
+function bashunit::coverage::_seed_one_path() {
+  local path="$1"
+  local root
+
+  case "$path" in
+  /*) root="$path" ;;
+  *) root="$(pwd)/$path" ;;
+  esac
+
+  if [ -f "$root" ]; then
+    root="$(bashunit::coverage::normalize_path "$root")"
+    bashunit::coverage::_seed_emit "$root"
+    return 0
+  fi
+  [ -d "$root" ] || return 0
+  root="$(cd "$root" && pwd)"
+
+  local file
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    bashunit::coverage::_seed_emit "$file"
+  done < <(find "$root" -type f -name '*.sh' 2>/dev/null)
+}
+
+##
+# Writes one already-absolute path to the tracked list unless an exclude
+# pattern matches it.
+##
+function bashunit::coverage::_seed_emit() {
+  local file="$1"
+  local old_ifs="$IFS"
+  IFS=','
+  local pattern
+  for pattern in ${BASHUNIT_COVERAGE_EXCLUDE:-}; do
+    case "$file" in
+    *$pattern*)
+      IFS="$old_ifs"
+      return 0
+      ;;
+    esac
+  done
+  IFS="$old_ifs"
+
+  printf '%s\n' "$file" >>"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+}
+
 function bashunit::coverage::should_track() {
   local file="$1"
 
@@ -211,6 +309,14 @@ function bashunit::coverage::should_track() {
       resolved_path="$(pwd)/$path"
       ;;
     esac
+    # Collapse doubled slashes the way normalize_path's cd/pwd does, or a
+    # configured path that arrived with one ("$TMPDIR/src" where TMPDIR ends in
+    # a slash) never prefixes the normalized file and the whole tree reads as
+    # untracked. Parameter expansion, not a cd/pwd subshell: should_track runs
+    # once per file on a cache miss, and a fork here is a fork per file.
+    while [ "$resolved_path" != "${resolved_path//\/\//\/}" ]; do
+      resolved_path="${resolved_path//\/\//\/}"
+    done
 
     case "$normalized_file" in
     "$resolved_path"*)

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -74,6 +74,10 @@ _BASHUNIT_COVERAGE_STATS_COUNT=0
 
 # Pre-compute stats for all tracked files (call once before reports)
 function bashunit::coverage::precompute_file_stats() {
+  # The report is about the files the user asked for, not only the ones that
+  # happened to run (#1053).
+  bashunit::coverage::seed_tracked_files
+
   _BASHUNIT_COVERAGE_STATS_FILES=()
   _BASHUNIT_COVERAGE_STATS_EXEC=()
   _BASHUNIT_COVERAGE_STATS_HIT=()

--- a/tests/unit/coverage/reporting_test.sh
+++ b/tests/unit/coverage/reporting_test.sh
@@ -258,9 +258,14 @@ function test_coverage_get_tracked_files_returns_empty_when_no_file() {
   assert_empty "$result"
 }
 
+# BASHUNIT_COVERAGE_PATHS is emptied first: init seeds the tracked list from it
+# now (#1053), and this asserts on exactly what the test itself wrote.
 function test_coverage_get_tracked_files_returns_sorted_unique() {
   BASHUNIT_COVERAGE="true"
+  local original_paths="${BASHUNIT_COVERAGE_PATHS:-}"
+  BASHUNIT_COVERAGE_PATHS=""
   bashunit::coverage::init
+  BASHUNIT_COVERAGE_PATHS="$original_paths"
 
   {
     echo "/path/to/b.sh"
@@ -379,8 +384,12 @@ EOF
   rm -f "$temp_file"
 }
 
+# BASHUNIT_COVERAGE_PATHS stays empty across precompute: it seeds the tracked
+# list from that variable now (#1053), and this asserts on exactly the one file
+# the test wrote. The test subshell dies with the value, so nothing restores it.
 function test_coverage_precompute_file_stats_populates_cache() {
   BASHUNIT_COVERAGE="true"
+  BASHUNIT_COVERAGE_PATHS=""
   bashunit::coverage::init
 
   local temp_file

--- a/tests/unit/coverage/seeded_tracking_test.sh
+++ b/tests/unit/coverage/seeded_tracking_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# A source file entered the tracked list the first time one of its lines
+# executed, so a file no test ever reached was absent from the report and could
+# not lower the percentage. Coverage was measured over the files that ran, not
+# over the files the user asked about (#1053).
+
+function set_up() {
+  WORK="$(bashunit::temp_dir)/seed"
+  mkdir -p "$WORK/src/sub"
+  printf 'function ran() {\n  echo "yes"\n}\n' >"$WORK/src/ran.sh"
+  printf 'function never() {\n  echo "no"\n}\n' >"$WORK/src/never.sh"
+  printf 'function nested() {\n  echo "deep"\n}\n' >"$WORK/src/sub/nested.sh"
+  printf 'function helper() {\n  echo "x"\n}\n' >"$WORK/src/helper_test.sh"
+
+  _ORIG_PATHS="${BASHUNIT_COVERAGE_PATHS:-}"
+  _ORIG_EXCLUDE="${BASHUNIT_COVERAGE_EXCLUDE:-}"
+  _ORIG_COVERAGE="${BASHUNIT_COVERAGE:-false}"
+}
+
+function tear_down() {
+  BASHUNIT_COVERAGE_PATHS="$_ORIG_PATHS"
+  BASHUNIT_COVERAGE_EXCLUDE="$_ORIG_EXCLUDE"
+  BASHUNIT_COVERAGE="$_ORIG_COVERAGE"
+}
+
+function seed_with() { # $1 = paths, $2 = excludes
+  BASHUNIT_COVERAGE="true"
+  BASHUNIT_COVERAGE_PATHS="$1"
+  BASHUNIT_COVERAGE_EXCLUDE="${2:-}"
+  bashunit::coverage::init
+  # Seeding happens once, at report time: the denominator is a reporting
+  # concern, and doing it in init made every capture-only run walk the project.
+  bashunit::coverage::seed_tracked_files
+  bashunit::coverage::get_tracked_files
+}
+
+function test_a_file_no_test_executed_is_tracked_from_the_start() {
+  local tracked
+  tracked=$(seed_with "$WORK/src")
+
+  assert_contains "never.sh" "$tracked"
+}
+
+function test_seeding_descends_into_subdirectories() {
+  local tracked
+  tracked=$(seed_with "$WORK/src")
+
+  assert_contains "sub/nested.sh" "$tracked"
+}
+
+function test_the_exclude_patterns_remove_a_seeded_file() {
+  local tracked
+  tracked=$(seed_with "$WORK/src" "*_test.sh")
+
+  assert_not_contains "helper_test.sh" "$tracked"
+  assert_contains "never.sh" "$tracked"
+}
+
+function test_a_single_file_path_is_seeded() {
+  local tracked
+  tracked=$(seed_with "$WORK/src/never.sh")
+
+  assert_contains "never.sh" "$tracked"
+  assert_not_contains "ran.sh" "$tracked"
+}
+
+# Seeded paths are normalized, because the capture path records normalized
+# paths: the same file listed twice reports once with no hits at all.
+function test_a_seeded_path_is_absolute() {
+  local tracked
+  tracked=$(seed_with "$WORK/src")
+
+  assert_not_contains "./" "$tracked"
+  # Normalized, so the expectation has to be too: $TMPDIR can carry a trailing
+  # slash, and the seed collapses it exactly as the capture path does.
+  assert_contains "$(bashunit::coverage::normalize_path "$WORK/src/never.sh")" "$tracked"
+}
+
+# Defined behaviour: seeding happens once, before the run. A file that appears
+# afterwards is still tracked if it executes, but is not seeded.
+function test_a_file_created_after_seeding_is_not_seeded() {
+  local tracked
+  tracked=$(seed_with "$WORK/src")
+  printf 'function late() { :; }\n' >"$WORK/src/late.sh"
+
+  # Seeding runs once per run; a file that appears afterwards is still tracked
+  # if it executes, but the report does not invent it.
+  assert_not_contains "late.sh" "$tracked"
+}
+
+function test_no_coverage_paths_seeds_nothing() {
+  local tracked
+  tracked=$(seed_with "")
+
+  assert_empty "$tracked"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1053 · sixth of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) order, after the perf work it depends on

A file entered the tracked list the first time one of its lines executed, so a file no test reached was **absent** from the report and could not lower the percentage. This repo reported 11 of its own 121 files: a denominator of 2,200 against a real 9,285.

## 💡 Changes

- The tracked list is seeded from `BASHUNIT_COVERAGE_PATHS`, so an untouched file shows as `0/N (0%)` in text, LCOV (`DA` at 0, `LH:0`), Cobertura and HTML, and `--coverage-min` gates on that denominator.
- Seeding runs **once, from `precompute_file_stats`**, not from `init`: the denominator is a reporting concern, and seeding at init made every capture-only run walk the whole project — that took the coverage unit suite from 19s to **8m32s** before I caught it. It is back to 19s.
- Exclusions are applied inline against `find`'s already-absolute output rather than through `should_track`, which normalizes every path it is handed (a subshell per file).
- **Also fixes** a pre-existing gap the seeding exposed: a coverage path with a doubled slash (`$TMPDIR/src` where `TMPDIR` ends in one) never prefixed the normalized file, so the whole tree read as untracked.

**Coverage percentages drop — the old ones were measured over the files that ran.** Expect the badge to move; that is the point of the issue.