### PR TITLE
perf(coverage): pick the report colours without a subshell per row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Performance: the coverage report picks its colours without a subshell per file and per function — the text report over 128 files went from 387ms to 318ms, and 4042ms to 3116ms with `BASHUNIT_COVERAGE_SHOW_FUNCTIONS` on (#1092)
+
 ## [0.47.0](https://github.com/TypedDevs/bashunit/compare/0.46.0...0.47.0) - 2026-08-13
 
 ### Added

--- a/src/coverage/diff.sh
+++ b/src/coverage/diff.sh
@@ -171,8 +171,9 @@ function bashunit::coverage::report_diff() {
     total_hit=$((total_hit + hit))
 
     pct=$(bashunit::coverage::diff_percentage "$changed" "$hit")
-    color=$(bashunit::coverage::get_color_for_class \
-      "$(bashunit::coverage::get_coverage_class "$pct")")
+    bashunit::coverage::class_to_slot "$pct"
+    bashunit::coverage::color_to_slot "$_BASHUNIT_COVERAGE_CLASS_OUT"
+    color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
     local display_file="${file#"$(pwd)"/}"
     printf "%s%-40s %3d/%3d lines (%3d%%)%s\n" \
@@ -186,8 +187,9 @@ function bashunit::coverage::report_diff() {
   echo "---------------"
   local total_pct
   total_pct=$(bashunit::coverage::diff_percentage "$total_changed" "$total_hit")
-  color=$(bashunit::coverage::get_color_for_class \
-    "$(bashunit::coverage::get_coverage_class "$total_pct")")
+  bashunit::coverage::class_to_slot "$total_pct"
+  bashunit::coverage::color_to_slot "$_BASHUNIT_COVERAGE_CLASS_OUT"
+  color="$_BASHUNIT_COVERAGE_COLOR_OUT"
   printf "%sTotal: %d/%d (%d%%)%s\n" \
     "$color" "$total_hit" "$total_changed" "$total_pct" "$reset"
 

--- a/src/coverage/html_file.sh
+++ b/src/coverage/html_file.sh
@@ -307,7 +307,8 @@ EOF
 
         local fn_pct fn_class row_class
         fn_pct=$(bashunit::coverage::calculate_percentage "$fn_hit" "$fn_executable")
-        fn_class=$(bashunit::coverage::get_coverage_class "$fn_pct")
+        bashunit::coverage::class_to_slot "$fn_pct"
+        fn_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
         case "$fn_class" in
         high) row_class="fn-covered" ;;
         medium) row_class="fn-partial" ;;

--- a/src/coverage/html_index.sh
+++ b/src/coverage/html_index.sh
@@ -29,7 +29,8 @@ function bashunit::coverage::generate_index_html() {
 
   # Determine coverage level and colors for gauge
   local total_class gauge_color_start gauge_color_end gauge_text_gradient
-  total_class=$(bashunit::coverage::get_coverage_class "$total_pct")
+  bashunit::coverage::class_to_slot "$total_pct"
+  total_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
   case "$total_class" in
   high)
     gauge_color_start="#10b981"
@@ -318,7 +319,8 @@ EOF
       IFS='|' read -r display_file hit executable pct safe_filename <<<"$data"
 
       local class
-      class=$(bashunit::coverage::get_coverage_class "$pct")
+      bashunit::coverage::class_to_slot "$pct"
+      class="$_BASHUNIT_COVERAGE_CLASS_OUT"
 
       echo "            <tr onclick=\"window.location='files/${safe_filename}.html'\">"
       echo "              <td>"

--- a/src/coverage/report_text.sh
+++ b/src/coverage/report_text.sh
@@ -53,7 +53,8 @@ function bashunit::coverage::report_text() {
     total_hit=$((total_hit + hit))
 
     local color reset="$_BASHUNIT_COLOR_DEFAULT"
-    color=$(bashunit::coverage::get_color_for_class "$class")
+    bashunit::coverage::color_to_slot "$class"
+    color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
     # Display relative path
     local display_file="${file#"$(pwd)"/}"
@@ -72,10 +73,12 @@ function bashunit::coverage::report_text() {
   # Total
   local total_pct total_class
   total_pct=$(bashunit::coverage::calculate_percentage "$total_hit" "$total_executable")
-  total_class=$(bashunit::coverage::get_coverage_class "$total_pct")
+  bashunit::coverage::class_to_slot "$total_pct"
+  total_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
 
   local color reset="$_BASHUNIT_COLOR_DEFAULT"
-  color=$(bashunit::coverage::get_color_for_class "$total_class")
+  bashunit::coverage::color_to_slot "$total_class"
+  color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
   printf "%sTotal: %d/%d (%d%%)%s\n" \
     "$color" "$total_hit" "$total_executable" "$total_pct" "$reset"
@@ -264,8 +267,10 @@ function bashunit::coverage::report_text_functions() {
       done
 
       fn_pct=$(bashunit::coverage::calculate_percentage "$fn_hit" "$fn_executable")
-      fn_class=$(bashunit::coverage::get_coverage_class "$fn_pct")
-      color=$(bashunit::coverage::get_color_for_class "$fn_class")
+      bashunit::coverage::class_to_slot "$fn_pct"
+      fn_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
+      bashunit::coverage::color_to_slot "$fn_class"
+      color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
       printf "  %s%-38s %3d/%3d lines (%3d%%)%s\n" \
         "$color" "$fn_name" "$fn_hit" "$fn_executable" "$fn_pct" "$reset"

--- a/src/coverage/stats.sh
+++ b/src/coverage/stats.sh
@@ -2,24 +2,50 @@
 
 # Coverage percentages, the precomputed per-file stats cache and the threshold gate.
 
-# Get coverage class (high/medium/low) based on percentage
-function bashunit::coverage::get_coverage_class() {
+# Return slots for the class and colour helpers below.
+_BASHUNIT_COVERAGE_CLASS_OUT=""
+_BASHUNIT_COVERAGE_COLOR_OUT=""
+
+##
+# Sets _BASHUNIT_COVERAGE_CLASS_OUT to high/medium/low for a percentage.
+# Arguments: $1 - percentage
+##
+function bashunit::coverage::class_to_slot() {
   local pct="$1"
   if [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}" ]; then
-    echo "high"
+    _BASHUNIT_COVERAGE_CLASS_OUT="high"
   elif [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}" ]; then
-    echo "medium"
+    _BASHUNIT_COVERAGE_CLASS_OUT="medium"
   else
-    echo "low"
+    _BASHUNIT_COVERAGE_CLASS_OUT="low"
   fi
 }
 
-function bashunit::coverage::get_color_for_class() {
+##
+# Sets _BASHUNIT_COVERAGE_COLOR_OUT to the colour of a class.
+# Arguments: $1 - high, medium or low
+##
+function bashunit::coverage::color_to_slot() {
   case "$1" in
-  high) printf '%s' "$_BASHUNIT_COLOR_PASSED" ;;
-  medium) printf '%s' "$_BASHUNIT_COLOR_SKIPPED" ;;
-  low) printf '%s' "$_BASHUNIT_COLOR_FAILED" ;;
+  high) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_PASSED" ;;
+  medium) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_SKIPPED" ;;
+  low) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_FAILED" ;;
+  *) _BASHUNIT_COVERAGE_COLOR_OUT="" ;;
   esac
