### PR TITLE
docs(configuration): say how conflicting suite options resolve

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,6 +142,13 @@ the command line and the global config: **CLI flags → suite settings → globa
 `.bashunitrc` → `.env` → defaults.** An explicit path argument likewise
 replaces the suite's `paths` and keeps its options.
 
+When several suites are named and they set the *same* option to different
+values, the one named later on the command line wins — so
+`--suite a --suite b` and `--suite b --suite a` run the union of the same paths
+but can run them in different modes if, say, one sets `parallel = true` and the
+other `no-parallel = true`. Their paths are always unioned regardless of order;
+it is only conflicting options that depend on it.
+
 An unknown suite name exits non-zero listing the defined ones, and a line
 inside a section that is not `key = value` — or an option that is not a real
 flag — exits non-zero quoting it, rather than running something other than what


### PR DESCRIPTION
## 🤔 Background

Naming several suites unions their paths, which the docs cover. What they did
not say is what happens when two of them set the *same* option differently —
the one named later on the command line wins:

```
--suite unit --suite acc  ->  BASHUNIT_PARALLEL_RUN: false
--suite acc --suite unit  ->  BASHUNIT_PARALLEL_RUN: true
```

So the same union of paths can run in different modes depending on the order
they are typed.

## 💡 Changes

- Documents the rule, and that paths are unioned regardless of order — it is only conflicting options that depend on it

Found while investigating #1137, where the failing acceptance case is exactly
that shape.