### PR TITLE
feat(doubles): refuse a command name the double cannot build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Performance: `--coverage` is roughly 5x faster and `--coverage-report-html` roughly 19x — a run over this repo went from 16.2s to 2.9s, and a 128-file HTML report from 58.7s to 3.1s. The report phase emits each format in one awk invocation per run instead of Bash loops and forks per file and per row, and the capture path writes records straight to disk, normalizes a path with one fork instead of four, and reads each cache once (#1092, #1096, #1098, #1099, #1102, #1104, #1110, #1117)
 
 ### Fixed
+- `mock`, `mock_sequence` and `spy` report a usable-name error instead of a raw bash syntax error when the command name carries whitespace or shell syntax — `mock "ls -l" echo hi` used to print `syntax error near unexpected token '-l'` from inside bashunit (#1136)
 - A data-provider value ending in a backslash reaches the test instead of vanishing: it escaped the `)` of the parser's `eval` fast path, and a syntax error inside `eval` kills the command substitution the runner calls it in, so the argument arrived unset (#1134)
 - `assert_equals` no longer expands backslash escapes while normalizing, so `C:\` and `C:\\` compare as different and a literal `\t` is no longer equal to a real tab. It still ignores ANSI sequences and control characters, which is what it documents (#1108)
 - `assert_file_contains` accepts a needle that starts with a dash instead of failing with `grep: invalid option`, and `assert_file_not_contains` matches literally like its counterpart, so `a.c` no longer matches `abc` (#1108)

--- a/src/doubles/mock.sh
+++ b/src/doubles/mock.sh
@@ -48,9 +48,45 @@ function bashunit::doubles::is_exit_code() {
 }
 
 
+# Refuses a name the doubles cannot build a function from.
+#
+# All three doubles run `eval "function $command() { … }"`, so a name carrying
+# whitespace or shell syntax is a syntax error and the user sees bashunit's
+# internals rather than their mistake -- `mock "ls -l" echo hi` reported
+# `syntax error near unexpected token '-l'` (#1136).
+#
+# Narrow on purpose: `foo-bar`, `a.b`, `x+y`, `a$b` and `a:b` are all legal
+# function names in bash and legitimate commands to mock, so only the
+# characters that actually break the eval are rejected.
+function bashunit::doubles::refuse_unusable_name() {
+  local fn=$1 command=$2
+
+  case "$command" in
+  '')
+    bashunit::assert::fail_with "" "$fn" "expects a command name, got" "nothing"
+    return 0
+    ;;
+  *[[:space:]\;\|\&\(\)\{\}\<\>\"\'\`]*)
+    # Through fail_with, like an assertion: it labels the failure with the test
+    # name and counts it, so the misuse is visible in a default run rather than
+    # only under --strict.
+    bashunit::assert::fail_with "" "$command" \
+      "is not a usable command name for $fn; pass arguments after it, as in" "$fn ls -l"
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
+
 function bashunit::mock() {
   local command=$1
   shift
+
+  if bashunit::doubles::refuse_unusable_name "mock" "$command"; then
+    return 1
+  fi
 
   if [ $# -eq 1 ] && bashunit::doubles::is_exit_code "$1"; then
     eval "function $command() { return $1; }"
@@ -83,6 +119,10 @@ function bashunit::mock() {
 function bashunit::mock_sequence() {
   local command=$1
   shift
+
+  if bashunit::doubles::refuse_unusable_name "mock_sequence" "$command"; then
+    return 1
+  fi
 
   if [ $# -eq 0 ]; then
     bashunit::assert::usage_error_detail "bashunit::mock_sequence" \

--- a/src/doubles/spy.sh
+++ b/src/doubles/spy.sh
@@ -194,6 +194,11 @@ function bashunit::doubles::record_call() {
 function bashunit::spy() {
   local command=$1
   local exit_code_or_impl="${2:-}"
+
+  if bashunit::doubles::refuse_unusable_name "spy" "$command"; then
+    return 1
+  fi
+
   local variable
   bashunit::helper::normalize_variable_name_to_slot "$command"
   variable=$_BASHUNIT_HELPER_VARNAME_OUT

--- a/tests/functional/doubles_test.sh
+++ b/tests/functional/doubles_test.sh
@@ -350,3 +350,33 @@ function test_a_destructive_command_is_never_reached() {
 
   assert_have_never_been_called a_destructive_command
 }
+
+# All three doubles build the double with `eval "function $command() { … }"`, so
+# a name carrying whitespace or shell syntax used to surface as a raw bash
+# syntax error pointing at bashunit's internals (#1136). Passing the arguments
+# along with the command is the easy way to hit it.
+function test_mock_refuses_a_name_with_arguments() {
+  assert_same \
+    "$(bashunit::console_results::print_failed_test "Mock refuses a name with arguments" \
+      "ls -l" "is not a usable command name for mock; pass arguments after it, as in" "mock ls -l")" \
+    "$(bashunit::mock "ls -l" echo hi)"
+}
+
+function test_spy_refuses_a_name_with_shell_syntax() {
+  assert_same \
+    "$(bashunit::console_results::print_failed_test "Spy refuses a name with shell syntax" \
+      "foo;bar" "is not a usable command name for spy; pass arguments after it, as in" "spy ls -l")" \
+    "$(bashunit::spy "foo;bar")"
+}
+
+# Narrow on purpose: these are legal function names in bash and legitimate
+# commands to mock, so the guard must not reject them.
+function test_mock_accepts_names_bash_allows() {
+  bashunit::mock foo-bar echo one
+  bashunit::mock a.b echo two
+  bashunit::mock a:b echo three
+
+  assert_same "one" "$(foo-bar)"
+  assert_same "two" "$(a.b)"
+  assert_same "three" "$(a:b)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1136

`mock`, `mock_sequence` and `spy` all run `eval "function $command() { … }"`, so
a name carrying whitespace or shell syntax was a syntax error and the user saw
bashunit's internals rather than their mistake:

```
✗ Error: Mock with args in name
    eval: line 58: syntax error near unexpected token `-l'
    ./src/doubles/mock.sh: eval: line 58: `function ls -l() { echo hi "$@"; }'
```

Passing the arguments along with the command — `mock "ls -l"` rather than
`mock ls` — is an easy way to hit it.

## 💡 Changes

- One shared guard for all three doubles, reported through `fail_with` the way `spy::fail_unregistered` reports its own misuse: counted, labelled with the test name, visible in a default run

  ```
  ✗ Failed: Mock with args in name
      is not a usable command name for mock; pass arguments after it, as in 'mock ls -l'
  ```

- Narrow on purpose: `foo-bar`, `a.b`, `a:b`, `x+y` and `a$b` are legal function names in bash and legitimate commands to mock, so only the characters that break the `eval` are rejected — with a test pinning that

My first attempt only wrote to stderr, which made a *default* run silent — worse
than the syntax error it replaced. Routing it through `fail_with` fixed that.