### PR TITLE
docs(coverage): state the measured cost range, not an optimistic one

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -59,11 +59,17 @@ A file created *after* that point is not seeded, though it is still tracked if i
 :::
 
 ::: tip Performance
-Coverage roughly doubles to quadruples wall-clock time, depending on Bash version
-and engine. Capture dominates: the report phase is a handful of `awk` passes for
-the whole run, while capture pays per executed line. If that is too slow to keep
-on while you work, narrow `BASHUNIT_COVERAGE_PATHS` — both halves scale with the
-number of tracked source lines, not with the size of the test suite.
+Coverage costs somewhere between 2x and 6x wall-clock time — how much depends on
+how much *tracked* code the suite actually executes, not on how many tests there
+are. Running this repo's own `tests/unit/assert/basic_test.sh` against all 128
+files of `src` sits at the top of that range: 0.6s to 3.4s on Bash 3.2, and 0.3s
+to 2.0s on Bash 5.
+
+Capture dominates: the report phase is a handful of `awk` passes for the whole
+run, while capture pays per executed line, through a `DEBUG` trap that fires for
+every command. If it is too slow to keep on while you work, narrow
+`BASHUNIT_COVERAGE_PATHS` — the cost follows the number of tracked source lines
+that run.
 :::
 
 ### Seeing which engine ran


### PR DESCRIPTION
## 🤔 Background

The performance tip said coverage "roughly doubles to quadruples wall-clock
time". Measured on this repo's own suite against all 128 files of `src`:

| | no coverage | with coverage | |
|---|---|---|---|
| Bash 3.2 (trap) | 0.6 s | 3.4 s | 5.6x |
| Bash 5 (xtrace) | 0.3 s | 2.0 s | 6.3x |

It was far more wrong before today — the same run was 16.2 s, 27x — but 2–4x
still understates it.

## 💡 Changes

- States the measured range with the real numbers for both engines
- Says what actually drives it: how much *tracked* code the suite executes, not how many tests there are