### PR TITLE
feat(coverage): report real per-arm execution counts in BRDA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- LCOV `BRDA` records carry the arm's execution count instead of a 0/1 taken flag — the fourth field is a count to every LCOV consumer, and reporting `1` for an arm entered 5,000 times lost what makes branch data useful. The count is the arm's first executable line, which is the line that runs once per entry; `BRF` and `BRH` are unchanged (#1061)
+
 ### Fixed
 - `--coverage-diff` counts a changed file that no test executed instead of skipping it: the report iterated the files that had run, so a brand new untested file left the changed-line total at 0 and the empty-set-is-100% rule passed it through a `--coverage-min 90` gate — the exact case the gate exists to catch. A docs-only commit still reports 100% and still passes (#1054)
 - Coverage now reports every file under `--coverage-paths`, not only the files a test happened to execute: a file nothing reached shows as `0/N (0%)` instead of being absent, in the text, LCOV, Cobertura and HTML reports, and `--coverage-min` gates on that denominator. This repo reported 11 of its own 121 files and a denominator of 2,200 against a real 9,285. **Percentages drop, because the old ones were measured over the files that ran** (#1053)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -339,7 +339,7 @@ end_of_record
 | `FNDA:` | Function call data: `count,name` (1 if any line in body was hit, else 0) | `FNDA:1,add` |
 | `FNF:` | Functions Found | `FNF:2` |
 | `FNH:` | Functions Hit | `FNH:1` |
-| `BRDA:` | Branch data: `decision_line,block,arm,taken` | `BRDA:12,0,1,1` |
+| `BRDA:` | Branch data: `decision_line,block,arm,execution_count` | `BRDA:12,0,1,7` |
 | `BRF:` | Branches Found | `BRF:6` |
 | `BRH:` | Branches Hit | `BRH:4` |
 | `DA:` | Line Data: `line_number,hit_count` | `DA:15,3` (line 15 hit 3 times) |
@@ -428,7 +428,14 @@ Beyond line and function coverage, bashunit emits **branch coverage** records in
 | `if X; then ... elif Y; then ... else ... fi` | 3 (one per arm) |
 | `case X in a) ... ;; b) ... ;; *) ... ;; esac` | one per pattern |
 
-An arm is reported as **taken** iff at least one executable line inside its range was hit by tests.
+An arm is reported as **taken** iff at least one executable line inside its range was hit
+by tests, and the `BRDA` count is **how many times it ran** — the execution count of the
+arm's first executable line.
+
+That line is the one that answers "how often was this branch taken": entering an arm runs
+it exactly once per entry, while a later line can run more often (a loop inside the arm)
+or fewer times (an early return). `BRF` and `BRH` are unchanged by this: `BRH` still counts
+the arms whose count is non-zero.
 
 ### Verbose Output Helpers
 
@@ -493,7 +500,8 @@ end_of_record
 ```
 
 **Reading the branch records:**
-- `BRDA:3,0,0,1`: decision on line 3, block 0, arm 0 (`then`/GET), taken.
+- `BRDA:3,0,0,1`: decision on line 3, block 0, arm 0 (`then`/GET), taken once. An arm
+  entered 12 times reads `BRDA:3,0,0,12`.
 - `BRDA:3,0,1,0`: same decision, arm 1 (`elif`/POST), not taken.
 - `BRDA:3,0,2,0`: same decision, arm 2 (`else`/405), not taken.
 - `BRF:3` `BRH:1`: 3 branches found, 1 taken.

--- a/src/coverage/branches.sh
+++ b/src/coverage/branches.sh
@@ -193,12 +193,18 @@ function bashunit::coverage::extract_branches() {
 }
 
 
-# Sets _BASHUNIT_ARM_TAKEN_OUT to 1 iff any executable line in
-# [arm_start..arm_end] has a recorded hit, else 0. Reads hit counts from
-# the shared _BASHUNIT_COVERAGE_HITS_BY_LINE global (see
-# load_hits_by_line); caller must have populated the src_lines array in
-# scope -- Bash 3.0 cannot pass arrays into a function. Result is
-# returned via the global to avoid a per-arm subshell.
+# Sets _BASHUNIT_ARM_TAKEN_OUT to how many times the arm [arm_start..arm_end]
+# ran, or 0 when it never did.
+#
+# The count is the FIRST executable line's, not the maximum across the arm.
+# Entering an arm executes its first line exactly once per entry, while a later
+# line can run more often (a loop) or fewer times (an early return), so the
+# first line is the one that answers "how often was this branch taken" (#1061).
+#
+# Reads hit counts from the shared _BASHUNIT_COVERAGE_HITS_BY_LINE global (see
+# load_hits_by_line); the caller must have populated the src_lines array in
+# scope -- Bash 3.0 cannot pass arrays into a function. Result is returned via
+# the global to avoid a per-arm subshell.
 _BASHUNIT_ARM_TAKEN_OUT=0
 
 function bashunit::coverage::_arm_taken() {
@@ -206,10 +212,8 @@ function bashunit::coverage::_arm_taken() {
   for ((ln = arm_start; ln <= arm_end; ln++)); do
     bashunit::coverage::is_executable_line \
       "${src_lines[$((ln - 1))]:-}" "$ln" || continue
-    if [ "${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}" -gt 0 ]; then
-      _BASHUNIT_ARM_TAKEN_OUT=1
-      return
-    fi
+    _BASHUNIT_ARM_TAKEN_OUT="${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}"
+    return
   done
   _BASHUNIT_ARM_TAKEN_OUT=0
 }
@@ -217,6 +221,8 @@ function bashunit::coverage::_arm_taken() {
 # Compute branch hit data for a file.
 # Output format: <decision_line>|<block>|<branch_index>|<taken_count>
 # block = sequential id per decision (0..N-1), branch_index = arm index (0..M-1).
+# taken_count is the execution count of the arm's first executable line, which
+# is what an LCOV consumer reads out of the BRDA fourth field.
 # An arm is "taken" iff at least one executable line inside its range
 # has a recorded hit. taken_count is 0 or 1 — MVP does not preserve
 # per-arm hit counts.

--- a/tests/unit/coverage/branches_test.sh
+++ b/tests/unit/coverage/branches_test.sh
@@ -371,9 +371,11 @@ EOF
 # for an arm taken 5,000 times and 1 for one grazed by a single test loses the
 # distinction that makes branch data useful.
 function test_an_arm_reports_how_many_times_it_ran() {
-  # shellcheck disable=SC2034  # _arm_taken reads src_lines from the caller's
-  # scope: Bash 3.0 cannot pass an array into a function.
-  local src_lines=("if true; then" "  echo one" "fi")
+  # _arm_taken reads src_lines from the caller's scope: Bash 3.0 cannot pass an
+  # array into a function, nor take a compound assignment on a `local`.
+  local -a src_lines
+  # shellcheck disable=SC2034
+  src_lines=("if true; then" "  echo one" "fi")
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
   _BASHUNIT_COVERAGE_HITS_BY_LINE[2]=10
 
@@ -383,8 +385,9 @@ function test_an_arm_reports_how_many_times_it_ran() {
 }
 
 function test_an_arm_never_taken_reports_zero() {
+  local -a src_lines
   # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
-  local src_lines=("if true; then" "  echo one" "fi")
+  src_lines=("if true; then" "  echo one" "fi")
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
 
   bashunit::coverage::_arm_taken 2 2
@@ -396,8 +399,9 @@ function test_an_arm_never_taken_reports_zero() {
 # that line once per entry, while a later line can run more often (a loop) or
 # fewer times (an early return).
 function test_an_arm_counts_its_first_executable_line_not_the_maximum() {
+  local -a src_lines
   # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
-  local src_lines=("if true; then" "  echo entry" "  while :; do" "    echo inner" "  done" "fi")
+  src_lines=("if true; then" "  echo entry" "  while :; do" "    echo inner" "  done" "fi")
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
   _BASHUNIT_COVERAGE_HITS_BY_LINE[2]=3
   _BASHUNIT_COVERAGE_HITS_BY_LINE[4]=30
@@ -408,8 +412,9 @@ function test_an_arm_counts_its_first_executable_line_not_the_maximum() {
 }
 
 function test_an_arm_skips_non_executable_lines_when_counting() {
+  local -a src_lines
   # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
-  local src_lines=("if true; then" "  # a comment" "  echo real" "fi")
+  src_lines=("if true; then" "  # a comment" "  echo real" "fi")
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
   _BASHUNIT_COVERAGE_HITS_BY_LINE[3]=7
 

--- a/tests/unit/coverage/branches_test.sh
+++ b/tests/unit/coverage/branches_test.sh
@@ -364,3 +364,56 @@ EOF
 
   rm -f "$fixture"
 }
+
+# --- per-arm execution counts (#1061) ---------------------------------------
+
+# BRDA's fourth field is an execution count to an LCOV consumer, so reporting 1
+# for an arm taken 5,000 times and 1 for one grazed by a single test loses the
+# distinction that makes branch data useful.
+function test_an_arm_reports_how_many_times_it_ran() {
+  # shellcheck disable=SC2034  # _arm_taken reads src_lines from the caller's
+  # scope: Bash 3.0 cannot pass an array into a function.
+  local src_lines=("if true; then" "  echo one" "fi")
+  _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+  _BASHUNIT_COVERAGE_HITS_BY_LINE[2]=10
+
+  bashunit::coverage::_arm_taken 2 2
+
+  assert_same "10" "$_BASHUNIT_ARM_TAKEN_OUT"
+}
+
+function test_an_arm_never_taken_reports_zero() {
+  # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
+  local src_lines=("if true; then" "  echo one" "fi")
+  _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+
+  bashunit::coverage::_arm_taken 2 2
+
+  assert_same "0" "$_BASHUNIT_ARM_TAKEN_OUT"
+}
+
+# Documented rule: the FIRST executable line's count. Entering an arm executes
+# that line once per entry, while a later line can run more often (a loop) or
+# fewer times (an early return).
+function test_an_arm_counts_its_first_executable_line_not_the_maximum() {
+  # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
+  local src_lines=("if true; then" "  echo entry" "  while :; do" "    echo inner" "  done" "fi")
+  _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+  _BASHUNIT_COVERAGE_HITS_BY_LINE[2]=3
+  _BASHUNIT_COVERAGE_HITS_BY_LINE[4]=30
+
+  bashunit::coverage::_arm_taken 2 5
+
+  assert_same "3" "$_BASHUNIT_ARM_TAKEN_OUT"
+}
+
+function test_an_arm_skips_non_executable_lines_when_counting() {
+  # shellcheck disable=SC2034  # read from the caller's scope by _arm_taken
+  local src_lines=("if true; then" "  # a comment" "  echo real" "fi")
+  _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+  _BASHUNIT_COVERAGE_HITS_BY_LINE[3]=7
+
+  bashunit::coverage::_arm_taken 2 3
+
+  assert_same "7" "$_BASHUNIT_ARM_TAKEN_OUT"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1061 · last of the [#1062](https://github.com/TypedDevs/bashunit/issues/1062) order

`BRDA`'s fourth field is an execution count to every LCOV consumer, and bashunit wrote a 0/1 taken flag into it. An arm entered 5,000 times and one grazed by a single test both read `1`.

## 💡 Changes

- `_arm_taken` returns the execution count of the arm's **first executable line** — the line that runs once per arm entry, unlike a later line that a loop inflates or an early return skips. The rule is documented in the function comment, since "maximum across the arm" is defensible too.
- `BRF`/`BRH` unchanged: `BRF:19 BRH:14` on both main and this branch for the same run.
- **genhtml 2.3.1** accepts the output with exactly the warnings main's file produces (verified in Alpine), and each engine reports what it reported before — the small `trap` vs `xtrace` difference is pre-existing.

Real output now: `BRDA:117,12,0,22`, `BRDA:112,13,0,2`, `BRDA:151,14,0,0`.