### PR TITLE
fix(coverage): --coverage-diff passes a new file that no test executed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- `--coverage-diff` counts a changed file that no test executed instead of skipping it: the report iterated the files that had run, so a brand new untested file left the changed-line total at 0 and the empty-set-is-100% rule passed it through a `--coverage-min 90` gate — the exact case the gate exists to catch. A docs-only commit still reports 100% and still passes (#1054)
 - Coverage now reports every file under `--coverage-paths`, not only the files a test happened to execute: a file nothing reached shows as `0/N (0%)` instead of being absent, in the text, LCOV, Cobertura and HTML reports, and `--coverage-min` gates on that denominator. This repo reported 11 of its own 121 files and a denominator of 2,200 against a real 9,285. **Percentages drop, because the old ones were measured over the files that ran** (#1053)
 - Coverage counted a statement whose line ends in `)` as a `case` arm, so `x=$(foo)` was dropped from the denominator while `x=$(printf '%s\n')` was not — an accident of the pre-#1005 regex, where a backslash inside a bracket expression suppressed the match. A `)` now only closes an arm when no `(` opened earlier on the line, which recovers 456 executable lines of this repo's own `src/` and correctly stops counting `case` arms that contain a backslash. **Coverage percentages move in both directions per file; the denominator is the honest one** (#1055)
 

--- a/src/coverage/diff.sh
+++ b/src/coverage/diff.sh
@@ -85,6 +85,64 @@ function bashunit::coverage::changed_line_stats() {
 }
 
 ##
+# The files diff coverage reports on: everything changed since $1 that coverage
+# would track.
+#
+# It used to iterate the tracked files, which only holds what executed at least
+# once -- so a brand new file no test touched was skipped, the changed-line
+# total stayed 0, and the empty-set-is-100% rule (right for a docs-only commit)
+# passed a fully untested file through a 90% gate (#1054). "Nothing changed"
+# and "the changed file never ran" were the same input.
+#
+# should_track is the filter, so a changed file outside the coverage paths or
+# matched by an exclude pattern is still not counted, and a deleted file is
+# skipped by git_changed_files' --diff-filter=d plus the -f test in the caller.
+# Arguments: $1 - base ref
+##
+function bashunit::coverage::diff_files() {
+  local base=$1
+  local changed
+  changed="$(bashunit::helper::git_changed_files "$base")"
+  [ -n "$changed" ] || return 0
+
+  # Everything coverage seeds is *.sh, and a changed README under the coverage
+  # path is not code -- counting its lines as uncovered would fail the gate for
+  # a docs-only commit, which is the case #1032 wrote the empty-set rule for.
+  # A file without the extension still counts once it has executed, which is
+  # how an extensionless script reaches the report at all.
+  local tracked
+  tracked="$(bashunit::coverage::get_tracked_files)"
+
+  local file normalized
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    [ -f "$file" ] || continue
+
+    normalized="$(bashunit::coverage::normalize_path "$file")"
+    case "$file" in
+    *.sh) ;;
+    *)
+      case "
+$tracked
+" in
+      *"
+$normalized
+"*) ;;
+      *) continue ;;
+      esac
+      ;;
+    esac
+
+    if bashunit::coverage::should_track "$file"; then
+      printf '%s\n' "$normalized"
+    fi
+  done <<EOF
+$changed
+EOF
+}
+
+
+##
 # Renders the diff coverage report, replacing the whole-file text report.
 # Returns: 0 always; the threshold gate is checked separately.
 ##
