### PR TITLE
fix(suites): list a duplicate section name once

### DIFF
--- a/src/config/suites.sh
+++ b/src/config/suites.sh
@@ -162,8 +162,20 @@ $entry"
 function bashunit::suites::names() {
   local i=0
   local total=${#_BASHUNIT_SUITE_NAMES[@]}
+  # Two sections with the same name printed it twice, here and in the
+  # unknown-suite error (#1131). resolve() returns the first match, so the
+  # first occurrence is the one that exists as far as a run is concerned.
+  local seen=""
+  local name
   while [ "$i" -lt "$total" ]; do
-    printf '%s\n' "${_BASHUNIT_SUITE_NAMES[i]}"
+    name="${_BASHUNIT_SUITE_NAMES[i]}"
+    case "$seen" in
+    *"|$name|"*) ;;
+    *)
+      seen="$seen|$name|"
+      printf '%s\n' "$name"
+      ;;
+    esac
     i=$((i + 1))
   done
 }

--- a/tests/unit/config/suites_test.sh
+++ b/tests/unit/config/suites_test.sh
@@ -109,3 +109,20 @@ paths = tests/unit'
 
   assert_same "tests/unit" "$_BASHUNIT_SUITE_PATHS_OUT"
 }
+
+# Two sections with the same name printed it twice, in --list-suites and in the
+# unknown-suite error. resolve() takes the first match, so the first occurrence
+# is the one a run actually sees.
+function test_a_duplicate_section_is_listed_once() {
+  load_rc '[suite:dup]
+paths = tests/a
+
+[suite:dup]
+paths = tests/b
+
+[suite:other]
+paths = tests/c'
+
+  assert_same "dup
+other" "$(bashunit::suites::names)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1131

Two `[suite:dup]` sections print the name twice, both in `--list-suites` and in
the "unknown suite" error that lists what is defined:

```
$ bashunit --list-suites
with spaces
dup
dup
empty
```

`resolve()` returns on the first match, so the first occurrence is the one a run
sees — saying it twice just misreports the config.

## 💡 Changes

- `suites::names` skips a name it has already printed; both call sites inherit the fix
- Test for a duplicate section listing once

The issue's other half — "a suite with no paths runs everything" — **is not a
bug**: option-only suites are intentional, tested, and documented in
`configuration.md`. I reverted that change after it broke the two tests that
encode the behaviour; the issue is corrected and retitled.