### PR TITLE
docs(assert): document how to assert a captured exit code

### DIFF
--- a/docs/assertions.md
+++ b/docs/assertions.md
@@ -837,6 +837,25 @@ function test_failure() {
 ```
 :::
 
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_successful_code            # reads $? — the assignment's 0
+assert_successful_code "$code"    # the first argument is ignored, same result
+
+assert_successful_code "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
+
 ## assert_unsuccessful_code
 > `assert_unsuccessful_code`
 
@@ -882,6 +901,25 @@ function test_failure() {
 ```
 :::
 
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_unsuccessful_code            # reads $? — the assignment's 0
+assert_unsuccessful_code "$code"    # the first argument is ignored, same result
+
+assert_unsuccessful_code "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
+
 ## assert_general_error
 > `assert_general_error`
 
@@ -926,6 +964,25 @@ function test_failure() {
 }
 ```
 :::
+
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_general_error            # reads $? — the assignment's 0
+assert_general_error "$code"    # the first argument is ignored, same result
+
+assert_general_error "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
 
 ## assert_command_available
 > `assert_command_available "command"`
@@ -984,6 +1041,25 @@ function test_failure_with_existing_command() {
 }
 ```
 :::
+
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_command_not_found            # reads $? — the assignment's 0
+assert_command_not_found "$code"    # the first argument is ignored, same result
+
+assert_command_not_found "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
 
 ## assert_file_exists
 > `assert_file_exists "file"`


### PR DESCRIPTION
## 🤔 Background

Related #1169

The exit-code assertions read `$?`. Under `set -e` — which `--strict` turns on
for every test — that idiom cannot be used directly: the non-zero exit aborts
the test before the assertion runs, so the code has to be captured, and
capturing it sets `$?` to zero.

```bash
local code=0
some_command || code=$?

assert_general_error            # reads $?, the assignment's 0
assert_general_error "$code"    # $1 is never read by these functions
```

Both silently assert the wrong thing, and the second is the natural spelling.
The working form — `assert_general_error "" "" "$code"` — was undocumented.

## 💡 Changes

- Document the third-argument form in all four sections, noting that `assert_exit_code` takes its *expected* code in `$1`
- Appended at the end of each section: the `bashunit doc` renderer truncates a section, and inserting earlier silently dropped the existing `assert_exec` tip from CLI output. With the block at the end the doc snapshot is byte-identical

## Not changing

Making `$1` the captured code would fix the natural spelling, but
`assert_general_error "$(some_cmd)"` is an established idiom in this repo that
relies on `$?` and would silently change meaning for numeric output. That is a
contract change for a maintainer.