### PR TITLE
perf(coverage): take the HTML function counts from the pass that scanned the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Coverage no longer loses hits recorded inside a command substitution: the DEBUG-trap engine buffered them in a shell variable, which dies with the subshell that filled it, so on Bash 5 a run reported 196 of 236 real hits while Bash 3.2 reported all of them — the same project measured differently per Bash version. Records go straight to disk, which is also 14-24% faster than the buffer was (#1101)
 
 ### Changed
+- Performance: the HTML report gets each function's line counts from the pass that already scanned the file, instead of walking every function's lines again in Bash — a 128-file report from 4.8s to 3.5s (#1099)
 - Performance: the coverage trap looks a file up once per executed line instead of twice, keeping the tracked decision and the normalized path under one key — about 8% off a `--coverage` run (#1110)
 - Performance: the coverage tracking decision cache is read once per process instead of `grep`-ing the file per lookup — 2ms to 0.064ms per lookup, and a `--coverage` run of one test file from 4.4s to 3.3s (#1104)
 - Performance: coverage normalizes a source path with one fork instead of four, which the DEBUG trap pays on every cache miss — 2081ms to 424ms per 500 calls, taking a `--coverage` run of one test file from 6.4s to 4.7s (#1102)

--- a/src/coverage/html_file.sh
+++ b/src/coverage/html_file.sh
@@ -91,6 +91,72 @@ END {
 }
 '
 
+# Function spans with their line counts, in one awk pass.
+#
+# The page used to call extract_functions and then, for every function, walk
+# fn_start..fn_end in Bash calling the classifier per line -- a second full
+# classification pass over every file, about 22,000 calls for this repo and
+# ~1.5s of a 4.5s report (#1099). The scanner already runs here, so the counts
+# come out of the same walk.
+#
+# Output: "<name>|<start>|<end>|<executable>|<hit>".
+# shellcheck disable=SC2016
+_BASHUNIT_COVERAGE_AWK_HTML_FUNCTIONS='
+FILENAME == hitsfile {
+  hits[$1 + 0] = $2 + 0
+  next
+}
+
+{
+  total++
+  sl[total] = $0
+}
+
+END {
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  bu_fn_reset()
+  for (ln = 1; ln <= total; ln++) { bu_fn_line(sl[ln], ln) }
+  bu_fn_finish(total)
+
+  for (i = 1; i <= fn_count; i++) {
+    executable = 0
+    hit = 0
+    for (ln = fns[i]; ln <= fne[i]; ln++) {
+      if (!bu_is_executable(sl[ln])) { continue }
+      executable++
+      if ((ln in hits) && hits[ln] > 0) { hit++ }
+    }
+    print fnn[i] "|" fns[i] "|" fne[i] "|" executable "|" hit
+  }
+}
+'
+
+##
+# Emits "<name>|<start>|<end>|<executable>|<hit>" for every function in $1.
+# Arguments: $1 - source file
+##
+function bashunit::coverage::html_function_rows() {
+  local file="$1"
+
+  bashunit::coverage::ensure_hits_aggregated
+  bashunit::coverage::hits_file_for "$file"
+  local hits_file="$_BASHUNIT_COVERAGE_HITS_FILE_OUT"
+  if [ -z "$hits_file" ] || [ ! -f "$hits_file" ]; then
+    hits_file="/dev/null"
+  fi
+
+  env LC_ALL=C "$AWK" -v hitsfile="$hits_file" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}\
+${_BASHUNIT_COVERAGE_AWK_HTML_FUNCTIONS}" \
+    "$hits_file" "$file"
+}
+
 ##
 # Emits the code-table rows of one page.
 # Arguments: $1 - source file, $2 - file holding its per-line test list
@@ -357,7 +423,7 @@ EOF
 
     # Extract functions and generate summary table
     local functions_data
-    functions_data=$(bashunit::coverage::extract_functions "$file")
+    functions_data=$(bashunit::coverage::html_function_rows "$file")
 
     if [ -n "$functions_data" ]; then
       bashunit::coverage::emit_block <<'EOF'
@@ -375,27 +441,16 @@ EOF
       local fn_entry
       while IFS= read -r fn_entry; do
         [ -z "$fn_entry" ] && continue
-        local fn_name fn_start fn_end
+        # name|start|end|executable|hit, all five from the one awk pass above.
+        local fn_name fn_start fn_executable fn_hit rest
         fn_name="${fn_entry%%|*}"
-        local rest="${fn_entry#*|}"
+        rest="${fn_entry#*|}"
         fn_start="${rest%%|*}"
-        fn_end="${rest#*|}"
-
-        # Calculate function coverage using pre-loaded hits data
-        local fn_executable=0
-        local fn_hit=0
-        local ln
-        for ((ln = fn_start; ln <= fn_end; ln++)); do
-          local ln_content
-          ln_content="${file_lines[$((ln - 1))]:-}"
-          if bashunit::coverage::is_executable_line "$ln_content" "$ln"; then
-            ((++fn_executable))
-            local ln_hits=${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}
-            if [ "$ln_hits" -gt 0 ]; then
-              ((++fn_hit))
-            fi
-          fi
-        done
+        # The end line is only the awk pass's business now, so skip past it.
+        rest="${rest#*|}"
+        rest="${rest#*|}"
+        fn_executable="${rest%%|*}"
+        fn_hit="${rest#*|}"
 
         local fn_pct fn_class row_class
         fn_pct=0


### PR DESCRIPTION
## 🤔 Background

Related #1099

The page called `extract_functions`, then walked `fn_start..fn_end` in Bash for
every function calling the classifier per line — a second full classification
pass over each file, ~22,000 calls for this repo and about 1.5 s of a 4.5 s
report.

## 💡 Changes

- The awk scanner already walks the file, so it emits `name|start|end|executable|hit` and the Bash side only formats rows
- **4.8 s → 3.5 s** for a 128-file report; output byte-identical across all 129 pages, verified with hits and tooltips against a freshly generated baseline