### PR TITLE
feat(doc): say when a filter matches no assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 
 ### Changed
+- `bashunit doc <filter>` says `No assertion matches '<filter>'` instead of printing nothing, which was indistinguishable from a broken install. Mirrors the existing `--custom` wording; the exit code stays 0 because `doc` is informational (#1201)
 - Docs: `assert_matches` runs `grep -E` in a subprocess per call — ~2.5ms against ~0.065ms for `assert_same`, about 38x — so hot loops matching a fixed substring should prefer `assert_contains`. The subprocess is required by the Bash 3.0 floor (#1187)
 - Docs: `assert_match_snapshot` warns that a `@data_provider` test shares one snapshot across all its values — the filename comes from the test function, so the first value creates it and the rest fail against its content. `assert_match_named_snapshot "$1"` gives each value its own (#1185)
 - A test file that fails to source without writing to stderr now reports its size and says there was no stderr, so a truncated file can be told apart from one whose last command returned non-zero (#1137)

--- a/src/main/subcommands.sh
+++ b/src/main/subcommands.sh
@@ -65,7 +65,18 @@ function bashunit::main::cmd_doc() {
     exit 0
   fi
 
-  bashunit::doc::print_asserts "$filter"
+  # Mirrors the --custom branch above: an empty answer to a lookup is
+  # indistinguishable from a broken install (#1201). Emptiness is decided here
+  # rather than by a non-zero return from print_asserts, whose status is part
+  # of its contract -- under `set -e` a capturing caller would abort instead.
+  local rendered
+  rendered=$(bashunit::doc::print_asserts "$filter")
+  if [ -n "$rendered" ]; then
+    printf '%s\n' "$rendered"
+  elif [ -z "$_BASHUNIT_DOC_CUSTOM_FNS_OUT" ]; then
+    printf "No assertion matches '%s'.\n" "$filter"
+    printf 'Run `bashunit doc` without a filter to list them all.\n'
+  fi
 
   if [ -n "$_BASHUNIT_DOC_CUSTOM_FNS_OUT" ]; then
     printf '\n## Custom assertions\n\n'

--- a/tests/acceptance/bashunit_doc_custom_test.sh
+++ b/tests/acceptance/bashunit_doc_custom_test.sh
@@ -101,3 +101,24 @@ function test_doc_exits_zero_when_the_default_bootstrap_is_missing() {
 
   assert_same "0" "$exit_code"
 }
+
+# `--custom` with no matches already says "No custom assertions found", but the
+# plain lookup printed nothing at all for a filter that matches no assertion —
+# indistinguishable from a broken install or missing docs. Substring matching
+# is generous (`equal` still returns 9), so this only bites a genuinely wrong
+# term, but silence is a poor answer to a lookup (#1201).
+function test_doc_says_so_when_the_filter_matches_no_assertion() {
+  local output
+  output=$(./bashunit doc no_such_assertion_xyz 2>&1) || true
+
+  assert_contains "No assertion matches" "$output"
+  assert_contains "no_such_assertion_xyz" "$output"
+}
+
+function test_doc_still_prints_a_matching_assertion() {
+  local output
+  output=$(./bashunit doc assert_same 2>&1) || true
+
+  assert_contains "## assert_same" "$output"
+  assert_not_contains "No assertion matches" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1201

```
$ bashunit doc no_such_assertion_xyz
$ echo $?
0
```

Nothing at all — indistinguishable from a broken install. The same command
already handles this on the other branch: `--custom` with no matches prints
`No custom assertions found.`

## 💡 Changes

- Say so, mirroring that wording: `No assertion matches '<filter>'` plus a pointer to the unfiltered listing
- **Exit code stays 0** — `doc` is informational, and grep-style exit 1 would be a contract change a script could trip on
- Emptiness is decided in the caller, not by returning non-zero from `print_asserts`: its status is part of its contract, and `test_print_asserts_with_no_matching_filter` captures its output, so under `--strict` `set -e` would abort at `output=$(...)` though its assertion still holds

Doc snapshot byte-identical; `doc_test.sh` unchanged.