### PR TITLE
fix(reports): percent-encode GitHub Actions annotations on Bash 3.0 too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Fixed
+- GitHub Actions annotations are percent-encoded on Bash 3.0 too: the encoder's `${text//%/%25}` silently did nothing there, so a message containing `%` reached GitHub unencoded with a stray `%25` appended (#1121)
 - TAP escapes a `#` in a test name, so a passing test called `check # SKIP me` is no longer read as a directive and reported as skipped by whatever consumes the file (#1119)
 - `assert_file_contains` accepts a needle that starts with a dash instead of failing with `grep: invalid option`, and `assert_file_not_contains` matches literally like its counterpart, so `a.c` no longer matches `abc` (#1108)
 - `assert_equals` no longer expands backslash escapes while normalizing, so `C:\` and `C:\\` compare as different, and a literal `\t` is no longer equal to a real tab. It still ignores ANSI sequences and control characters, which is what it documents (#1108)

--- a/src/reports/gha.sh
+++ b/src/reports/gha.sh
@@ -8,7 +8,11 @@ function bashunit::reports::__gha_encode() {
   # Percent-encode reserved chars per GHA workflow-commands spec.
   # Bash 3.0+ parameter expansion avoids extra awk/sed calls.
   # Order matters: encode '%' first so the sequences we inject stay literal.
-  text="${text//%/%25}"
+  # `[%]`, not `%`: Bash 3.0 reads the `%` right after `//` as the anchor-to-end
+  # syntax with an empty pattern, appending the replacement instead of
+  # substituting -- `100% and 50%` came out as `100% and 50%%25`, so an
+  # annotation reached GitHub unencoded (#1121). Same trap as #1119 with `#`.
+  text="${text//[%]/%25}"
   text="${text//$'\r'/%0D}"
   text="${text//$'\n'/%0A}"
   printf '%s' "$text"

--- a/tests/unit/reports/reports_test.sh
+++ b/tests/unit/reports/reports_test.sh
@@ -470,6 +470,24 @@ function test_print_gha_annotations_failed_only_to_stdout() {
   assert_not_contains 'test_risky' "$output"
 }
 
+# The encoder writes %25 first so its own escapes stay literal, and on Bash 3.0
+# that substitution silently did nothing: `${text//%/%25}` reads the `%` after
+# `//` as the anchor-to-end form, so the replacement was appended and the text
+# left unencoded (#1121).
+function test_gha_annotation_percent_encodes_a_percent_sign() {
+  _mock_state_functions
+  BASHUNIT_LOG_GHA="gha.log"
+
+  bashunit::reports::add_test "tests/foo_test.sh" "test_bad" "100" "1" "failed" \
+    "coverage 80% -> 90%"
+
+  local output
+  output=$(bashunit::reports::print_gha_annotations failed-only)
+
+  assert_contains "coverage 80%25 -> 90%25" "$output"
+  assert_not_contains "80% " "$output"
+}
+
 function test_generate_gha_log_encodes_newlines_in_message() {
   _mock_state_functions
   BASHUNIT_LOG_GHA="gha.log"


### PR DESCRIPTION
## 🤔 Background

Related #1121

`__gha_encode` writes `%25` first so its own escapes stay literal — and on Bash
3.0 that substitution silently did nothing: `${text//%/%25}` reads the `%` right
after `//` as the anchor-to-end form, so the replacement is appended and the
text left alone.

| bash | `100% and 50%` |
|---|---|
| 3.2, 4.4, 5 | `100%25 and 50%25` |
| **3.0** | `100% and 50%%25` |

So the annotation reaches GitHub unencoded, a user-written `%0A` would decode
as a newline, and a stray `%25` trails every message.

## 💡 Changes

- `[%]` instead of `%`, which means the same thing on 3.0, 3.2, 4.4 and 5
- Regression test that **fails against the old encoder under real Bash 3.0** and passes with the fix

Same trap as #1119 (`#` there, `%` here); grepping `src/` says these two were
the only occurrences.