@@ -119,7 +177,7 @@ function bashunit::coverage::report_diff() {
     local display_file="${file#"$(pwd)"/}"
     printf "%s%-40s %3d/%3d lines (%3d%%)%s\n" \
       "$color" "$display_file" "$hit" "$changed" "$pct" "$reset"
-  done < <(bashunit::coverage::get_tracked_files)
+  done < <(bashunit::coverage::diff_files "$base")
 
   if [ "$has_files" = false ]; then
     echo "No changed executable lines."

--- a/tests/acceptance/bashunit_coverage_diff_test.sh
+++ b/tests/acceptance/bashunit_coverage_diff_test.sh
@@ -162,3 +162,104 @@ function test_running_outside_a_repository_fails_loudly() {
 
   assert_contains "needs a git repository" "$output"
 }
+
+# --- a changed file that no test executed (#1054) ---------------------------
+
+# The gate exists to catch exactly this: a PR adding a fully untested file used
+# to pass, because the report iterated the files that RAN, so the new file was
+# skipped, the changed-line total stayed 0, and the empty-set-is-100% rule
+# (right for a docs-only commit) applied.
+function test_a_new_file_no_test_executed_is_reported_at_zero() {
+  local repo
+  repo="$(_diff_project)"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'function never_called() {'
+    echo '  echo "one"'
+    echo '  echo "two"'
+    echo '}'
+  } >"$repo/brand_new.sh"
+
+  local output
+  output="$(_run_diff_coverage "$repo" --coverage-diff base)"
+
+  assert_contains "brand_new.sh" "$output"
+  assert_matches "brand_new.sh[[:space:]]+0/" "$output"
+}
+
+function test_the_gate_fails_for_a_new_untested_file() {
+  local repo
+  repo="$(_diff_project)"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'function never_called() {'
+    echo '  echo "one"'
+    echo '}'
+  } >"$repo/brand_new.sh"
+
+  local ec=0
+  (
+    cd "$repo" || exit 1
+    BASHUNIT_COVERAGE_PATHS="$repo" BASHUNIT_COVERAGE_REPORT="" \
+      "$OLDPWD/bashunit" --no-parallel --coverage --coverage-diff base \
+      --coverage-min 90 ./suite_test.sh >/dev/null 2>&1
+  ) || ec=$?
+
+  assert_equals "1" "$ec"
+}
+
+# #1032's behaviour, preserved: nothing changed anywhere is still 100% and
+# still passes, which is what keeps a docs-only commit green.
+function test_no_changed_executable_lines_still_passes_the_gate() {
+  local repo
+  repo="$(_diff_project)"
+  printf 'docs only\n' >"$repo/README.md"
+
+  local ec=0
+  (
+    cd "$repo" || exit 1
+    BASHUNIT_COVERAGE_PATHS="$repo" BASHUNIT_COVERAGE_REPORT="" \
+      "$OLDPWD/bashunit" --no-parallel --coverage --coverage-diff base \
+      --coverage-min 90 ./suite_test.sh >/dev/null 2>&1
+  ) || ec=$?
+
+  assert_equals "0" "$ec"
+}
+
+# A changed file the coverage paths do not cover must not be counted, however
+# untested it is.
+function test_a_changed_file_outside_the_coverage_paths_is_not_counted() {
+  local repo
+  repo="$(_diff_project)"
+  mkdir -p "$repo/outside"
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'function elsewhere() { echo "x"; }'
+  } >"$repo/outside/other.sh"
+
+  local output
+  output="$(
+    cd "$repo" || exit 1
+    BASHUNIT_COVERAGE_PATHS="$repo/lib.sh" BASHUNIT_COVERAGE_REPORT="" \
+      "$OLDPWD/bashunit" --no-parallel --coverage --coverage-diff base \
+      ./suite_test.sh 2>&1 | sed 's/\x1B\[[0-9;]*m//g'
+  )"
+
+  assert_not_contains "other.sh" "$output"
+}
+
+function test_a_deleted_file_does_not_break_the_report() {
+  local repo
+  repo="$(_diff_project)"
+  # `|| true`: under --strict a non-zero from this setup would end the test
+  # before it asserts anything.
+  (cd "$repo" && git rm -q lib.sh) >/dev/null 2>&1 || true
+
+  # `|| true`: the suite sources the file this test just deleted, so the child
+  # run exits non-zero, and under --strict (pipefail) that would end this test
+  # at the assignment instead of at the assertion.
+  local output
+  output="$(_run_diff_coverage "$repo" --coverage-diff base || true)"
+
+  assert_contains "Diff Coverage" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1054

`--coverage-diff` reported **100%** for a brand new file no test executed, and `--coverage-min 90` passed — the exact case the gate exists to catch. `report_diff` iterated `get_tracked_files`, which only holds files that ran, so the new file was skipped, the changed-line total stayed 0, and the empty-set-is-100% rule (written so a docs-only commit does not fail) applied.

## 💡 Changes

- The report iterates the **changed** set now. `should_track` stays the filter, so a changed file outside the coverage paths or matched by an exclude is still not counted, and a deleted one is skipped.
- The changed set is narrowed to `*.sh` plus anything already tracked: a changed `README.md` sits under the coverage path but is not code — counting its lines as uncovered failed the gate for the docs-only commit the empty-set rule exists for (caught by the test I wrote for that behaviour).
- Tests cover: new untested file reported `0/N`, the gate failing for it, docs-only still passing, a changed file outside the paths ignored, and a deleted file not breaking the report.