### PR TITLE
perf(coverage): read the tracking decision cache once per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
 
 ### Changed
+- Performance: the coverage tracking decision cache is read once per process instead of `grep`-ing the file per lookup — 2ms to 0.064ms per lookup, and a `--coverage` run of one test file from 4.4s to 3.3s (#1104)
 - Performance: coverage normalizes a source path with one fork instead of four, which the DEBUG trap pays on every cache miss — 2081ms to 424ms per 500 calls, taking a `--coverage` run of one test file from 6.4s to 4.7s (#1102)
 - Performance: the HTML report emits each page's code table in one awk pass and stops forking `cat` for every markup block — 9.5s to 4.5s for 128 files, and 58.7s to 4.5s together with the escaping fix (#1098)
 - Performance: `--coverage-report-html` no longer forks twice per source line to escape it — 58.7s to 9.5s for 128 files here, with the escaping done once per file and the per-page `wc`, `basename` and `pwd` calls replaced by parameter expansions (#1096)

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -89,6 +89,10 @@ function bashunit::coverage::init() {
   : >"$_BASHUNIT_COVERAGE_TEST_HITS_FILE"
 
   # Reset in-memory caches
+  _BASHUNIT_COVERAGE_DISKCACHE_FILE=""
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
   # The lookups live in the variable table now, so clearing them means dropping
   # their namespaces: a second run in the same shell must not inherit a
   # tracking decision or a normalized path from the first.

--- a/src/coverage/paths.sh
+++ b/src/coverage/paths.sh
@@ -266,6 +266,69 @@ function bashunit::coverage::_seed_emit() {
   printf '%s\n' "$file" >>"$_BASHUNIT_COVERAGE_TRACKED_FILES"
 }
 
+# The decision cache on disk, read into memory once per process.
+#
+# It used to be consulted with `grep "^$file:" | head -1`, three processes per
+# lookup, on every in-memory miss -- and the in-memory caches die with each
+# test subshell, so that was 1427 lookups in a single run of one test file:
+# 2ms each against 0.064ms for an in-memory scan of the same 13 entries
+# (#1104). The same shape #1076 removed from the stats cache.
+#
+# Entries this process writes are appended to both, so the file is read once
+# and never re-read. A worker that misses an entry another worker appended
+# afterwards just recomputes it, which is the same decision at a little cost.
+_BASHUNIT_COVERAGE_DISKCACHE_FILE=""
+_BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+_BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+_BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
+
+function bashunit::coverage::_diskcache_load() {
+  local cache_file="$1"
+  [ "$_BASHUNIT_COVERAGE_DISKCACHE_FILE" = "$cache_file" ] && return 0
+
+  _BASHUNIT_COVERAGE_DISKCACHE_FILE="$cache_file"
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
+  [ -f "$cache_file" ] || return 0
+
+  local line idx=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    _BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]="${line%:*}"
+    _BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]="${line##*:}"
+    idx=$((idx + 1))
+  done <"$cache_file"
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=$idx
+}
+
+# Sets _BASHUNIT_COVERAGE_DISKCACHE_OUT to the cached decision, or returns 1.
+_BASHUNIT_COVERAGE_DISKCACHE_OUT=""
+
+function bashunit::coverage::_diskcache_get() {
+  local file="$1" idx=0
+  while [ "$idx" -lt "$_BASHUNIT_COVERAGE_DISKCACHE_COUNT" ]; do
+    if [ "${_BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]}" = "$file" ]; then
+      _BASHUNIT_COVERAGE_DISKCACHE_OUT="${_BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]}"
+      return 0
+    fi
+    idx=$((idx + 1))
+  done
+  return 1
+}
+
+# Records a decision in the file and in the copy this process is reading.
+function bashunit::coverage::_diskcache_put() {
+  local cache_file="$1" file="$2" decision="$3"
+  { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } || return 0
+
+  echo "${file}:${decision}" >>"$cache_file"
+  local idx="$_BASHUNIT_COVERAGE_DISKCACHE_COUNT"
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]="$file"
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]="$decision"
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=$((idx + 1))
+}
+
 function bashunit::coverage::should_track() {
   local file="$1"
 
@@ -281,15 +344,16 @@ function bashunit::coverage::should_track() {
   local cache_file="$_BASHUNIT_COVERAGE_TRACKED_CACHE_FILE"
   if bashunit::parallel::is_enabled && [ -n "$cache_file" ]; then
     cache_file="${cache_file}.$$"
-    # Initialize per-process cache if needed
-    [ ! -f "$cache_file" ] && [ -d "$(dirname "$cache_file")" ] && : >"$cache_file"
+    # Initialize per-process cache if needed. `${cache_file%/*}` rather than
+    # dirname: this runs per call, and a fork here is a fork per file.
+    if [ ! -f "$cache_file" ] && [ -d "${cache_file%/*}" ]; then
+      : >"$cache_file"
+    fi
   fi
-  if [ -n "$cache_file" ] && [ -f "$cache_file" ]; then
-    local cached_decision
-    # Use || true to prevent exit in strict mode when grep finds no match
-    cached_decision=$(grep "^${file}:" "$cache_file" 2>/dev/null | head -1) || true
-    if [ -n "$cached_decision" ]; then
-      [ "${cached_decision##*:}" = "1" ] && return 0 || return 1
+  if [ -n "$cache_file" ]; then
+    bashunit::coverage::_diskcache_load "$cache_file"
+    if bashunit::coverage::_diskcache_get "$file"; then
+      [ "$_BASHUNIT_COVERAGE_DISKCACHE_OUT" = "1" ] && return 0 || return 1
     fi
   fi
 
@@ -307,7 +371,7 @@ function bashunit::coverage::should_track() {
     *$pattern*)
       IFS="$old_ifs"
       # Cache exclusion decision (use per-process cache in parallel mode)
-      { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:0" >>"$cache_file"
+      bashunit::coverage::_diskcache_put "$cache_file" "$file" "0"
       return 1
       ;;
     esac
@@ -347,12 +411,12 @@ function bashunit::coverage::should_track() {
 
   if [ "$matched" = "false" ]; then
     # Cache exclusion decision (use per-process cache in parallel mode)
-    { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:0" >>"$cache_file"
+    bashunit::coverage::_diskcache_put "$cache_file" "$file" "0"
     return 1
   fi
 
   # Cache tracking decision (use per-process cache in parallel mode)
-  { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:1" >>"$cache_file"
+  bashunit::coverage::_diskcache_put "$cache_file" "$file" "1"
 
   # Track this file for later reporting
   # In parallel mode, use a per-process file to avoid race conditions


### PR DESCRIPTION
## 🤔 Background

Related #1104

`should_track` consulted its on-disk decision cache with
`$(grep "^${file}:" "$cache_file" | head -1)` — three processes per lookup. The
in-memory caches die with each test subshell, so that ran **1427 times in one
run of one test file**, over 13 distinct files.

## 💡 Changes

- The cache file is read once per process into memory; entries this process writes go to both copies, so it is never re-read
- 2 ms → 0.064 ms per lookup; a `--coverage` run of one test file **4.4 s → 3.3 s**, same hit count, sequential and parallel agreeing
- The `dirname` fork in the parallel cache path goes too — it ran per call
- Same shape #1076 removed from the stats cache: a cache costing more than the computation it replaces