### PR TITLE
fix(assert): a dash-leading needle and backslashes in assert_equals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+- `assert_file_contains` accepts a needle that starts with a dash instead of failing with `grep: invalid option`, and `assert_file_not_contains` matches literally like its counterpart, so `a.c` no longer matches `abc` (#1108)
+- `assert_equals` no longer expands backslash escapes while normalizing, so `C:\` and `C:\\` compare as different, and a literal `\t` is no longer equal to a real tab. It still ignores ANSI sequences and control characters, which is what it documents (#1108)
+
 ### Added
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 

--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -157,6 +157,10 @@ function test_failure() {
 
 Reports an error if the two variables `expected` and `actual` are not equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
 
+Those are *characters*, not escape sequences. A backslash followed by `t` is
+two characters and stays two characters, so comparing it against a real tab
+fails; only the tab itself is stripped.
+
 - [assert_same](#assert-same) is similar but including special chars.
 
 ::: code-group

--- a/src/assert/files.sh
+++ b/src/assert/files.sh
@@ -314,7 +314,9 @@ function assert_file_contains() {
   local file="$1"
   local string="$2"
 
-  if ! grep -F -q "$string" "$file"; then
+  # `-e` and `--`: a needle starting with a dash is a pattern, not an option,
+  # and a file named like one is still a file (#1108).
+  if ! grep -F -q -e "$string" -- "$file"; then
     bashunit::assert::fail_with "" "${file}" "to contain" "${string}"
     return
   fi
@@ -328,7 +330,9 @@ function assert_file_not_contains() {
   local file="$1"
   local string="$2"
 
-  if grep -q "$string" "$file"; then
+  # -F for the same reason assert_file_contains uses it: the needle is a
+  # literal, so `a.c` must not match `abc` here either (#1108).
+  if grep -F -q -e "$string" -- "$file"; then
     bashunit::assert::fail_with "" "${file}" "to not contain" "${string}"
     return
   fi

--- a/src/util/str.sh
+++ b/src/util/str.sh
@@ -75,7 +75,11 @@ function bashunit::str::strip_ansi_to_slot() {
     fi
     ;;
   esac
-  _BASHUNIT_STR_STRIPPED_OUT=$(echo -e "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g')
+  # `printf '%s'`, never `echo -e`: this normalizes ANSI and control bytes for
+  # the comparison, and interpreting backslash escapes on the way made
+  # assert_equals read `C:\` and `C:\\` as the same value, and a literal
+  # `\t` as a real tab (#1108). Normalizing must not rewrite what it compares.
+  _BASHUNIT_STR_STRIPPED_OUT=$(printf '%s' "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g')
 }
 
 # Strip ANSI escape codes and control characters, echoing the result.

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_all_assert_docs.snapshot
@@ -31,6 +31,10 @@ Reports an error if the `expected` and `actual` are not the same - including spe
 
 Reports an error if the two variables `expected` and `actual` are not equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
 
+Those are *characters*, not escape sequences. A backslash followed by `t` is
+two characters and stays two characters, so comparing it against a real tab
+fails; only the tab itself is stripped.
+
 - assert_same is similar but including special chars.
 
 

--- a/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_filtered_assert_docs.snapshot
+++ b/tests/acceptance/snapshots/bashunit_test_sh.test_bashunit_should_display_filtered_assert_docs.snapshot
@@ -4,6 +4,10 @@
 
 Reports an error if the two variables `expected` and `actual` are not equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
 
+Those are *characters*, not escape sequences. A backslash followed by `t` is
+two characters and stays two characters, so comparing it against a real tab
+fails; only the tab itself is stripped.
+
 - assert_same is similar but including special chars.
 
 

--- a/tests/unit/assert/basic_test.sh
+++ b/tests/unit/assert/basic_test.sh
@@ -256,3 +256,37 @@ function test_assert_true_variadic_reports_a_missing_command() {
       "unknown command: definitely_not_a_command --flag")" \
     "$(assert_true definitely_not_a_command --flag)"
 }
+
+# assert_equals normalizes ANSI and control characters, which it did by piping
+# through `echo -e` -- and that interprets backslash escapes, so a trailing
+# backslash and an escaped one compared equal, as did a literal `\t` and a real
+# tab. Normalizing must not rewrite the values it is comparing (#1108).
+function test_assert_equals_distinguishes_a_backslash_from_an_escaped_one() {
+  # Built with printf so the backslashes are unambiguous to reader and linter
+  # alike: one trailing backslash against two.
+  local bs one two
+  # shellcheck disable=SC1003  # a lone backslash is the value under test
+  bs="$(printf '\\')"
+  one="C:$bs"
+  two="C:$bs$bs"
+
+  assert_same \
+    "$(bashunit::console_results::print_failed_test \
+      "Assert equals distinguishes a backslash from an escaped one" \
+      "$one" "but got " "$two")" \
+    "$(assert_equals "$one" "$two")"
+}
+
+function test_assert_equals_distinguishes_an_escape_sequence_from_the_character() {
+  local with_real_tab
+  with_real_tab="$(printf 'a\tb')"
+
+  # The reported values are the normalized ones, which is the point of the
+  # normalization: the real tab is a control byte and is stripped, so `ab` is
+  # what the comparison saw. The literal `a\tb` keeps its backslash.
+  assert_same \
+    "$(bashunit::console_results::print_failed_test \
+      "Assert equals distinguishes an escape sequence from the character" \
+      'a\tb' "but got " "ab")" \
+    "$(assert_equals 'a\tb' "$with_real_tab")"
+}

--- a/tests/unit/assert/files_test.sh
+++ b/tests/unit/assert/files_test.sh
@@ -170,6 +170,36 @@ function test_fails_assert_file_contains() {
   rm "$file"
 }
 
+# A pattern that starts with a dash is a pattern, not an option. grep read it
+# as one and failed the assertion with "grep: invalid option" (#1108).
+function test_assert_file_contains_accepts_a_pattern_starting_with_a_dash() {
+  local file
+  file="$(bashunit::temp_file dash_pattern)"
+  printf 'ssh -o BatchMode=yes host uptime\n' >"$file"
+
+  # A passing assertion prints nothing; the bug printed grep's usage text.
+  assert_empty "$(assert_file_contains "$file" "-o BatchMode=yes" 2>&1)"
+}
+
+function test_assert_file_not_contains_accepts_a_pattern_starting_with_a_dash() {
+  local file
+  file="$(bashunit::temp_file dash_pattern_absent)"
+  printf 'ssh host uptime\n' >"$file"
+
+  assert_empty "$(assert_file_not_contains "$file" "-o BatchMode=yes" 2>&1)"
+}
+
+# The needle is a literal string in both directions: assert_file_contains says
+# so with `grep -F`, and its negative counterpart has to agree or `a.c` matches
+# `abc` only when you assert the absence (#1108).
+function test_assert_file_not_contains_treats_the_needle_as_a_literal() {
+  local file
+  file="$(bashunit::temp_file literal_needle)"
+  printf 'abc\n' >"$file"
+
+  assert_empty "$(assert_file_not_contains "$file" "a.c" 2>&1)"
+}
+
 function test_successful_assert_file_not_contains() {
   local file="/tmp/test_successful_assert_file_not_contains"
   echo -e "original content" >"$file"

--- a/tests/unit/util/str_test.sh
+++ b/tests/unit/util/str_test.sh
@@ -56,10 +56,19 @@ function test_strip_ansi_percent_is_unchanged() {
   assert_same "100% done" "$(bashunit::str::strip_ansi "100% done")"
 }
 
-function test_strip_ansi_backslash_escape_is_expanded_then_stripped() {
-  # A literal backslash sends input through the slow path, where echo -e
-  # expands "\t" to a tab and sed then strips it as a control char
-  assert_same "col1col2" "$(bashunit::str::strip_ansi "col1\\tcol2")"
+function test_strip_ansi_keeps_a_literal_backslash_escape() {
+  # A literal backslash sends input through the slow path, which used to run
+  # `echo -e` and expand "\t" into a tab that sed then stripped -- so
+  # assert_equals could not tell `a\tb` from a real tab, nor `C:\` from `C:\\`
+  # (#1108). Normalizing ANSI and control bytes must not rewrite the text.
+  assert_same "col1\\tcol2" "$(bashunit::str::strip_ansi "col1\\tcol2")"
+}
+
+function test_strip_ansi_still_strips_a_real_control_character() {
+  local with_tab
+  with_tab="$(printf 'col1\tcol2')"
+
+  assert_same "col1col2" "$(bashunit::str::strip_ansi "$with_tab")"
 }
 
 function test_rpad_default_width_padding_and_empty_left_text() {


### PR DESCRIPTION
## 🤔 Background

Related #1108 — two defects from one report, both against 0.47.0.

## 💡 Changes

- `assert_file_contains` passes the needle through `-e` and `--`, so `"-o BatchMode=yes"` is a pattern rather than options and no longer dies with `grep: invalid option`
- `assert_file_not_contains` gains the `-F` its counterpart already had: `a.c` matched `abc` when asserting absence but not when asserting presence
- `assert_equals` normalizes with `printf '%s'` instead of `echo -e`, which was **interpreting** backslash escapes — so `C:\` equalled `C:\\`, and a literal `\t` equalled a real tab. It still strips ANSI sequences and control characters, which is all it documents
- A test pinned the old expansion as intentional; it now pins the opposite, with a companion test for a real control character. Doc snapshot regenerated, and the `assert_equals` docs now say the ignored specials are *characters*, not escape sequences