### PR TITLE
perf(coverage): emit the whole LCOV report in one awk invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Performance: the LCOV emitter classifies and writes each file in one awk pass instead of a Bash loop per line — 8520ms to 6632ms for 40 files of 752 lines. The awk rules are diffed against the Bash reference line by line over every shell file in the repo (#1059)
 - Performance: function declarations are scanned in one awk pass instead of a Bash loop counting braces with pattern substitution — 2238ms to 399ms for 128 files, and a `--coverage` run over `src` from 9.23s to 6.81s (#1084)
 - Performance: every tracked file's line stats are computed by one awk invocation for the whole run instead of a Bash loop and three subshells per file — 2585ms to 153ms for 128 files, taking that `--coverage` run to 3.77s (#1088)
+- Performance: the LCOV report is emitted by one awk invocation instead of three forks and two Bash loops per file — 3133ms to 267ms for 128 files, taking a `--coverage` run over `src` to 0.96s, from 9.23s before this series (#1090)
 
 ### Fixed
 - Coverage reports every file under `--coverage-paths`, not only the ones a test executed: an untouched file shows as `0/N (0%)` and `--coverage-min` gates on that denominator. This repo reported 11 of its own 121 files. **Percentages drop, because the old ones were measured over the files that ran** (#1053)

--- a/src/coverage/branches.sh
+++ b/src/coverage/branches.sh
@@ -125,6 +125,116 @@ function bashunit::coverage::_branch_emit_loop() {
   loop_depth=$idx
 }
 
+# The branch extractor, as awk source.
+#
+# Same rules as extract_branches below, which stays the reference: the two are
+# diffed line by line over every shell file in the repo by
+# tests/unit/coverage/branches_differential_test.sh. This one exists so the
+# whole LCOV report can be emitted in one awk invocation (#1090); the Bash one
+# still serves the per-file API and the fallback path.
+#
+# Records land in br_dec/br_kind/br_arms rather than being printed, so the
+# caller decides what to do with them.
+# shellcheck disable=SC2016
+_BASHUNIT_COVERAGE_AWK_BRANCHES='
+function bu_br_append_arm(existing, s, e) {
+  return (existing == "") ? (s ":" e) : (existing "," s ":" e)
+}
+
+# A case-pattern opener ends with `)`, optionally followed by a comment. This
+# does not exclude a `(` earlier on the line -- the reference does not either.
+function bu_br_is_case_pattern(t,   before, after) {
+  if (index(t, ")") == 0) { return 0 }
+  before = t
+  sub(/\).*$/, "", before)
+  after = substr(t, length(before) + 2)
+  sub(/^[ \t]+/, "", after)
+  return (after == "" || substr(after, 1, 1) == "#")
+}
+
+function bu_br_add(decision, kind, arms) {
+  br_count++
+  br_dec[br_count] = decision
+  br_kind[br_count] = kind
+  br_arms[br_count] = arms
+}
+
+function bu_br_line(line, lineno,   trimmed, first, idx) {
+  trimmed = line
+  sub(/^[ \t]+/, "", trimmed)
+  if (trimmed == "" || substr(trimmed, 1, 1) == "#") { return }
+
+  first = trimmed
+  sub(/[ \t;].*$/, "", first)
+
+  if (first == "if") {
+    if_decision_line[if_depth] = lineno
+    if_arms[if_depth] = ""
+    if_arm_start[if_depth] = lineno + 1
+    if_depth++
+  } else if (first == "elif" || first == "else") {
+    if (if_depth > 0) {
+      idx = if_depth - 1
+      if_arms[idx] = bu_br_append_arm(if_arms[idx], if_arm_start[idx], lineno - 1)
+      if_arm_start[idx] = lineno + 1
+    }
+  } else if (first == "fi") {
+    if (if_depth > 0) {
+      idx = if_depth - 1
+      bu_br_add(if_decision_line[idx], "if", bu_br_append_arm(if_arms[idx], if_arm_start[idx], lineno - 1))
+      if_depth = idx
+    }
+  } else if (first == "case") {
+    case_decision_line[case_depth] = lineno
+    case_arms[case_depth] = ""
+    case_arm_start[case_depth] = 0
+    case_in_pattern[case_depth] = 0
+    case_depth++
+  } else if (first == "esac") {
+    if (case_depth > 0) {
+      idx = case_depth - 1
+      if (case_in_pattern[idx] == 1) {
+        case_arms[idx] = bu_br_append_arm(case_arms[idx], case_arm_start[idx], lineno - 1)
+        case_in_pattern[idx] = 0
+      }
+      if (case_arms[idx] != "") { bu_br_add(case_decision_line[idx], "case", case_arms[idx]) }
+      case_depth = idx
+    }
+  } else if (first == "while" || first == "until" || first == "for" || first == "select") {
+    loop_decision_line[loop_depth] = lineno
+    loop_arm_start[loop_depth] = lineno + 1
+    loop_depth++
+  } else if (first == "done") {
+    if (loop_depth > 0) {
+      idx = loop_depth - 1
+      bu_br_add(loop_decision_line[idx], "loop", loop_arm_start[idx] ":" (lineno - 1))
+      loop_depth = idx
+    }
+  } else if (case_depth > 0) {
+    idx = case_depth - 1
+    if (trimmed ~ /^;;&/ || trimmed ~ /^;;/ || trimmed ~ /^;&/) {
+      if (case_in_pattern[idx] == 1) {
+        case_arms[idx] = bu_br_append_arm(case_arms[idx], case_arm_start[idx], lineno - 1)
+        case_in_pattern[idx] = 0
+      }
+    } else if (bu_br_is_case_pattern(trimmed)) {
+      case_arm_start[idx] = lineno + 1
+      case_in_pattern[idx] = 1
+    }
+  }
+}
+
+# The depths must be numeric before they index anything: an uninitialised awk
+# variable is the empty string as a subscript, so the first push would land in
+# arr[""] and the matching pop would read arr[0].
+function bu_br_reset() {
+  if_depth = 0
+  case_depth = 0
+  loop_depth = 0
+  br_count = 0
+}
+'
+
 function bashunit::coverage::extract_branches() {
   local file="$1"
 

--- a/src/coverage/functions.sh
+++ b/src/coverage/functions.sh
@@ -95,8 +95,10 @@ function bu_scan(line,   i, n, c, rest, delim, q) {
   }
 }
 
-{
-  line = $0
+# Feeds one line to the scanner, recording a declaration when it opens and its
+# span when the braces balance. A caller reads the records out of fnn/fns/fne,
+# which is what lets the per-file API below and the batch report share this.
+function bu_fn_line(line, lineno,   stripped, name, after, ok) {
   bu_scan(line)
 
   if (in_function == 0 && code_start) {
@@ -136,34 +138,56 @@ function bu_scan(line,   i, n, c, rest, delim, q) {
       if (ok) {
         in_function = 1
         current_fn = name
-        fn_start = NR
+        fn_start = lineno
         brace_count = nopen - nclose
         # Single-line function: braces balance on the same line, both present.
-        if (brace_count == 0 && nopen > 0 && nclose > 0) {
-          print current_fn "|" fn_start "|" NR
-          in_function = 0
-          current_fn = ""
-        }
-        next
+        if (brace_count == 0 && nopen > 0 && nclose > 0) { bu_fn_emit(lineno) }
+        return
       }
     }
   }
 
   if (in_function == 1) {
     brace_count = brace_count + nopen - nclose
-    if (brace_count <= 0) {
-      print current_fn "|" fn_start "|" NR
-      in_function = 0
-      current_fn = ""
-      brace_count = 0
-    }
+    if (brace_count <= 0) { bu_fn_emit(lineno) }
   }
+}
+
+function bu_fn_emit(endline) {
+  fn_count++
+  fnn[fn_count] = current_fn
+  fns[fn_count] = fn_start
+  fne[fn_count] = endline
+  in_function = 0
+  current_fn = ""
+  brace_count = 0
 }
 
 # An unclosed function (should not happen in valid code) still gets a record,
 # ending at the last line, so a truncated file cannot drop one silently.
+function bu_fn_finish(lastline) {
+  if (in_function == 1 && current_fn != "") { bu_fn_emit(lastline) }
+}
+
+# Clears the per-file state: quote and heredoc carry-over, the open
+# declaration, and the records collected so far.
+function bu_fn_reset() {
+  in_s = 0; in_d = 0; hd = ""; hd_strip = 0
+  in_function = 0; current_fn = ""; brace_count = 0
+  fn_count = 0
+}
+'
+
+# The per-file driver: feed every line, then print the records.
+# shellcheck disable=SC2016
+_BASHUNIT_COVERAGE_AWK_FUNCTIONS_MAIN='
+{ bu_fn_line($0, NR) }
+
 END {
-  if (in_function == 1 && current_fn != "") { print current_fn "|" fn_start "|" NR }
+  bu_fn_finish(NR)
+  for (bu_i = 1; bu_i <= fn_count; bu_i++) {
+    print fnn[bu_i] "|" fns[bu_i] "|" fne[bu_i]
+  }
 }
 '
 
@@ -173,5 +197,6 @@ END {
 # Arguments: $1 - source file
 ##
 function bashunit::coverage::extract_functions() {
-  env LC_ALL=C "$AWK" "$_BASHUNIT_COVERAGE_AWK_FUNCTIONS" "$1"
+  env LC_ALL=C "$AWK" \
+    "${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS_MAIN}" "$1"
 }

--- a/src/coverage/lines.sh
+++ b/src/coverage/lines.sh
@@ -248,6 +248,46 @@ function bashunit::coverage::hits_file_for() {
   _BASHUNIT_COVERAGE_HITS_FILE_OUT="$dir/$name"
 }
 
+# The path of the manifest written by write_batch_manifest, empty when there is
+# nothing to report on.
+_BASHUNIT_COVERAGE_MANIFEST_OUT=""
+
+##
+# Writes a "<hits block>\t<source>" line per tracked file into $1 under the
+# coverage data dir, for the awk passes that do the whole run in one call
+# (#1088, #1090). The source path comes last so a path holding a tab still
+# reads back whole.
+#
+# Sets _BASHUNIT_COVERAGE_MANIFEST_OUT to the manifest path, or to the empty
+# string when nothing is tracked. Returns 1 when there is nowhere to write it,
+# which is the caller's signal to use the per-file path instead.
+# Arguments: $1 - manifest file name
+##
+function bashunit::coverage::write_batch_manifest() {
+  _BASHUNIT_COVERAGE_MANIFEST_OUT=""
+
+  local data_dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}"
+  { [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] && [ -d "$data_dir" ]; } || return 1
+
+  bashunit::coverage::ensure_hits_aggregated
+
+  local manifest="$data_dir/$1"
+  local tracked=0 file
+  {
+    while IFS= read -r file; do
+      { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
+      tracked=$((tracked + 1))
+      bashunit::coverage::hits_file_for "$file"
+      printf '%s\t%s\n' "$_BASHUNIT_COVERAGE_HITS_FILE_OUT" "$file"
+    done < <(bashunit::coverage::get_tracked_files)
+  } >"$manifest" 2>/dev/null || return 1
+
+  if [ "$tracked" -gt 0 ]; then
+    _BASHUNIT_COVERAGE_MANIFEST_OUT="$manifest"
+  fi
+  return 0
+}
+
 ##
 # Invalidates the aggregation. Called wherever the data file grows, so a report
 # never reads counts that predate the records it is reporting on.

--- a/src/coverage/report_lcov.sh
+++ b/src/coverage/report_lcov.sh
@@ -12,6 +12,21 @@ function bashunit::coverage::report_lcov() {
   # Create output directory if needed
   mkdir -p "$(dirname "$output_file")"
 
+  # One awk invocation for the whole report: three forks and two Bash loops per
+  # tracked file was 3133ms for 128 files against 262ms this way, and the awk
+  # work itself is a rounding error either way (#1090). The per-file path below
+  # stays as the fallback for when the batch pass cannot run.
+  if bashunit::coverage::write_batch_manifest "lcov-manifest"; then
+    if [ -z "$_BASHUNIT_COVERAGE_MANIFEST_OUT" ]; then
+      echo "TN:" >"$output_file"
+      return 0
+    fi
+    if bashunit::coverage::awk_lcov_report "$_BASHUNIT_COVERAGE_MANIFEST_OUT" \
+      >"$output_file" 2>/dev/null && [ -s "$output_file" ]; then
+      return 0
+    fi
+  fi
+
   # Generate LCOV format
   {
     echo "TN:"

--- a/src/coverage/rules_awk.sh
+++ b/src/coverage/rules_awk.sh
@@ -208,6 +208,118 @@ _BASHUNIT_COVERAGE_AWK_STATS='
 }
 '
 
+# The whole LCOV report, in one awk invocation.
+#
+# report_lcov used to run three awk forks and two Bash loops per tracked file:
+# 3133ms for 128 files, of which the awk work itself was a rounding error. This
+# reads the same manifest as the stats pass and emits every record a file needs
+# from a single walk that already holds the source lines and the propagated hit
+# counts: 262ms, byte-identical output (#1090).
+#
+# Composed with the classifier rules, the declaration scanner and the branch
+# scanner, all of which are included ahead of it.
+# shellcheck disable=SC2016
+_BASHUNIT_COVERAGE_AWK_LCOV_ALL='
+# An arm ran as often as its FIRST executable line did (#1061).
+function bu_arm_taken(s, e,   ln) {
+  for (ln = s; ln <= e; ln++) {
+    if (!bu_is_executable(sl[ln])) { continue }
+    return (ln in hits) ? hits[ln] : 0
+  }
+  return 0
+}
+
+BEGIN { print "TN:" }
+
+{
+  hitsfile = $0
+  sub(/\t.*$/, "", hitsfile)
+  src = $0
+  sub(/^[^\t]*\t/, "", src)
+
+  split("", hits)
+  if (hitsfile != "") {
+    while ((getline hline < hitsfile) > 0) {
+      split(hline, hp, " ")
+      hits[hp[1] + 0] = hp[2] + 0
+    }
+    close(hitsfile)
+  }
+
+  total = 0
+  split("", sl)
+  while ((getline sline < src) > 0) {
+    total++
+    sl[total] = sline
+  }
+  close(src)
+
+  # The DEBUG trap attributes a multi-line statement to its starting line, so
+  # the count carries forward across the backslash chain (#722).
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  bu_fn_reset()
+  bu_br_reset()
+  for (ln = 1; ln <= total; ln++) {
+    bu_fn_line(sl[ln], ln)
+    bu_br_line(sl[ln], ln)
+  }
+  bu_fn_finish(total)
+
+  print "SF:" src
+
+  # FN lines as we walk, the matching FNDA lines after them, per LCOV
+  # convention.
+  fn_hit = 0
+  fnda = ""
+  for (i = 1; i <= fn_count; i++) {
+    print "FN:" fns[i] "," fnn[i]
+    any = 0
+    for (ln = fns[i]; ln <= fne[i]; ln++) {
+      if ((ln in hits) && hits[ln] > 0) { any = 1; break }
+    }
+    fnda = fnda "FNDA:" any "," fnn[i] "\n"
+    if (any == 1) { fn_hit++ }
+  }
+  printf "%s", fnda
+  print "FNF:" fn_count
+  print "FNH:" fn_hit
+
+  br_total = 0
+  br_hit = 0
+  for (i = 1; i <= br_count; i++) {
+    n = split(br_arms[i], arms, ",")
+    for (a = 1; a <= n; a++) {
+      split(arms[a], se, ":")
+      taken = bu_arm_taken(se[1] + 0, se[2] + 0)
+      print "BRDA:" br_dec[i] "," (i - 1) "," (a - 1) "," taken
+      br_total++
+      if (taken > 0) { br_hit++ }
+    }
+  }
+  print "BRF:" br_total
+  print "BRH:" br_hit
+
+  executable = 0
+  hit = 0
+  for (ln = 1; ln <= total; ln++) {
+    if (!bu_is_executable(sl[ln])) { continue }
+    executable++
+    h = (ln in hits) ? hits[ln] : 0
+    if (h > 0) { hit++ }
+    print "DA:" ln "," h
+  }
+  print "LF:" executable
+  print "LH:" hit
+  print "end_of_record"
+}
+'
+
 ##
 # The awk source of the shared classification rules.
 ##
@@ -243,5 +355,17 @@ function bashunit::coverage::awk_lcov_lines() {
 function bashunit::coverage::awk_file_stats() {
   env LC_ALL=C "$AWK" \
     "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_STATS}" \
+    "$1"
+}
+
+##
+# Emits the whole LCOV report for every pair in the manifest, in one awk
+# invocation.
+# Arguments: $1 - manifest of "<hits block>\t<source>" lines
+##
+function bashunit::coverage::awk_lcov_report() {
+  env LC_ALL=C "$AWK" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}\
+${_BASHUNIT_COVERAGE_AWK_BRANCHES}${_BASHUNIT_COVERAGE_AWK_LCOV_ALL}" \
     "$1"
 }

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -140,27 +140,15 @@ function bashunit::coverage::_record_file_stats() {
 # manifest or the pass produced nothing for a non-empty tracked list, so the
 # caller falls back to the per-file path and a report is never silently empty.
 function bashunit::coverage::_precompute_batch() {
-  local data_dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}"
-  { [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] && [ -d "$data_dir" ]; } || return 1
+  bashunit::coverage::write_batch_manifest "stats-manifest" || return 1
+  local manifest="$_BASHUNIT_COVERAGE_MANIFEST_OUT"
 
-  bashunit::coverage::ensure_hits_aggregated
-
-  local manifest="$data_dir/stats-manifest"
-  local tracked=0 file
-  {
-    while IFS= read -r file; do
-      { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
-      tracked=$((tracked + 1))
-      bashunit::coverage::hits_file_for "$file"
-      printf '%s\t%s\n' "$_BASHUNIT_COVERAGE_HITS_FILE_OUT" "$file"
-    done < <(bashunit::coverage::get_tracked_files)
-  } >"$manifest" 2>/dev/null || return 1
-
-  if [ "$tracked" -eq 0 ]; then
+  if [ -z "$manifest" ]; then
+    # Nothing tracked is a valid, empty report -- not a reason to fall back.
     return 0
   fi
 
-  local executable hit
+  local executable hit file
   while IFS="$(printf '\t')" read -r executable hit file; do
     [ -n "$file" ] || continue
     bashunit::coverage::_record_file_stats "$file" "$executable" "$hit"

--- a/tests/unit/coverage/branches_differential_test.sh
+++ b/tests/unit/coverage/branches_differential_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# The awk branch scanner and the Bash one must agree on every shell file in the
+# repo. Both are live: the Bash one serves the per-file API and the fallback,
+# the awk one runs inside the single-invocation LCOV report (#1090). A
+# disagreement moves BRDA/BRF/BRH silently, so this compares them file by file
+# rather than trusting either.
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+}
+
+# Extracts $1's branches with awk, in the same
+# "<decision>|<kind>|<arm>[,<arm>]" shape the Bash reference prints.
+# $2 overrides the scanner source, which is how the mutation below is injected.
+function awk_branches() { # $1 = file, $2 = optional scanner source
+  local scanner="${2:-$_BASHUNIT_COVERAGE_AWK_BRANCHES}"
+  env LC_ALL=C "$AWK" "$scanner"'
+    BEGIN { bu_br_reset() }
+    { bu_br_line($0, FNR) }
+    END {
+      for (i = 1; i <= br_count; i++) {
+        print br_dec[i] "|" br_kind[i] "|" br_arms[i]
+      }
+    }
+  ' "$1"
+}
+
+function test_both_branch_scanners_agree_on_every_shell_file_in_the_repo() {
+  # One awk fork per file plus a Bash loop over its lines: seconds here, but
+  # minutes under Git Bash, where forks are slow enough to hang a shard.
+  bashunit::skip_on windows "an awk fork per repo file takes minutes under Git Bash"
+
+  local disagreements=""
+  local file
+  for file in $(cd "$ROOT_DIR" && git ls-files '*.sh'); do
+    local diff_out
+    diff_out=$(diff <(bashunit::coverage::extract_branches "$ROOT_DIR/$file") \
+      <(awk_branches "$ROOT_DIR/$file") 2>&1) || true
+    if [ -n "$diff_out" ]; then
+      disagreements="$disagreements
+$file
+$diff_out"
+    fi
+  done
+
+  assert_empty "$disagreements"
+}
+
+# The differential is only worth anything if it can fail. The mutation drops the
+# `elif`/`else` arm split and leaves a valid program, so a disagreement is what
+# fails the test -- not an awk error.
+function test_the_differential_catches_a_broken_awk_scanner() {
+  local fixture
+  fixture="$(bashunit::temp_file)"
+  printf 'if [ -n "$x" ]; then\n  echo a\nelse\n  echo b\nfi\n' >"$fixture"
+
+  local mutated_scanner
+  mutated_scanner=$(printf '%s' "$_BASHUNIT_COVERAGE_AWK_BRANCHES" |
+    sed 's|} else if (first == "elif" \|\| first == "else") {|} else if (first == "@never@") {|')
+
+  local mutated reference
+  mutated=$(awk_branches "$fixture" "$mutated_scanner")
+  reference=$(bashunit::coverage::extract_branches "$fixture")
+
+  assert_not_empty "$mutated"
+  assert_not_equals "$reference" "$mutated"
+}
+
+function test_the_scanners_agree_on_nested_and_mixed_constructs() {
+  local fixture
+  fixture="$(bashunit::temp_file)"
+  {
+    printf '%s\n' 'while read -r line; do'
+    printf '%s\n' '  case "$line" in'
+    printf '%s\n' '  a)'
+    printf '%s\n' '    if [ -n "$line" ]; then'
+    printf '%s\n' '      echo one'
+    printf '%s\n' '    elif [ -z "$line" ]; then'
+    printf '%s\n' '      echo two'
+    printf '%s\n' '    else'
+    printf '%s\n' '      echo three'
+    printf '%s\n' '    fi'
+    printf '%s\n' '    ;;'
+    printf '%s\n' '  b | c) # a trailing comment'
+    printf '%s\n' '    for i in 1 2; do'
+    printf '%s\n' '      echo "$i"'
+    printf '%s\n' '    done'
+    printf '%s\n' '    ;;&'
+    printf '%s\n' '  *) : ;;'
+    printf '%s\n' '  esac'
+    printf '%s\n' 'done'
+  } >"$fixture"
+
+  assert_same "$(bashunit::coverage::extract_branches "$fixture")" \
+    "$(awk_branches "$fixture")"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1090

`report_lcov` ran three awk forks and two Bash loops per tracked file — the
per-function span scan behind `FNDA`, the per-arm scan behind `BRDA`, and
separate passes for lines, declarations and branches. 3133 ms for 128 files,
of which the awk work itself was a rounding error.

## 💡 Changes

- One invocation reads the manifest from #1088 and emits every record from a single walk that already holds the source lines and the propagated hit counts
- The declaration scanner and the branch scanner moved into shared awk functions, so the per-file API and the batch pass run the same code rather than a copy; the per-file path stays as the fallback
- A differential test pins the awk branch scanner against the Bash reference over every shell file in the repo, with a mutation guard so it cannot pass on an awk error
- 3133 ms → 267 ms for 128 files, and a `--coverage` run over `src` 3.77 s → 0.96 s (9.23 s before this series). Byte-identical output — 15,357 records in the same order, on macOS awk, BusyBox awk and mawk alike