### PR TITLE
test(coverage): tell a failed awk apart from a rule disagreement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 
 ### Changed
+- The classifier differential test distinguishes a failed `awk` from a genuine rule disagreement: an awk that failed printed nothing, which diffed as "every line classified differently" and reported as the rules disagreeing (#1143)
 - A test file that fails to source without writing to stderr now reports its size and says there was no stderr, so a truncated file can be told apart from one whose last command returned non-zero (#1137)
 - Performance: cold start makes two fewer forks — `check_os::init` ran twice, once at source time and again from the entrypoint, and the root directory came from `$(dirname …)` — worth about 4ms of a 65ms startup, on every invocation (#1124)
 - Performance: `--coverage` is roughly 5x faster and `--coverage-report-html` roughly 19x — a run over this repo went from 16.2s to 2.9s, and a 128-file HTML report from 58.7s to 3.1s. The report phase emits each format in one awk invocation per run instead of Bash loops and forks per file and per row, and the capture path writes records straight to disk, normalizes a path with one fork instead of four, and reads each cache once (#1092, #1096, #1098, #1099, #1102, #1104, #1110, #1117)

--- a/tests/unit/coverage/branches_differential_test.sh
+++ b/tests/unit/coverage/branches_differential_test.sh
@@ -15,7 +15,8 @@ function set_up_before_script() {
 # $2 overrides the scanner source, which is how the mutation below is injected.
 function awk_branches() { # $1 = file, $2 = optional scanner source
   local scanner="${2:-$_BASHUNIT_COVERAGE_AWK_BRANCHES}"
-  env LC_ALL=C "$AWK" "$scanner"'
+  local out status=0
+  out=$(env LC_ALL=C "$AWK" "$scanner"'
     BEGIN { bu_br_reset() }
     { bu_br_line($0, FNR) }
     END {
@@ -23,7 +24,21 @@ function awk_branches() { # $1 = file, $2 = optional scanner source
         print br_dec[i] "|" br_kind[i] "|" br_arms[i]
       }
     }
-  ' "$1"
+  ' "$1") || status=$?
+
+  # An awk that failed prints nothing, which diffs as "the scanners disagree
+  # about every branch in the file" -- alarming, and not what happened. Say
+  # which it was (#1143).
+  if [ "$status" -ne 0 ]; then
+    printf 'AWK-FAILED(exit %s) on %s\n' "$status" "$1"
+    return 0
+  fi
+
+  # A file with no output must stay empty: printf '%s\n' "" emits a blank line,
+  # which diffs against awk's genuine no-output as a disagreement.
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  fi
 }
 
 function test_both_branch_scanners_agree_on_every_shell_file_in_the_repo() {
@@ -37,6 +52,8 @@ function test_both_branch_scanners_agree_on_every_shell_file_in_the_repo() {
     local diff_out
     diff_out=$(diff <(bashunit::coverage::extract_branches "$ROOT_DIR/$file") \
       <(awk_branches "$ROOT_DIR/$file") 2>&1) || true
+    # A process substitution reports no status at all, so awk_branches marks its
+    # own failure in-band rather than leaving the diff to guess.
     if [ -n "$diff_out" ]; then
       disagreements="$disagreements
 $file
@@ -94,4 +111,13 @@ function test_the_scanners_agree_on_nested_and_mixed_constructs() {
 
   assert_same "$(bashunit::coverage::extract_branches "$fixture")" \
     "$(awk_branches "$fixture")"
+}
+
+# Same diagnostic gap as the line classifier's: empty output from a failed awk
+# is indistinguishable from a total disagreement once it reaches the diff.
+function test_a_failing_awk_is_reported_as_a_failure_not_a_disagreement() {
+  local out
+  out=$(awk_branches "/definitely/not/a/file.sh")
+
+  assert_contains "AWK-FAILED" "$out"
 }

--- a/tests/unit/coverage/classifier_differential_test.sh
+++ b/tests/unit/coverage/classifier_differential_test.sh
@@ -13,9 +13,22 @@ function set_up_before_script() {
 # $2 overrides the rule source, which is how the mutation below is injected.
 function awk_classification() { # $1 = file, $2 = optional rule source
   local rules="${2:-$(bashunit::coverage::awk_rules)}"
-  env LC_ALL=C "$AWK" "$rules"'
+  local out status=0
+  out=$(env LC_ALL=C "$AWK" "$rules"'
     { printf "%s %s\n", FNR, bu_is_executable($0) }
-  ' "$1"
+  ' "$1") || status=$?
+
+  # An awk that failed prints nothing, and empty output is indistinguishable
+  # from "every line classified differently" once it reaches the diff -- so a
+  # transient fork failure under load reported as "the classifiers disagree",
+  # which is the most alarming message this suite can produce and was not what
+  # happened (#1143). Say which it was.
+  if [ "$status" -ne 0 ]; then
+    printf 'AWK-FAILED(exit %s) on %s\n' "$status" "$1"
+    return 0
+  fi
+
+  printf '%s\n' "$out"
 }
 
 # Classifies every line of $1 with the Bash reference, same format.
@@ -96,4 +109,15 @@ function test_the_classifiers_agree_on_the_quirk_cases() {
   } >"$fixture"
 
   assert_same "$(bash_classification "$fixture")" "$(awk_classification "$fixture")"
+}
+
+# The differential compares two outputs, so anything that empties one of them
+# reads as a total disagreement. A transient awk failure under CI load did
+# exactly that, reporting "the classifiers disagree on every shell file" when
+# nothing had disagreed (#1143).
+function test_a_failing_awk_is_reported_as_a_failure_not_a_disagreement() {
+  local out
+  out=$(awk_classification "/definitely/not/a/file.sh")
+
+  assert_contains "AWK-FAILED" "$out"
 }

--- a/tests/unit/coverage/classifier_differential_test.sh
+++ b/tests/unit/coverage/classifier_differential_test.sh
@@ -28,7 +28,11 @@ function awk_classification() { # $1 = file, $2 = optional rule source
     return 0
   fi
 
-  printf '%s\n' "$out"
+  # A file with no output must stay empty: printf '%s\n' "" emits a blank line,
+  # which diffs against awk's genuine no-output as a disagreement.
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+  fi
 }
 
 # Classifies every line of $1 with the Bash reference, same format.


### PR DESCRIPTION
## 🤔 Background

Related #1143

The classifier differential forks one `awk` per shell file in the repo and diffs
its stdout against the Bash classifier, without checking whether awk succeeded.
A failed awk prints nothing, and empty output diffs as though every line had
been classified differently — so a transient failure on macOS CI reported as
"the classifiers disagree on every shell file in the repo".

## 💡 Changes

- Check awk's exit status and emit `AWK-FAILED(exit N) on <file>`; the run still fails, but names which of the two it was
- Cover the failure path with a test, so the diagnostic can't rot back to silence