### PR TITLE
chore(test): delete two snapshots whose test file no longer exists

### DIFF
--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
@@ -1,3 +1,0 @@
-[31m✗ Failed[0m: assert same
-    [90mExpected[0m [1m'foo'[0m
-    [90mbut got [0m [1m'bar'[0m

--- a/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_non_existing_fn.snapshot
+++ b/tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_non_existing_fn.snapshot
@@ -1,1 +1,0 @@
-Function non_existing_fn does not exist.


### PR DESCRIPTION
## 🤔 Background

Related #1194

`91e523bb` split `bashunit_direct_fn_call_test.sh` into `_basic_` and
`_advanced_` and left the pre-split snapshots behind:

```
tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_failure.snapshot
tests/acceptance/snapshots/bashunit_direct_fn_call_test_sh.test_bashunit_direct_fn_call_non_existing_fn.snapshot
```

Their owner file is gone, nothing references them, and their content predates
the source-location line the live recordings carry — they record a path that no
longer exists.

Neither `--snapshot-report-unused` nor `--snapshot-prune` can see them, because
a snapshot is only considered when its owner prefix matches a test file the run
discovered. That detection gap is #1194 and needs a decision; deleting these
two does not.

## 💡 Changes

- Remove the two dead files (`git rm`, so it is reviewable and revertible)
- Verified: the two successor test files pass 19/19 without them; full suite green with 46 snapshots remaining