+}
+
+# The two above are the decision; these are the same thing for a caller that
+# wants it on stdout. Every per-file and per-function caller uses the slots: a
+# subshell to pick one of three constants cost 168ms of the 253ms the text
+# report spent on 128 files (#1092).
+function bashunit::coverage::get_coverage_class() {
+  bashunit::coverage::class_to_slot "$1"
+  echo "$_BASHUNIT_COVERAGE_CLASS_OUT"
+}
+
+function bashunit::coverage::get_color_for_class() {
+  bashunit::coverage::color_to_slot "$1"
+  printf '%s' "$_BASHUNIT_COVERAGE_COLOR_OUT"
 }
 
 # Calculate percentage from hit and executable counts
@@ -65,13 +91,8 @@ function bashunit::coverage::_derive_file_stats() {
   fi
   _BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT="$pct"
 
-  if [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}" ]; then
-    _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT="high"
-  elif [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}" ]; then
-    _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT="medium"
-  else
-    _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT="low"
-  fi
+  bashunit::coverage::class_to_slot "$pct"
+  _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT="$_BASHUNIT_COVERAGE_CLASS_OUT"
 }
 
 # Get file coverage stats as "executable:hit:pct:class"

--- a/tests/unit/coverage/class_color_slots_test.sh
+++ b/tests/unit/coverage/class_color_slots_test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# The report picks a class and a colour once per file and once per function. It
+# used to do that in a subshell, which cost more than every other thing the text
+# report did: 168ms of 253ms at 128 files (#1092). The slots below are the same
+# decision without the fork, so they have to agree with the stdout helpers
+# exactly -- these pin them together, including on the threshold boundaries.
+
+function set_up() {
+  # shellcheck disable=SC2034  # read by the class helpers under test
+  BASHUNIT_COVERAGE_THRESHOLD_HIGH=80
+  # shellcheck disable=SC2034  # read by the class helpers under test
+  BASHUNIT_COVERAGE_THRESHOLD_LOW=50
+}
+
+# @data_provider percentages
+function test_the_class_slot_agrees_with_the_stdout_helper() {
+  local pct="$1"
+
+  bashunit::coverage::class_to_slot "$pct"
+
+  assert_same "$(bashunit::coverage::get_coverage_class "$pct")" \
+    "$_BASHUNIT_COVERAGE_CLASS_OUT"
+}
+
+# @data_provider percentages
+function test_the_colour_slot_agrees_with_the_stdout_helper() {
+  local pct="$1"
+
+  local class
+  class="$(bashunit::coverage::get_coverage_class "$pct")"
+  bashunit::coverage::color_to_slot "$class"
+
+  assert_same "$(bashunit::coverage::get_color_for_class "$class")" \
+    "$_BASHUNIT_COVERAGE_COLOR_OUT"
+}
+
+function percentages() {
+  echo 0
+  echo 49
+  echo 50
+  echo 79
+  echo 80
+  echo 100
+}
+
+function test_the_class_slot_follows_the_configured_thresholds() {
+  # shellcheck disable=SC2034  # read by the class helpers under test
+  BASHUNIT_COVERAGE_THRESHOLD_HIGH=95
+  # shellcheck disable=SC2034  # read by the class helpers under test
+  BASHUNIT_COVERAGE_THRESHOLD_LOW=90
+
+  bashunit::coverage::class_to_slot 94
+  assert_same "medium" "$_BASHUNIT_COVERAGE_CLASS_OUT"
+
+  bashunit::coverage::class_to_slot 95
+  assert_same "high" "$_BASHUNIT_COVERAGE_CLASS_OUT"
+
+  bashunit::coverage::class_to_slot 89
+  assert_same "low" "$_BASHUNIT_COVERAGE_CLASS_OUT"
+}
+
+# An unknown class is not a colour. The stdout helper printed nothing for it,
+# so the slot must be emptied rather than left holding the previous caller's.
+function test_an_unknown_class_clears_the_colour_slot() {
+  bashunit::coverage::color_to_slot "high"
+  assert_not_empty "$_BASHUNIT_COVERAGE_COLOR_OUT"
+
+  bashunit::coverage::color_to_slot "nonsense"
+
+  assert_empty "$_BASHUNIT_COVERAGE_COLOR_OUT"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1092

`get_coverage_class` and `get_color_for_class` each print one of three
constants, and the report called them through `$()` once per file and twice per
function — a subshell costing more than the decision it wrapped.

## 💡 Changes

- Both helpers fill a return slot, the shape `bash-style.md` prescribes and `_derive_file_stats` already used for the percentage; the stdout versions stay and delegate to them, so there is one decision rather than two copies
- Every per-file and per-function caller reads the slot: `report_text`, both HTML emitters and the diff report
- Text report over 128 files 387 ms → 318 ms, and 4042 ms → 3116 ms with `BASHUNIT_COVERAGE_SHOW_FUNCTIONS` on, where the fork is paid ~700 times
- Output byte-identical over a fixed corpus, colours and per-function rows included; new tests pin the slots against the stdout helpers on the threshold boundaries