### PR TITLE
fix(bench): fail when there is nothing to benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Performance: `--coverage` is roughly 5x faster and `--coverage-report-html` roughly 19x — a run over this repo went from 16.2s to 2.9s, and a 128-file HTML report from 58.7s to 3.1s. The report phase emits each format in one awk invocation per run instead of Bash loops and forks per file and per row, and the capture path writes records straight to disk, normalizes a path with one fork instead of four, and reads each cache once (#1092, #1096, #1098, #1099, #1102, #1104, #1110, #1117)
 
 ### Fixed
+- `bashunit bench` reports `No benchmarks found` and exits non-zero instead of printing a header and exiting 0 when the path does not exist, or holds no `bench_` function — a typo left a CI benchmark job green having measured nothing (#1199)
 - `install.sh` names the real problem when the destination is unusable, instead of reporting `failed to download … from <url>` for a folder it cannot write, or leaking a raw `rm: Not a directory` when the path is a regular file. The destination is validated before any network call (#1197)
 - A bootstrap file that fails to load reports it and exits non-zero, through every path that loads one (`BASHUNIT_BOOTSTRAP`, `--env`, `--boot`, and the `bench` equivalents), instead of leaving the run with no tests, no summary and exit 0. An absent bootstrap is still ignored (#1179, #1181)
 - A report path that is a directory (`--report-junit build/` with the filename forgotten) fails fast with `is a directory, not a file` instead of exiting 0 with no report written. Affects every report flag and the `bench` equivalents (#1177)

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -309,6 +309,19 @@ function bashunit::main::exec_benchmarks() {
 
   bashunit::runner::load_bench_files "$filter" "${bench_files[@]}"
 
+  # A path that does not exist survives find_files_recursive and
+  # helper::load_bench_files, and is dropped silently by the `[ -f ]` guard
+  # inside the loop -- so the count above is non-zero and the "at least one
+  # file path" check never fires. The run then printed a header and exited 0,
+  # green having measured nothing, which on a benchmark job is invisible
+  # because the whole output is numbers (#1199). Same for a file that holds no
+  # bench_ function. `test` reports "No tests found" and exits 1; match it.
+  if [ "${#_BASHUNIT_BENCH_NAMES[@]}" -eq 0 ]; then
+    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_RETURN_ERROR" " No benchmarks found " \
+      "$_BASHUNIT_COLOR_DEFAULT"
+    exit 1
+  fi
+
   bashunit::benchmark::print_results
 
   # After the table, so a writer failure cannot swallow the results a human

--- a/tests/acceptance/bashunit_bench_test.sh
+++ b/tests/acceptance/bashunit_bench_test.sh
@@ -18,3 +18,39 @@ function test_bench_command_runs_in_dev_mode() {
   assert_not_contains "command not found" "$output"
   assert_contains "bench_sample" "$output"
 }
+
+# `bench` was silent and green where `test` is explicit and red: a path that
+# does not exist, or one holding no bench_ function, printed a header and
+# exited 0. A typo in the path or in the prefix gave a CI job that measured
+# nothing, and a benchmark's whole output is numbers nobody notices are
+# missing (#1199).
+function test_bench_fails_on_a_path_that_does_not_exist() {
+  local ec=0
+  local output
+  output=$(./bashunit bench ./no_such_bench_path_test.sh 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No benchmarks found" "$output"
+}
+
+function test_bench_fails_on_a_directory_that_does_not_exist() {
+  local ec=0
+  local output
+  output=$(./bashunit bench ./no_such_bench_dir/ 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No benchmarks found" "$output"
+}
+
+function test_bench_fails_when_a_file_holds_no_bench_function() {
+  local dir
+  dir="$(bashunit::temp_dir)"
+  printf 'function test_not_a_bench() { assert_same 1 1; }\n' >"$dir/empty_bench.sh"
+
+  local ec=0
+  local output
+  output=$(./bashunit bench "$dir/empty_bench.sh" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No benchmarks found" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1199

| invocation | `bashunit test` | `bashunit bench` (before) |
|---|---|---|
| file that does not exist | `No tests found`, exit 1 | header only, **exit 0** |
| directory that does not exist | `No tests found`, exit 1 | header only, **exit 0** |
| file present, nothing to run | `No tests found`, exit 1 | header only, **exit 0** |

A typo in the path or in the `bench_` prefix left a CI benchmark job green
having measured nothing — invisible, because a benchmark's whole output is
numbers.

The existing "at least one file path" guard could not catch it: a nonexistent
path survives `find_files_recursive` *and* `helper::load_bench_files`, so the
count is non-zero, and the path is dropped only by the `[ -f ]` guard inside
the loop.

## 💡 Changes

- Key the check off `_BASHUNIT_BENCH_NAMES` — what actually got recorded — so it covers a missing path and an empty file alike
- Wording matches the runner's `No tests found`
- Real benchmarks unaffected; all 23 bench tests pass