### PR TITLE
test(runner): give the timeout acceptance test room on a loaded runner

### DIFF
--- a/tests/acceptance/bashunit_timeout_test.sh
+++ b/tests/acceptance/bashunit_timeout_test.sh
@@ -14,8 +14,15 @@ function test_bashunit_terminates_a_hanging_test_with_timeout() {
 }
 
 function test_bashunit_keeps_running_tests_after_a_timed_out_one() {
+  # The only case here that asserts on the FAST test, so the only one whose
+  # budget has to cover how long that test takes to run rather than how long
+  # the blocked one sleeps. One second did not: the watchdog marks a test that
+  # is still running when the budget expires, and on a CI runner already busy
+  # with the parallel suite even an immediate assertion crossed it, so the run
+  # reported `2 failed` and the job went red (#1093). Five seconds against a
+  # thirty-second sleep still proves both halves.
   local output
-  output="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --test-timeout 1 "$FIXTURE")" || true
+  output="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --test-timeout 5 "$FIXTURE")" || true
 
   # The fast test still ran and passed and the run reached its summary instead
   # of hanging forever on the blocked test.


### PR DESCRIPTION
## 🤔 Background

Related #1093

`main` went red on a tree that had passed 35/35 on its own PR. One case in
`bashunit_timeout_test.sh` asserts that the *fast* test in the fixture still
passes, under a one-second budget — and on a runner already busy with the
parallel suite, even an immediate assertion crossed it, so the run reported
`2 failed`.

## 💡 Changes

- That one case gets five seconds against the fixture's thirty-second sleep, which still proves both halves: the blocked test is killed, the fast one survives
- The other cases keep their one second — they only assert the blocked test is killed, which no load makes marginal
- The watchdog is untouched: it only marks a test still running when the budget expires, so it measured correctly and the budget was the bug