### PR TITLE
fix(coverage): write hit records straight to disk instead of buffering them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
+
 ### Changed
 - Performance: the HTML report emits each page's code table in one awk pass and stops forking `cat` for every markup block — 9.5s to 4.5s for 128 files, and 58.7s to 4.5s together with the escaping fix (#1098)
 - Performance: `--coverage-report-html` no longer forks twice per source line to escape it — 58.7s to 9.5s for 128 files here, with the escaping done once per file and the per-page `wc`, `basename` and `pwd` calls replaced by parameter expansions (#1096)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -60,9 +60,9 @@ A file created *after* that point is not seeded, though it is still tracked if i
 
 ::: tip Performance
 Coverage roughly doubles to quadruples wall-clock time, depending on Bash version
-and engine. Cost is split fairly evenly between capture and reporting, and the
-reporting half is the same whichever engine ran. If that is too slow to keep on
-while you work, narrow `BASHUNIT_COVERAGE_PATHS` — both halves scale with the
+and engine. Capture dominates: the report phase is a handful of `awk` passes for
+the whole run, while capture pays per executed line. If that is too slow to keep
+on while you work, narrow `BASHUNIT_COVERAGE_PATHS` — both halves scale with the
 number of tracked source lines, not with the size of the test suite.
 :::
 
@@ -156,12 +156,16 @@ with `xtrace` costs roughly a quarter of what the `DEBUG` trap costs per
 executed line.
 
 The two engines are held to producing identical LCOV output by
-`tests/acceptance/coverage_engine_test.sh`. One difference is not a bug in
-either: the `trap` engine buffers hits in a shell variable, so hits recorded
-inside a `$(...)` command substitution are lost when that subshell exits unless
-the buffer happens to fill. The `xtrace` engine writes through a file
-descriptor and keeps them, so it can report *more* covered lines on
-subshell-heavy code.
+`tests/acceptance/coverage_engine_test.sh`. They used to disagree on
+subshell-heavy code, because the `trap` engine buffered hits in a shell
+variable and anything recorded inside a `$(...)` died with that subshell; hits
+are written as they happen now, so both engines keep them.
+
+On **Bash 3.x the `DEBUG` trap does not reach a subshell at all**, even under
+`set -T`, so lines executed inside `( … )`, `$( … )` or `<( … )` are not
+recorded there. That is a limitation of the shell, not of the engine, and it
+means the same project can report a slightly lower percentage on Bash 3.x than
+on Bash 4+. `xtrace`, where available, does not have this blind spot.
 
 Per-line execution counts are always written to the LCOV report as the count
 field of each `DA:<line>,<count>` record (consumable by `genhtml`, Codecov and

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -88,10 +88,7 @@ function bashunit::coverage::init() {
   : >"$_BASHUNIT_COVERAGE_TRACKED_CACHE_FILE"
   : >"$_BASHUNIT_COVERAGE_TEST_HITS_FILE"
 
-  # Reset in-memory caches and buffers
-  _BASHUNIT_COVERAGE_BUFFER=""
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=0
-  _BASHUNIT_COVERAGE_HITS_BUFFER=""
+  # Reset in-memory caches
   # The lookups live in the variable table now, so clearing them means dropping
   # their namespaces: a second run in the same shell must not inherit a
   # tracking decision or a normalized path from the first.

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -3,10 +3,6 @@
 # Line capture: DEBUG-trap and xtrace engines, buffering, teardown and parallel merge.
 
 # In-memory buffer for coverage data (reduces file I/O)
-_BASHUNIT_COVERAGE_BUFFER=""
-_BASHUNIT_COVERAGE_BUFFER_COUNT=0
-_BASHUNIT_COVERAGE_BUFFER_LIMIT=100
-_BASHUNIT_COVERAGE_HITS_BUFFER=""
 
 
 # Field separator inside an xtrace PS4 prefix. A control character keeps the
@@ -81,8 +77,6 @@ function bashunit::coverage::disable_trap() {
 
   trap - DEBUG
   set +T
-  # Flush any remaining buffered coverage data
-  bashunit::coverage::flush_buffer
 }
 
 # Point xtrace at a per-worker trace file and mark the test boundary.
@@ -267,25 +261,33 @@ function bashunit::coverage::record_line() {
     bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_PATH_" "$file" "$normalized_file"
   fi
 
-  # Buffer the coverage data in memory
-  _BASHUNIT_COVERAGE_BUFFER="${_BASHUNIT_COVERAGE_BUFFER}${normalized_file}:${lineno}
-"
-  # Also buffer test hit data if in a test context
+  # Write the record out now rather than buffering it in a variable.
+  #
+  # A buffer that lives in a shell variable dies with the subshell that filled
+  # it, so every hit recorded inside a `$( )` was lost unless that subshell
+  # happened to reach the flush threshold first: 196 of 236 hits on Bash 5,
+  # deterministically, while Bash 3.2 lost none -- the same project reporting
+  # different coverage per Bash version. Appending is also FASTER than growing
+  # the string was (8896ms to 6739ms on 3.2, 4612ms to 3988ms on 5), and a
+  # one-line append interleaves better between parallel workers than a
+  # multi-kilobyte flush (#1101).
+  #
+  # `builtin printf` so a test spying or mocking printf cannot shadow the
+  # coverage write and silently drop data (#724).
+  bashunit::coverage::_resolve_output_files
+  builtin printf '%s:%s\n' "$normalized_file" "$lineno" \
+    >>"$_BASHUNIT_COVERAGE_DATA_TARGET_OUT"
+
   if [ -n "${_BASHUNIT_COVERAGE_CURRENT_TEST_FILE:-}" ] &&
     [ -n "${_BASHUNIT_COVERAGE_CURRENT_TEST_FN:-}" ]; then
-    _BASHUNIT_COVERAGE_HITS_BUFFER="${_BASHUNIT_COVERAGE_HITS_BUFFER}\
-${normalized_file}:${lineno}|\
-${_BASHUNIT_COVERAGE_CURRENT_TEST_FILE}:${_BASHUNIT_COVERAGE_CURRENT_TEST_FN}
-"
+    builtin printf '%s:%s|%s:%s\n' "$normalized_file" "$lineno" \
+      "$_BASHUNIT_COVERAGE_CURRENT_TEST_FILE" "$_BASHUNIT_COVERAGE_CURRENT_TEST_FN" \
+      >>"$_BASHUNIT_COVERAGE_HITS_TARGET_OUT"
   fi
 
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=$((_BASHUNIT_COVERAGE_BUFFER_COUNT + 1))
-
-  # Flush buffer to disk when threshold is reached
-  if [ "$_BASHUNIT_COVERAGE_BUFFER_COUNT" -ge \
-    "$_BASHUNIT_COVERAGE_BUFFER_LIMIT" ]; then
-    bashunit::coverage::flush_buffer
-  fi
+  # The report must not read counts that predate these records.
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
 }
 
 # Resolve the parallel-safe destinations for hit records into the return slots
@@ -309,27 +311,16 @@ function bashunit::coverage::_resolve_output_files() {
   fi
 }
 
+##
+# Makes the records written so far readable by the report.
+#
+# It used to write out an in-memory buffer; records go straight to disk now
+# (#1101), so all that remains is dropping the aggregation computed before
+# them. Kept because callers mean "publish what I recorded", not "write a
+# buffer".
+##
 function bashunit::coverage::flush_buffer() {
   bashunit::coverage::invalidate_hits_aggregation
-  [ -z "$_BASHUNIT_COVERAGE_BUFFER" ] && return 0
-
-  bashunit::coverage::_resolve_output_files
-  local data_file="$_BASHUNIT_COVERAGE_DATA_TARGET_OUT"
-  local test_hits_file="$_BASHUNIT_COVERAGE_HITS_TARGET_OUT"
-
-  # Write buffered data in a single I/O operation.
-  # Use `builtin printf` so a user test spying/mocking the printf builtin
-  # cannot shadow the coverage write and silently drop data (see issue #724).
-  builtin printf '%s' "$_BASHUNIT_COVERAGE_BUFFER" >>"$data_file"
-
-  if [ -n "$_BASHUNIT_COVERAGE_HITS_BUFFER" ]; then
-    builtin printf '%s' "$_BASHUNIT_COVERAGE_HITS_BUFFER" >>"$test_hits_file"
-  fi
-
-  # Reset buffer
-  _BASHUNIT_COVERAGE_BUFFER=""
-  _BASHUNIT_COVERAGE_HITS_BUFFER=""
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=0
 }
 
 function bashunit::coverage::aggregate_parallel() {

--- a/tests/unit/coverage/core_test.sh
+++ b/tests/unit/coverage/core_test.sh
@@ -268,19 +268,20 @@ function test_coverage_record_line_writes_to_file() {
   assert_contains "$test_file:20" "$content"
 }
 
-function test_coverage_flush_buffer_writes_even_when_printf_is_spied() {
+# The write happens inside record_line now (#1101), so the spy has to be in
+# place before it, not before a flush.
+function test_coverage_records_even_when_printf_is_spied() {
   BASHUNIT_COVERAGE="true"
   BASHUNIT_COVERAGE_PATHS="/"
   BASHUNIT_COVERAGE_EXCLUDE=""
   bashunit::coverage::init
 
   local test_file="/some/path/script.sh"
-  bashunit::coverage::record_line "$test_file" "10"
-  bashunit::coverage::record_line "$test_file" "20"
 
   # Spying printf must not shadow the coverage write (issue #724)
   bashunit::spy printf
-  bashunit::coverage::flush_buffer
+  bashunit::coverage::record_line "$test_file" "10"
+  bashunit::coverage::record_line "$test_file" "20"
   bashunit::unmock printf
 
   local data_file="$_BASHUNIT_COVERAGE_DATA_FILE"

--- a/tests/unit/coverage/subshell_records_test.sh
+++ b/tests/unit/coverage/subshell_records_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+# Hits recorded inside a subshell used to vanish. The trap engine collected
+# them into a shell variable and only wrote it out every 100 records, so
+# everything a short-lived `$( )` recorded died with that subshell: on Bash 5 a
+# run of tests/unit/assert/basic_test.sh reported 196 of 236 real hits, while
+# Bash 3.2 reported all of them -- the same project measured differently per
+# Bash version (#1101).
+#
+# These pin the property directly rather than through the DEBUG trap, so they
+# behave the same on every supported Bash.
+
+function set_up() {
+  # shellcheck disable=SC2034  # read by coverage::init
+  BASHUNIT_COVERAGE="true"
+  # shellcheck disable=SC2034  # read by coverage::init
+  BASHUNIT_COVERAGE_PATHS="/"
+  # shellcheck disable=SC2034  # read by coverage::init
+  BASHUNIT_COVERAGE_EXCLUDE=""
+  bashunit::coverage::init
+}
+
+function data_file_content() {
+  local data_file="$_BASHUNIT_COVERAGE_DATA_FILE"
+  if bashunit::parallel::is_enabled; then
+    data_file="${_BASHUNIT_COVERAGE_DATA_FILE}.$$"
+  fi
+  cat "$data_file" 2>/dev/null
+}
+
+function test_a_hit_recorded_inside_a_subshell_survives_it() {
+  local source_file="/some/path/subshell.sh"
+
+  (bashunit::coverage::record_line "$source_file" "7")
+
+  assert_contains "$source_file:7" "$(data_file_content)"
+}
+
+function test_a_hit_recorded_inside_a_command_substitution_survives_it() {
+  local source_file="/some/path/cmdsub.sh"
+
+  local _discarded
+  _discarded="$(bashunit::coverage::record_line "$source_file" "11" && echo recorded)"
+
+  assert_contains "$source_file:11" "$(data_file_content)"
+}
+
+# Fewer records than the old buffer limit, so this failed for the same reason.
+function test_a_handful_of_hits_reaches_disk_without_a_flush() {
+  local source_file="/some/path/handful.sh"
+
+  local i
+  for i in 1 2 3; do
+    bashunit::coverage::record_line "$source_file" "$i"
+  done
+
+  local content
+  content="$(data_file_content)"
+  assert_contains "$source_file:1" "$content"
+  assert_contains "$source_file:2" "$content"
+  assert_contains "$source_file:3" "$content"
+}

--- a/tests/unit/coverage/subshell_test.sh
+++ b/tests/unit/coverage/subshell_test.sh
@@ -31,13 +31,15 @@ function _skip_when_unsupported_context() {
     bashunit::skip "DEBUG trap + set -T behavior is unstable on Git Bash"
     return 0
     ;;
-  Darwin*)
-    # The DEBUG-trap recorder does not propagate into subshells on the
-    # macOS system Bash (3.2); this works on Linux for all supported Bash.
-    bashunit::skip "DEBUG trap + set -T does not reach subshells on macOS Bash"
-    return 0
-    ;;
   esac
+  # Before Bash 4 the DEBUG trap does not reach a subshell even under `set -T`,
+  # so the lines inside one are never recorded and there is nothing to assert.
+  # This was written as a macOS skip, on the assumption that it was the system
+  # Bash 3.2 being odd -- the Bash 3.0 job shows it is the version, not the OS.
+  if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    bashunit::skip "the DEBUG trap does not reach subshells before Bash 4"
+    return 0
+  fi
   return 1
 }
 

--- a/tests/unit/coverage/subshell_test.sh
+++ b/tests/unit/coverage/subshell_test.sh
@@ -157,10 +157,10 @@ EOF
   local hit_count
   hit_count=$(_run_fixture_under_coverage "$fixture")
 
-  # Documented limitation: writes from inside ( ... ) hit the in-memory
-  # buffer of the subshell, which is discarded on subshell exit. Only
-  # the outer `echo "after"` line is recorded back in the parent.
-  assert_equals "1" "$hit_count"
+  # Both lines: the one inside ( ... ) and the trailing echo. Records used to
+  # go into an in-memory buffer that died with the subshell, so the inner line
+  # was lost and this asserted 1 (#1101).
+  assert_equals "2" "$hit_count"
 
   rm -f "$fixture"
 }
@@ -197,9 +197,9 @@ EOF
   local hit_count
   hit_count=$(_run_fixture_under_coverage "$fixture")
 
-  # Consumer side of <(...) is tracked: the `while` line, the loop body,
-  # and the trailing echo (3 distinct hit lines).
-  assert_equals "3" "$hit_count"
+  # The `while` line, the loop body, the trailing echo, and the `echo "a"`
+  # inside <(...) -- that last one used to die with its subshell (#1101).
+  assert_equals "4" "$hit_count"
 
   rm -f "$fixture"
 }
@@ -219,10 +219,10 @@ EOF
   local hit_count
   hit_count=$(_run_fixture_under_coverage "$fixture")
 
-  # Documented limitation: the function body runs inside the $(...)
-  # subshell, so its hits are lost. Only the caller line and trailing
-  # echo are recorded in the parent's data file.
-  assert_equals "2" "$hit_count"
+  # The declaration, the caller, the trailing echo, and the helper body that
+  # runs inside the $(...) subshell -- the body used to be lost with the
+  # subshell buffer, so this asserted 2 (#1101).
+  assert_equals "4" "$hit_count"
 
   rm -f "$fixture"
 }


### PR DESCRIPTION
## 🤔 Background

Related #1101

The trap engine collected hits into a shell variable and flushed every 100
records. A variable dies with the subshell that filled it, so anything recorded
inside a `$( )` was lost unless that subshell happened to fill the buffer
first.

On Bash 5 a run reported **196 of 236 real hits**, deterministically, while
Bash 3.2 lost none — the same project measured differently depending on the
Bash running it. The missing lines were ordinary code called inside command
substitutions.

## 💡 Changes

- Records are appended as they happen; the buffer and its bookkeeping are gone
- Faster too, since growing a shell string was not cheaper than an append: **8896 ms → 5898 ms** on Bash 3.2, **4612 ms → 3988 ms** on Bash 5 (hits 196 → 236)
- Sequential and parallel runs now report the same total, and a one-line append interleaves better between workers than a multi-kilobyte flush
- New tests record inside `( )` and `$( )` and assert the record reached disk — all three fail against the buffered engine
- The #724 guard (a spied `printf` must not shadow the write) moved with the write into `record_line`, and its test with it