### PR TITLE
perf(coverage): look a file up once per executed line, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
 
 ### Changed
+- Performance: the coverage trap looks a file up once per executed line instead of twice, keeping the tracked decision and the normalized path under one key — about 8% off a `--coverage` run (#1110)
 - Performance: the coverage tracking decision cache is read once per process instead of `grep`-ing the file per lookup — 2ms to 0.064ms per lookup, and a `--coverage` run of one test file from 4.4s to 3.3s (#1104)
 - Performance: coverage normalizes a source path with one fork instead of four, which the DEBUG trap pays on every cache miss — 2081ms to 424ms per 500 calls, taking a `--coverage` run of one test file from 6.4s to 4.7s (#1102)
 - Performance: the HTML report emits each page's code table in one awk pass and stops forking `cat` for every markup block — 9.5s to 4.5s for 128 files, and 58.7s to 4.5s together with the escaping fix (#1098)

--- a/src/coverage/config.sh
+++ b/src/coverage/config.sh
@@ -99,8 +99,7 @@ function bashunit::coverage::init() {
   bashunit::coverage::build_trap_glob
   export _BASHUNIT_COVERAGE_TRAP_GLOB
   bashunit::coverage::invalidate_hits_aggregation
-  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_TRACK_"
-  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_PATH_"
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_FILE_"
   _BASHUNIT_COVERAGE_IS_PARALLEL=""
   _BASHUNIT_COVERAGE_STATS_FILES=()
   _BASHUNIT_COVERAGE_STATS_EXEC=()

--- a/src/coverage/engine.sh
+++ b/src/coverage/engine.sh
@@ -236,29 +236,25 @@ function bashunit::coverage::record_line() {
   # Skip if coverage data file doesn't exist (trap inherited by child process)
   [ -z "$_BASHUNIT_COVERAGE_DATA_FILE" ] && return 0
 
-  # Fast in-memory should_track cache (avoids grep + file I/O per line)
-  local decision=""
-  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_TRACK_" "$file"; then
-    decision="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+  # One cache, not two: the decision and the normalized path live under a
+  # single key, so a line pays the ${file//[^a-zA-Z0-9]/_} key rebuild once
+  # instead of twice (#1110). Value is "0" or "1 <normalized path>".
+  local entry="" decision="" normalized_file=""
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_FILE_" "$file"; then
+    entry="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+    decision="${entry%% *}"
+    [ "$decision" = "0" ] && return 0
+    normalized_file="${entry#* }"
   else
     if bashunit::coverage::should_track "$file"; then
       decision=1
+      normalized_file=$(bashunit::coverage::normalize_path "$file")
+      bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_FILE_" "$file" \
+        "1 $normalized_file"
     else
-      decision=0
+      bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_FILE_" "$file" "0"
+      return 0
     fi
-    bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_TRACK_" "$file" "$decision"
-  fi
-  if [ "$decision" = "0" ]; then
-    return 0
-  fi
-
-  # Fast in-memory path normalization cache (avoids cd + pwd subshell per line)
-  local normalized_file=""
-  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_PATH_" "$file"; then
-    normalized_file="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
-  else
-    normalized_file=$(bashunit::coverage::normalize_path "$file")
-    bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_PATH_" "$file" "$normalized_file"
   fi
 
   # Write the record out now rather than buffering it in a variable.


### PR DESCRIPTION
## 🤔 Background

Related #1110

The tracked decision and the normalized path lived in separate cache
namespaces, so every recorded line rebuilt the `${file//[^a-zA-Z0-9]/_}` cache
key twice.

## 💡 Changes

- One key holds `"<decision> <normalized path>"`; a line pays the key rebuild once
- **3197 ms → 2953 ms** for `--coverage` over `src` on one test file, same hit count, sequential and parallel agreeing — and one namespace fewer to reset

## Not landing

The issue's other half — holding the two record files open on fixed
descriptors instead of `>>` per record — measured **6%** and would add two
globals, reopen-on-target-change and a close path, with fds 200/201 visible to
user test code. This one is 8% and *removes* state, so it is the one worth
having. Worth noting the stage attribution predicted 20% for the descriptors;
in-situ measurement disagreed, as it did with the memo in #1102.