### PR TITLE
ci: retry the Bash 3.0 image build on a Docker Hub hiccup

### DIFF
--- a/.github/workflows/tests-bash-3.0.yml
+++ b/.github/workflows/tests-bash-3.0.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Build Bash 3.0 Docker image
         run: |
-          docker build -t bashunit-bash3 -f - . <<'EOF'
+          # Docker Hub answers 502 often enough to have failed this job on an
+          # unrelated PR (#1127); the curl retries inside the build (#1107) do
+          # not help, because the base-image pull happens before them. Three
+          # attempts, backing off, and the last one still fails the job.
+          cat >/tmp/bash3.Dockerfile <<'EOF'
           FROM debian:bookworm-slim
 
           RUN apt-get update && apt-get install -y \
@@ -64,6 +68,15 @@ jobs:
           WORKDIR /bashunit
           CMD ["/opt/bash-3.0/bin/bash", "--version"]
           EOF
+
+          for attempt in 1 2 3; do
+            if docker build -t bashunit-bash3 -f /tmp/bash3.Dockerfile .; then
+              exit 0
+            fi
+            echo "docker build failed (attempt $attempt/3)" >&2
+            sleep $((attempt * 10))
+          done
+          exit 1
 
       - name: Save Docker image
         run: docker save bashunit-bash3 -o /tmp/bashunit-bash3.tar


### PR DESCRIPTION
## 🤔 Background

Related #1127

`Build Bash 3.0 Image` failed on an unrelated PR with a Docker Hub **502**
resolving `debian:bookworm-slim` — before any of the build's own commands ran,
so the `curl` retries from #1107 could not help.

That is two distinct transient modes for this one job today (`ftp.gnu.org`
timeouts, now registry 502s), each costing a human the time to notice the red
tick is not about the change.

## 💡 Changes

- The Dockerfile is written to a file and `docker build` runs up to three times with a backoff; the third failure still fails the job
- Verified with `docker build --check` that the file parses with the indentation the YAML heredoc preserves