### PR TITLE
perf: drop two forks from every cold start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 
 ### Changed
+- Performance: cold start makes two fewer forks — `check_os::init` ran twice, once at source time and again from the entrypoint, and the root directory came from `$(dirname …)` — worth about 4ms of a 65ms startup, on every invocation (#1124)
 - Performance: `--coverage` is roughly 5x faster and `--coverage-report-html` roughly 19x — a run over this repo went from 16.2s to 2.9s, and a 128-file HTML report from 58.7s to 3.1s. The report phase emits each format in one awk invocation per run instead of Bash loops and forks per file and per row, and the capture path writes records straight to disk, normalizes a path with one fork instead of four, and reads each cache once (#1092, #1096, #1098, #1099, #1102, #1104, #1110, #1117)
 
 ### Fixed

--- a/bashunit
+++ b/bashunit
@@ -38,7 +38,19 @@ _check_bash_version
 declare -r BASHUNIT_VERSION="0.47.0"
 
 # shellcheck disable=SC2155
-declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+# `${x%/*}` rather than `$(dirname "$x")`: one fork on every invocation, and
+# the acceptance suite spawns hundreds of them (#1124). The expansion differs
+# from dirname only when the path holds no slash -- invoked as a bare name off
+# PATH -- which is what the guard covers.
+_bashunit_root="${BASH_SOURCE[0]%/*}"
+# No slash means a bare name off PATH (dirname: "."); empty means the
+# filesystem root (dirname: "/").
+case "$_bashunit_root" in
+"${BASH_SOURCE[0]}") _bashunit_root="." ;;
+"") _bashunit_root="/" ;;
+esac
+declare -r BASHUNIT_ROOT_DIR="$_bashunit_root"
+unset _bashunit_root
 export BASHUNIT_ROOT_DIR
 
 # Capture working directory at startup (before any test changes it)
@@ -81,7 +93,10 @@ source "$BASHUNIT_ROOT_DIR/src/benchmark/index.sh"
 source "$BASHUNIT_ROOT_DIR/src/learn/index.sh"
 source "$BASHUNIT_ROOT_DIR/src/main/index.sh"
 
-bashunit::check_os::init
+# check_os.sh runs its own init when sourced, above; calling it again here cost
+# a second `uname` on every invocation, plus the `grep /etc/os-release` inside
+# is_nixos on Linux (#1124). The tests re-init deliberately with a mocked
+# `uname`, so the function itself must stay re-runnable.
 bashunit::clock::init
 
 # Subcommand detection


### PR DESCRIPTION
## 🤔 Background

Related #1124

A fork census of `./bashunit --version` showed five: `2 uname`, `1 tput`,
`1 perl`, `1 dirname`. Two are avoidable, and every invocation pays them —
including the ~258 nested runs the acceptance suite spawns.

## 💡 Changes

- `check_os::init` ran twice (once at source time, once from the entrypoint), so its `_BASHUNIT_UNAME` cache never helped the second run — which on Linux also re-greps `/etc/os-release`. The entrypoint call goes; the function stays re-runnable, because the OS tests re-init deliberately with a mocked `uname` (a guard inside it broke them)
- `BASHUNIT_ROOT_DIR` uses parameter expansion instead of `$(dirname …)`, with a `case` for the two shapes where they differ — a bare name off PATH, and the filesystem root. Verified identical to `dirname` for six path shapes
- **Five forks → three**, about **4 ms off a 65 ms startup** measured over 200 runs per sample; single-run comparisons are far too noisy here to show it
- Written as a `case` rather than an `if`/`elif` chain to stay under the artifact size budget, which has only 186 bytes of headroom (#1125)