### PR TITLE
perf(coverage): emit each HTML page's code table in one awk pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changed
+- Performance: the HTML report emits each page's code table in one awk pass and stops forking `cat` for every markup block — 9.5s to 4.5s for 128 files, and 58.7s to 4.5s together with the escaping fix (#1098)
 - Performance: `--coverage-report-html` no longer forks twice per source line to escape it — 58.7s to 9.5s for 128 files here, with the escaping done once per file and the per-page `wc`, `basename` and `pwd` calls replaced by parameter expansions (#1096)
 - Performance: the coverage report picks its colours without a subshell per file and per function — the text report over 128 files went from 387ms to 318ms, and 4042ms to 3116ms with `BASHUNIT_COVERAGE_SHOW_FUNCTIONS` on (#1092)
 

--- a/src/coverage/html_file.sh
+++ b/src/coverage/html_file.sh
@@ -2,6 +2,116 @@
 
 # HTML coverage report: the per-file page.
 
+# The code table of one page, in one awk pass.
+#
+# The Bash loop that did this classified, looked up and echoed per source line:
+# 8116ms for 128 pages over 22,405 lines, with no forks left in it -- Bash is
+# simply the wrong tool for emitting 7MB of markup (#1098). Every input it
+# needs is already a file: the aggregated hits, the per-line test list and the
+# source itself.
+#
+# Composed with the classifier rules, which are included ahead of it.
+# shellcheck disable=SC2016
+_BASHUNIT_COVERAGE_AWK_HTML_ROWS='
+FILENAME == hitsfile {
+  hits[$1 + 0] = $2 + 0
+  next
+}
+
+FILENAME == testsfile {
+  # "<lineno>|<test_file>:<test_fn>", deduplicated, first-seen order kept.
+  p = index($0, "|")
+  if (p == 0) { next }
+  tln = substr($0, 1, p - 1) + 0
+  info = substr($0, p + 1)
+  key = tln SUBSEP info
+  if (key in seen) { next }
+  seen[key] = 1
+  tests[tln] = (tln in tests) ? tests[tln] "\n" info : info
+  next
+}
+
+{
+  total++
+  sl[total] = $0
+}
+
+function escape(t) {
+  gsub(/&/, "\\&amp;", t)
+  gsub(/</, "\\&lt;", t)
+  gsub(/>/, "\\&gt;", t)
+  return t
+}
+
+END {
+  # The DEBUG trap attributes a multi-line statement to its starting line, so
+  # the count carries forward across the backslash chain (#722).
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  for (ln = 1; ln <= total; ln++) {
+    row_class = ""
+    hits_display = ""
+
+    if (bu_is_executable(sl[ln])) {
+      h = (ln in hits) ? hits[ln] : 0
+      if (h > 0) {
+        row_class = "covered"
+        if (ln in tests) {
+          tooltip = "<div class=\"hits-tooltip\"><div class=\"hits-tooltip-title\">Tests hitting this line</div><ul class=\"hits-tooltip-list\">"
+          n = split(tests[ln], entries, "\n")
+          for (e = 1; e <= n; e++) {
+            if (entries[e] == "") { continue }
+            c = index(entries[e], ":")
+            if (c == 0) { tfile = entries[e]; tfn = "" } else { tfile = substr(entries[e], 1, c - 1); tfn = substr(entries[e], c + 1) }
+            sub(/^.*\//, "", tfile)
+            tooltip = tooltip "<li><span class=\"hits-tooltip-file\">" tfile "</span>:<span class=\"hits-tooltip-fn\">" tfn "</span></li>"
+          }
+          tooltip = tooltip "</ul></div>"
+          hits_display = "<span class=\"hits-badge has-tooltip\">" h times tooltip "</span>"
+        } else {
+          hits_display = "<span class=\"hits-badge\">" h times "</span>"
+        }
+      } else {
+        row_class = "uncovered"
+        hits_display = "<span class=\"hits-badge\">" h times "</span>"
+      }
+    }
+
+    printf "          <tr id=\"line-%s\" class=\"%s line-anchor\">\n", ln, row_class
+    printf "            <td class=\"line-num\">%s</td>\n", ln
+    printf "            <td class=\"hits\">%s</td>\n", hits_display
+    printf "            <td class=\"code\">%s</td>\n", escape(sl[ln])
+    printf "          </tr>\n"
+  }
+}
+'
+
+##
+# Emits the code-table rows of one page.
+# Arguments: $1 - source file, $2 - file holding its per-line test list
+##
+function bashunit::coverage::html_code_rows() {
+  local file="$1" tests_file="$2"
+
+  bashunit::coverage::ensure_hits_aggregated
+  bashunit::coverage::hits_file_for "$file"
+  local hits_file="$_BASHUNIT_COVERAGE_HITS_FILE_OUT"
+  if [ -z "$hits_file" ] || [ ! -f "$hits_file" ]; then
+    hits_file="/dev/null"
+  fi
+
+  # The multiplication sign comes in as a value, not as an awk escape: `\x` is
+  # not POSIX awk, so the byte sequence stays on the shell side.
+  env LC_ALL=C "$AWK" -v hitsfile="$hits_file" -v testsfile="$tests_file" -v times="×" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_HTML_ROWS}" \
+    "$hits_file" "$tests_file" "$file"
+}
+
 function bashunit::coverage::generate_file_html() {
   local file="$1"
   local output_file="$2"
@@ -27,47 +137,20 @@ function bashunit::coverage::generate_file_html() {
     ((++_fli))
   done <"$file"
 
-  # And their escaped form, in ONE awk pass for the whole file. Escaping per
-  # line cost a command substitution and a sed each -- about 22,000 processes
-  # for this repo, 58.7s of HTML report (#1096).
-  local -a escaped_lines=()
-  local _eli=0 _el
-  while IFS= read -r _el || [ -n "$_el" ]; do
-    escaped_lines[_eli]="$_el"
-    ((++_eli))
-  done < <(bashunit::coverage::html_escape_file "$file")
-
-  # Pre-load test hits data into indexed array (for tooltips)
-  # Index: line number, Value: newline-separated list of "test_file:test_function"
-  # Using indexed array for Bash 3.0 compatibility (no associative arrays)
-  local -a tests_by_line=()
-  local _line_and_test
-  while IFS= read -r _line_and_test; do
-    [ -z "$_line_and_test" ] && continue
-    local _tln="${_line_and_test%%|*}"
-    local _tinfo="${_line_and_test#*|}"
-    if [ -n "${tests_by_line[_tln]:-}" ]; then
-      # Append only if not already present (avoid duplicates)
-      # Use newline boundaries to prevent false positives (e.g., test_foo matching test_foo_bar)
-      case $'\n'"${tests_by_line[_tln]}"$'\n' in
-      *$'\n'"$_tinfo"$'\n'*)
-        # already present, skip
-        ;;
-      *)
-        tests_by_line[_tln]="${tests_by_line[_tln]}"$'\n'"${_tinfo}"
-        ;;
-      esac
-    else
-      tests_by_line[_tln]="$_tinfo"
-    fi
-  done < <(bashunit::coverage::get_all_line_tests "$file")
+  # The per-line test list, for the tooltips. It goes to a file because the row
+  # emitter below is one awk pass that reads it alongside the hits and the
+  # source (#1098).
+  local tests_file="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/page-tests"
+  if ! bashunit::coverage::get_all_line_tests "$file" >"$tests_file" 2>/dev/null; then
+    : >"$tests_file"
+  fi
 
   # Count total lines and functions
   local total_lines="${#file_lines[@]}"
   local non_executable=$((total_lines - executable))
 
   {
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -75,7 +158,7 @@ function bashunit::coverage::generate_file_html() {
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 EOF
     echo "  <title>${display_file##*/} | Coverage Report</title>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
   <style>
     :root {
       --primary: #6366f1; --primary-dark: #4f46e5; --primary-light: #818cf8;
@@ -214,20 +297,20 @@ EOF
         <div class="file-title">
 EOF
     echo "          <span class=\"file-name\">${display_file##*/}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
       <div class="stats-section">
         <div class="stat-item">
 EOF
     echo "          <span class=\"stat-badge coverage $class\">${pct}%</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <span class="stat-label">Coverage</span>
         </div>
         <div class="stat-item">
 EOF
     echo "          <span class=\"stat-badge lines\">${hit}/${executable}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <span class="stat-label">Lines</span>
         </div>
       </div>
@@ -240,12 +323,12 @@ EOF
           <span class="progress-label">Line Coverage Progress</span>
 EOF
     echo "          <span class=\"progress-percent $class\">${pct}%</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="progress-bar">
 EOF
     echo "          <div class=\"progress-fill $class\" style=\"width: ${pct}%;\"></div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
       <div class="legend">
@@ -253,19 +336,19 @@ EOF
           <span class="legend-color covered"></span>
 EOF
     echo "          <span>${hit} lines covered</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="legend-item">
           <span class="legend-color uncovered"></span>
 EOF
     echo "          <span>${uncovered} lines uncovered</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="legend-item">
           <span class="legend-color neutral"></span>
 EOF
     echo "          <span>${non_executable} non-executable</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
     </div>
@@ -277,7 +360,7 @@ EOF
     functions_data=$(bashunit::coverage::extract_functions "$file")
 
     if [ -n "$functions_data" ]; then
-      cat <<'EOF'
+      bashunit::coverage::emit_block <<'EOF'
   <div class="function-summary">
     <table class="function-table">
       <thead>
@@ -339,14 +422,14 @@ EOF
         echo "        </tr>"
       done <<<"$functions_data"
 
-      cat <<'EOF'
+      bashunit::coverage::emit_block <<'EOF'
       </tbody>
     </table>
   </div>
 EOF
     fi
 
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
   <div class="code-container">
     <div class="code-wrapper">
       <div class="code-header">
@@ -355,59 +438,15 @@ EOF
     echo "        <div class=\"code-stats\">"
     echo "          <span>${total_lines} total lines</span>"
     echo "        </div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
       </div>
       <div class="code-body">
         <table class="code-table">
 EOF
 
-    local lineno=0
-    local line
-    for line in "${file_lines[@]}"; do
-      ((++lineno))
+    bashunit::coverage::html_code_rows "$file" "$tests_file"
 
-      local escaped_line="${escaped_lines[$((lineno - 1))]:-}"
-
-      local row_class=""
-      local hits_display=""
-
-      if bashunit::coverage::is_executable_line "$line" "$lineno"; then
-        # O(1) lookup from pre-loaded array
-        local hits=${_BASHUNIT_COVERAGE_HITS_BY_LINE[$lineno]:-0}
-
-        if [ "$hits" -gt 0 ]; then
-          row_class="covered"
-
-          # Check if we have test info for this line
-          local test_info="${tests_by_line[$lineno]:-}"
-          if [ -n "$test_info" ]; then
-            # Build tooltip with test information
-            local tooltip_html="<div class=\"hits-tooltip\"><div class=\"hits-tooltip-title\">Tests hitting this line</div><ul class=\"hits-tooltip-list\">"
-            local test_file test_fn
-            while IFS=':' read -r test_file test_fn; do
-              [ -z "$test_file" ] && continue
-              local short_file="${test_file##*/}"
-              tooltip_html="$tooltip_html<li><span class=\"hits-tooltip-file\">${short_file}</span>:<span class=\"hits-tooltip-fn\">${test_fn}</span></li>"
-            done <<<"$test_info"
-            tooltip_html="$tooltip_html</ul></div>"
-            hits_display="<span class=\"hits-badge has-tooltip\">${hits}×${tooltip_html}</span>"
-          else
-            hits_display="<span class=\"hits-badge\">${hits}×</span>"
-          fi
-        else
-          row_class="uncovered"
-          hits_display="<span class=\"hits-badge\">${hits}×</span>"
-        fi
-      fi
-
-      echo "          <tr id=\"line-${lineno}\" class=\"$row_class line-anchor\">"
-      echo "            <td class=\"line-num\">$lineno</td>"
-      echo "            <td class=\"hits\">$hits_display</td>"
-      echo "            <td class=\"code\">$escaped_line</td>"
-      echo "          </tr>"
-    done
-
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </table>
       </div>
     </div>

--- a/src/coverage/html_index.sh
+++ b/src/coverage/html_index.sh
@@ -50,7 +50,7 @@ function bashunit::coverage::generate_index_html() {
   esac
 
   {
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -89,7 +89,7 @@ function bashunit::coverage::generate_index_html() {
     .gauge-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; width: 100%; }
 EOF
     echo "    .gauge-percent { font-size: 3.5rem; font-weight: 800; background: ${gauge_text_gradient}; -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; line-height: 1; margin: 0; display: block; }"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
     .gauge-label { color: var(--text-secondary); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 2px; margin: 0; display: block; }
     .gauge-info { flex: 1; }
     .gauge-title { font-size: 1.8rem; font-weight: 700; margin-bottom: 12px; }
@@ -179,7 +179,7 @@ EOF
         </div>
 EOF
     echo "        <div class=\"header-badge\">v${BASHUNIT_VERSION:-0.0.0}</div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
       </div>
       <h1 class="header-title">Code Coverage Report</h1>
       <p class="header-subtitle">Comprehensive line-by-line coverage analysis for your bash scripts</p>
@@ -194,18 +194,18 @@ EOF
 EOF
     echo "              <stop offset=\"0%\" style=\"stop-color:${gauge_color_start}\"/>"
     echo "              <stop offset=\"100%\" style=\"stop-color:${gauge_color_end}\"/>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
             </linearGradient>
           </defs>
           <circle class="gauge-bg" cx="80" cy="80" r="70"/>
 EOF
     echo "          <circle class=\"gauge-fill\" cx=\"80\" cy=\"80\" r=\"70\" stroke-dasharray=\"440\" stroke-dashoffset=\"${gauge_offset}\"/>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </svg>
         <div class="gauge-text">
 EOF
     echo "          <div class=\"gauge-percent\">${total_pct}%</div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <div class="gauge-label">Coverage</div>
         </div>
       </div>
@@ -213,7 +213,7 @@ EOF
         <h2 class="gauge-title">Overall Code Coverage</h2>
 EOF
     echo "        <p class=\"gauge-description\"><strong>${total_hit} of ${total_executable}</strong> executable lines covered across <strong>${file_count} files</strong>.</p>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 
         <div class="compact-metrics">
           <div class="metrics-group coverage-group">
@@ -224,21 +224,21 @@ EOF
                 <span class="breakdown-label">Total:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_executable} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot covered"></span>
                 <span class="breakdown-label">Covered:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_hit} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot uncovered"></span>
                 <span class="breakdown-label">Uncovered:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_uncovered} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
             </div>
           </div>
@@ -250,28 +250,28 @@ EOF
                 <span class="breakdown-label">Files:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${file_count}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests"></span>
                 <span class="breakdown-label">Tests:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_total} total</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests-passed"></span>
                 <span class="breakdown-label">Passed:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_passed}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests-failed"></span>
                 <span class="breakdown-label">Failed:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_failed}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
             </div>
           </div>
@@ -286,19 +286,19 @@ EOF
             <span class="legend-color high"></span>
 EOF
     echo "            <span>≥${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}% High</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
           <div class="legend-item">
             <span class="legend-color medium"></span>
 EOF
     echo "            <span>${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}-${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}% Medium</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
           <div class="legend-item">
             <span class="legend-color low"></span>
 EOF
     echo "            <span>&lt;${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}% Low</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
         </div>
       </div>
@@ -346,7 +346,7 @@ EOF
       echo "            </tr>"
     done
 
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </tbody>
         </table>
       </div>

--- a/src/coverage/report_html.sh
+++ b/src/coverage/report_html.sh
@@ -33,6 +33,21 @@ _BASHUNIT_COVERAGE_AWK_HTML_ESCAPE='
 '
 
 ##
+# Writes a heredoc block to stdout without forking.
+#
+# `cat <<EOF` is an external command, and the page emitter has 15 such blocks:
+# 1935 forks for a 129-page report, about 3 seconds of it (#1098). A read loop
+# over the same heredoc is a builtin, so the markup stays where it is and the
+# fork does not happen.
+##
+function bashunit::coverage::emit_block() {
+  local _line
+  while IFS= read -r _line || [ -n "$_line" ]; do
+    printf '%s\n' "$_line"
+  done
+}
+
+##
 # Escapes every line of $1, one line of output per line of input.
 # Arguments: $1 - source file
 ##


### PR DESCRIPTION
## 🤔 Background

Related #1098

After the escaping fix, `generate_file_html` was 8.1 s of a 9.5 s report: a
Bash loop classifying, looking up and echoing markup for each of 22,405 source
lines, plus 15 `cat <<EOF` blocks per page — 1935 forks for a 129-page report.

## 💡 Changes

- The code table is one awk pass, reading the hits block, the per-line test list and the source together
- Markup blocks go through a builtin read loop instead of `cat`
- 9.5 s → 4.5 s, or **58.7 s → 4.5 s** counting #1097
- Byte-identical on a fixed corpus, verified both with no hits and with real hits and tooltips — the no-hits corpus never renders a badge, so it alone would not catch a mistake there
- The badge's `×` is passed as an awk variable rather than `\xc3\x97`, since `\x` is not POSIX awk