### PR TITLE
fix(reports): escape a hash in a TAP test description

### DIFF
--- a/.claude/rules/perf-fork-budget.md
+++ b/.claude/rules/perf-fork-budget.md
@@ -111,6 +111,12 @@ Check out the two versions of the file into one tree and alternate rounds.
   supported range, and **both failure modes are silent** — this is why HTML
   escaping goes through `awk` and not parameter expansion (#1096). Grep for
   `&` in any replacement before writing one.
+- **`${var//#/…}` does not substitute on Bash 3.0.** The `#` right after `//`
+  is read as the anchor-to-start syntax with an empty pattern, so the
+  replacement is *prepended* and the text is left alone: `check # SKIP me`
+  became `\#check # SKIP me`. Write the pattern as `[#]` (or quote it), which
+  means the same thing on 3.0, 3.2, 4.4 and 5 (#1119). Same family as the `&`
+  trap above: silent, and only on some versions.
 - **`\x` escapes are not POSIX awk.** They happen to work in macOS awk,
   BusyBox awk and mawk, but pass the byte in with `-v` instead of relying on
   it (#1098).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- TAP escapes a `#` in a test name, so a passing test called `check # SKIP me` is no longer read as a directive and reported as skipped by whatever consumes the file (#1119)
 - `assert_file_contains` accepts a needle that starts with a dash instead of failing with `grep: invalid option`, and `assert_file_not_contains` matches literally like its counterpart, so `a.c` no longer matches `abc` (#1108)
 - `assert_equals` no longer expands backslash escapes while normalizing, so `C:\` and `C:\\` compare as different, and a literal `\t` is no longer equal to a real tab. It still ignores ANSI sequences and control characters, which is what it documents (#1108)
 

--- a/src/reports/tap.sh
+++ b/src/reports/tap.sh
@@ -24,7 +24,11 @@ function bashunit::reports::__tap_message() {
 function bashunit::reports::__tap_description() {
   local text="$1"
   text="${text//\\/\\\\}"
-  printf '%s' "${text//#/\\#}"
+  # `[#]`, not `#`: Bash 3.0 reads the `#` right after `//` as the
+  # anchor-to-start syntax with an empty pattern and prepends the replacement
+  # instead of substituting. A bracket expression means the same thing to every
+  # supported Bash -- verified on 3.0, 3.2, 4.4 and 5.
+  printf '%s' "${text//[#]/\\#}"
 }
 
 ##

--- a/src/reports/tap.sh
+++ b/src/reports/tap.sh
@@ -14,6 +14,20 @@ function bashunit::reports::__tap_message() {
 }
 
 ##
+# Escapes a test description for a TAP `ok`/`not ok` line.
+#
+# TAP 13 reads an unescaped `#` as the start of a directive, so a passing test
+# called "check # SKIP me" is reported as skipped and vanishes from the count
+# (#1119). The backslash goes first, or an escape written by this function
+# would itself be re-escaped.
+##
+function bashunit::reports::__tap_description() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  printf '%s' "${text//#/\\#}"
+}
+
+##
 # Writes results in TAP version 13 format (https://testanything.org).
 # Passing/snapshot -> "ok", failed -> "not ok" with a YAML diagnostic,
 # skipped/risky -> "# SKIP", incomplete -> "# TODO".
@@ -30,7 +44,8 @@ function bashunit::reports::generate_report_tap() {
     local i seq=0
     for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
       seq=$((seq + 1))
-      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+      local name
+      name="$(bashunit::reports::__tap_description "${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}")"
       local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
       local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
 

--- a/tests/unit/reports/reports_test.sh
+++ b/tests/unit/reports/reports_test.sh
@@ -536,6 +536,41 @@ function test_generate_report_tap_ok_for_passed_test() {
   assert_contains "ok 1 - test_one" "$(cat "$_TEMP_OUTPUT_FILE")"
 }
 
+# TAP reads an unescaped `#` as the start of a directive, so a passing test
+# named "check # SKIP me" was reported as skipped and disappeared from the
+# count on any dashboard consuming the file (#1119).
+function test_generate_report_tap_escapes_a_hash_in_the_test_name() {
+  _mock_state_functions
+  BASHUNIT_REPORT_TAP="report.tap"
+
+  bashunit::reports::add_test "test.sh" "check # SKIP me" "100" "2" "passed"
+  bashunit::reports::generate_report_tap "$_TEMP_OUTPUT_FILE"
+
+  assert_contains 'ok 1 - check \# SKIP me' "$(cat "$_TEMP_OUTPUT_FILE")"
+}
+
+# A directive bashunit itself emits comes after the description and must stay
+# readable as one.
+function test_generate_report_tap_keeps_its_own_skip_directive_unescaped() {
+  _mock_state_functions
+  BASHUNIT_REPORT_TAP="report.tap"
+
+  bashunit::reports::add_test "test.sh" "test_one" "100" "2" "skipped"
+  bashunit::reports::generate_report_tap "$_TEMP_OUTPUT_FILE"
+
+  assert_contains "ok 1 - test_one # SKIP" "$(cat "$_TEMP_OUTPUT_FILE")"
+}
+
+function test_generate_report_tap_escapes_a_backslash_before_the_hash() {
+  _mock_state_functions
+  BASHUNIT_REPORT_TAP="report.tap"
+
+  bashunit::reports::add_test "test.sh" 'path\to # thing' "100" "2" "passed"
+  bashunit::reports::generate_report_tap "$_TEMP_OUTPUT_FILE"
+
+  assert_contains 'ok 1 - path\\to \# thing' "$(cat "$_TEMP_OUTPUT_FILE")"
+}
+
 function test_generate_report_tap_not_ok_for_failed_test() {
   _mock_state_functions
   BASHUNIT_REPORT_TAP="report.tap"


### PR DESCRIPTION
## 🤔 Background

Related #1119

TAP reads an unescaped `#` as the start of a directive, and the description
went out verbatim — so a **passing** test called `check # SKIP me` was reported
as *skipped*: green, and gone from the count on whatever consumes the file.
Confirmed against a parser implementing the usual `#\s*(SKIP|TODO)` rule.

## 💡 Changes

- Escape the backslash first, then the hash, per TAP 13; the directives bashunit itself emits come after the description and still parse
- Three unit tests: a hash in the name, a real `# SKIP` directive surviving, and a backslash already present in the name

Found by probing every machine-readable format for the same class of defect —
JUnit (including `]]>`), JSON, Markdown and the GitHub Actions annotations
(`%0A`/`%25`) all escape correctly already.