### PR TITLE
perf(coverage): normalize a path with one fork instead of four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
 
 ### Changed
+- Performance: coverage normalizes a source path with one fork instead of four, which the DEBUG trap pays on every cache miss — 2081ms to 424ms per 500 calls, taking a `--coverage` run of one test file from 6.4s to 4.7s (#1102)
 - Performance: the HTML report emits each page's code table in one awk pass and stops forking `cat` for every markup block — 9.5s to 4.5s for 128 files, and 58.7s to 4.5s together with the escaping fix (#1098)
 - Performance: `--coverage-report-html` no longer forks twice per source line to escape it — 58.7s to 9.5s for 128 files here, with the escaping done once per file and the per-page `wc`, `basename` and `pwd` calls replaced by parameter expansions (#1096)
 - Performance: the coverage report picks its colours without a subshell per file and per function — the text report over 128 files went from 387ms to 318ms, and 4042ms to 3116ms with `BASHUNIT_COVERAGE_SHOW_FUNCTIONS` on (#1092)

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -78,12 +78,30 @@ function bashunit::coverage::reset_lookup_namespace() {
 function bashunit::coverage::normalize_path() {
   local file="$1"
 
-  # Normalize path to absolute
-  if [ -f "$file" ]; then
-    echo "$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
-  else
-    echo "$file"
+  [ -f "$file" ] || {
+    # `builtin printf` throughout: a test spying or mocking printf must not be
+    # able to shadow a path the coverage engine depends on (#724).
+    builtin printf '%s' "$file"
+    return 0
+  }
+
+  # One fork, not four. This runs on every cache miss in the DEBUG trap -- 494
+  # times in a single run of one test file -- and `$(cd "$(dirname X)" && pwd)`
+  # plus `$(basename X)` is a command substitution each: 2081ms per 500 calls
+  # against 424ms this way (#1102).
+  #
+  # The `cd` stays: it resolves symlinks, so `/tmp/x` normalizes to
+  # `/private/tmp/x` on macOS the way the rest of the tracking expects. Pure
+  # string manipulation would be faster still and would report the unresolved
+  # path, which no longer matches the tracked roots.
+  local dir="${file%/*}" base="${file##*/}"
+  if [ "$dir" = "$file" ]; then
+    dir="."
+  elif [ -z "$dir" ]; then
+    dir="/"
   fi
+
+  builtin printf '%s/%s' "$(cd "$dir" 2>/dev/null && pwd)" "$base"
 }
 
 # Get deduplicated list of tracked files


### PR DESCRIPTION
## 🤔 Background

Related #1102

`normalize_path` is what the DEBUG trap calls on every cache miss — 494 times
in a single run of one test file, because the caches live in shell variables
and each test body is a subshell. Its body was

```bash
echo "$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
```

four command substitutions per call.

## 💡 Changes

- `dirname`/`basename` become parameter expansions, leaving one fork: **2081 ms → 424 ms** per 500 calls, and a `--coverage` run of `basic_test.sh` **6.4 s → 4.7 s** with the same hit count
- `cd`+`pwd` stays deliberately: it resolves symlinks, so `/tmp/x` normalizes to `/private/tmp/x` on macOS the way the tracked roots expect. Pure string manipulation is faster still and would quietly stop matching them
- `builtin printf`, not `printf`, so a test spying `printf` cannot shadow a path the engine depends on — the #724 test caught exactly that during development

Note the issue's original premise (path *mangling* dominates) was wrong and is
corrected in the thread: the memo it proposed bought 4%, this buys 27%.