### PR TITLE
feat(runner): say why a silent source failure happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 
 ### Changed
+- A test file that fails to source without writing to stderr now reports its size and says there was no stderr, so a truncated file can be told apart from one whose last command returned non-zero (#1137)
 - Performance: cold start makes two fewer forks — `check_os::init` ran twice, once at source time and again from the entrypoint, and the root directory came from `$(dirname …)` — worth about 4ms of a 65ms startup, on every invocation (#1124)
 - Performance: `--coverage` is roughly 5x faster and `--coverage-report-html` roughly 19x — a run over this repo went from 16.2s to 2.9s, and a 128-file HTML report from 58.7s to 3.1s. The report phase emits each format in one awk invocation per run instead of Bash loops and forks per file and per row, and the capture path writes records straight to disk, normalizes a path with one fork instead of four, and reads each cache once (#1092, #1096, #1098, #1099, #1102, #1104, #1110, #1117)
 

--- a/src/runner/discovery.sh
+++ b/src/runner/discovery.sh
@@ -92,7 +92,18 @@ function bashunit::runner::load_test_files() {
     fi
     if [ "$source_failed" = true ]; then
       local message="$source_err"
-      [ -z "$message" ] && message="Failed to source '$test_file' (exit $source_status)"
+      if [ -z "$message" ]; then
+        # Non-zero with nothing on stderr is the puzzling case: the file exists
+        # and parsed, so the size distinguishes a truncated or empty file from
+        # one whose last command simply returned non-zero. #1137 is exactly
+        # this, seen only on loaded CI, and the message as it stood carried no
+        # way to tell those apart.
+        local source_bytes="unknown"
+        if [ -f "$test_file" ]; then
+          source_bytes=$(bashunit::io::file_size "$test_file")
+        fi
+        message="Failed to source '$test_file' (exit $source_status, $source_bytes bytes, no stderr)"
+      fi
       bashunit::runner::record_file_hook_failure \
         "source" "$test_file" "$message" 1 true
       bashunit::runner::clean_set_up_and_tear_down_after_script

--- a/src/system/io.sh
+++ b/src/system/io.sh
@@ -5,6 +5,23 @@
 # Uses `tput clear` when available (queries terminfo for the right sequence)
 # and falls back to the ANSI sequence \033[2J\033[H otherwise.
 ##
+##
+# Echoes the byte size of $1, or "unknown" when it cannot be read.
+#
+# `wc -c` is a fork, which is why this is not on any hot path: it exists for
+# the failure message in discovery.sh, where one fork buys the difference
+# between "the file was truncated" and "its last command returned non-zero"
+# (#1137).
+##
+function bashunit::io::file_size() {
+  local bytes
+  bytes=$(wc -c <"$1" 2>/dev/null | tr -d ' ') || bytes=""
+  if [ -z "$bytes" ]; then
+    bytes="unknown"
+  fi
+  printf '%s' "$bytes"
+}
+
 function bashunit::io::clear_screen() {
   if bashunit::dependencies::has_tput; then
     local out

--- a/tests/acceptance/bashunit_hook_source_failure_test.sh
+++ b/tests/acceptance/bashunit_hook_source_failure_test.sh
@@ -49,3 +49,21 @@ function test_bashunit_when_tear_down_after_script_sources_nonexistent_file() {
   assert_contains "failed" "$actual"
   assert_general_error "$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$test_file")"
 }
+
+# A file that fails to source without writing anything to stderr used to report
+# only "Failed to source 'x' (exit N)", which cannot distinguish a truncated
+# file from one whose last command simply returned non-zero -- the difference
+# that matters when it only happens on loaded CI (#1137).
+function test_a_silent_source_failure_reports_the_file_size() {
+  local fixture
+  fixture="$(bashunit::temp_file silent_source).sh"
+  printf 'function test_x() { assert_same 1 1; }\nfalse\n' >"$fixture"
+
+  local actual
+  set +e
+  actual="$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$fixture" 2>&1)"
+  set -e
+
+  assert_contains "no stderr" "$(printf '%s' "$actual" | strip_ansi)"
+  assert_contains "bytes" "$(printf '%s' "$actual" | strip_ansi)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1137

A test file that fails to source **without writing to stderr** reported only
`Failed to source 'x' (exit N)`. That cannot distinguish a truncated or empty
file from one whose last command simply returned non-zero — and stderr is
already surfaced when there is any, so this fallback is the case where the
information is most needed.

It is exactly the distinction #1137 needs. That flake fails only on loaded CI,
and three reproduction attempts came up clean: the file alone (5 runs), six
concurrent copies, and the whole acceptance directory under a real Bash 3.0
build with `--cpus=2`.

## 💡 Changes

- The fallback message carries the file size and says there was no stderr:

  ```
  Failed to source 'x_test.sh' (exit 1, 45 bytes, no stderr)
  ```

- `bashunit::io::file_size` for it — one `wc` fork, on a path that has already failed
- Acceptance test covering the silent-failure case