### PR TITLE
feat(coverage): warn under --verbose that Bash 3.x misses subshell lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
+
 ### Fixed
 - Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
 

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -163,7 +163,8 @@ are written as they happen now, so both engines keep them.
 
 On **Bash 3.x the `DEBUG` trap does not reach a subshell at all**, even under
 `set -T`, so lines executed inside `( … )`, `$( … )` or `<( … )` are not
-recorded there. That is a limitation of the shell, not of the engine, and it
+recorded there. `--verbose` says so next to the engine it reports, since the
+percentage alone gives no hint. That is a limitation of the shell, not of the engine, and it
 means the same project can report a slightly lower percentage on Bash 3.x than
 on Bash 4+. `xtrace`, where available, does not have this blind spot.
 

--- a/src/coverage/report_text.sh
+++ b/src/coverage/report_text.sh
@@ -19,6 +19,18 @@ function bashunit::coverage::print_engine_notice() {
 
   if bashunit::env::is_verbose_enabled; then
     printf "Coverage engine: %s\n" "$(bashunit::coverage::engine_in_use)"
+
+    # Before Bash 4 the DEBUG trap does not reach a subshell even under
+    # `set -T`, so lines executed inside ( ), $( ) or <( ) are never recorded
+    # and the percentage comes out lower than the same project measures on
+    # Bash 4+. Nothing in the numbers hints at it, so say it where the engine
+    # is already being reported (#1112).
+    if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+      printf "%sNote: Bash %s.%s does not report lines run inside a subshell; \
+coverage may read lower than on Bash 4+.%s\n" \
+        "$_BASHUNIT_COLOR_INCOMPLETE" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" \
+        "$_BASHUNIT_COLOR_DEFAULT"
+    fi
   fi
 }
 

--- a/tests/unit/coverage/engine_notice_test.sh
+++ b/tests/unit/coverage/engine_notice_test.sh
@@ -41,6 +41,7 @@ function test_bash_four_and_newer_get_no_note() {
 }
 
 function test_the_note_is_verbose_only() {
+  # shellcheck disable=SC2034  # read by the notice under test
   BASHUNIT_VERBOSE=false
 
   local output

--- a/tests/unit/coverage/engine_notice_test.sh
+++ b/tests/unit/coverage/engine_notice_test.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Before Bash 4 the DEBUG trap does not reach a subshell even under `set -T`,
+# so lines run inside ( ), $( ) or <( ) are never recorded and the percentage
+# comes out lower than the same project measures on Bash 4+. The numbers give
+# no hint of it, so `--verbose` says so next to the engine it already reports
+# (#1112).
+
+function set_up() {
+  # shellcheck disable=SC2034  # read by the header under test
+  BASHUNIT_VERBOSE=true
+  # shellcheck disable=SC2034  # read by coverage::init
+  BASHUNIT_COVERAGE="true"
+}
+
+function header_output() {
+  bashunit::coverage::print_engine_notice 2>&1
+}
+
+function test_the_note_names_the_running_bash_when_it_is_older_than_four() {
+  if [ "${BASH_VERSINFO[0]:-0}" -ge 4 ]; then
+    bashunit::skip "the note is only for Bash 3.x" && return
+  fi
+
+  local output
+  output="$(header_output)"
+
+  assert_contains "does not report lines run inside a subshell" "$output"
+  assert_contains "Bash ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}" "$output"
+}
+
+function test_bash_four_and_newer_get_no_note() {
+  if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    bashunit::skip "the note is expected on Bash 3.x" && return
+  fi
+
+  local output
+  output="$(header_output)"
+
+  assert_not_contains "does not report lines run inside a subshell" "$output"
+}
+
+function test_the_note_is_verbose_only() {
+  BASHUNIT_VERBOSE=false
+
+  local output
+  output="$(header_output)"
+
+  assert_not_contains "does not report lines run inside a subshell" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1112

Before Bash 4 the `DEBUG` trap does not reach a subshell even under `set -T`,
so lines run inside `( )`, `$( )` or `<( )` are never recorded. The same project
reads lower on Bash 3.x than on Bash 4+ and nothing says why — usually on the
machine where `trap` is the only engine available.

Found while fixing #1101: the Bash 3.0 job kept the old counts after that fix,
because there had never been anything to buffer there.

## 💡 Changes

- `--verbose` prints the note next to the engine it already reports, so a normal run gains no noise:

  ```
  Coverage engine: trap
  Note: Bash 3.2 does not report lines run inside a subshell; coverage may read lower than on Bash 4+.
  ```

- Bash 3.x only — verified silent on Bash 5 — with tests for all three cases (3.x note, 4+ silence, non-verbose silence) and a line in `docs/coverage.md`