### PR TITLE
test(project): assert every assertion is documented

### DIFF
--- a/tests/unit/project/assertions_docs_parity_test.sh
+++ b/tests/unit/project/assertions_docs_parity_test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Settings and CLI flags are checked against the docs; the assertions never
+# were. A new assertion ships in `src/` and nobody notices it is missing from
+# the reference page until a user goes looking for it — the same drift that
+# left 17 settings undocumented before `docs_parity_test.sh` existed.
+#
+# Both pages count: the spy and mock assertions live in `docs/test-doubles.md`,
+# the rest in `docs/assertions.md`. Checking only the latter reports the whole
+# `assert_have_been_called*` family as undocumented, which is how this started.
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  DOC_PAGES="$ROOT_DIR/docs/assertions.md $ROOT_DIR/docs/test-doubles.md"
+}
+
+# Public assertions: `function assert_x()` anywhere under src/. The namespaced
+# `bashunit::assert::*` helpers are internal and deliberately excluded.
+function _src_assertions() {
+  # shellcheck disable=SC2086
+  find "$ROOT_DIR/src" -name '*.sh' -print0 |
+    xargs -0 "$GREP" -hoE '^function assert_[a-z0-9_]+' |
+    sed 's/^function //' | LC_ALL=C sort -u
+}
+
+function _documented_assertions() {
+  # shellcheck disable=SC2086
+  "$GREP" -hoE '^## assert_[a-z0-9_]+$' $DOC_PAGES |
+    sed 's/^## //' | LC_ALL=C sort -u
+}
+
+# Guards the guard: both extractors returning nothing would make every
+# comparison below pass while checking nothing.
+function test_both_extractors_find_assertions() {
+  assert_greater_than 40 "$(_src_assertions | wc -l)"
+  assert_greater_than 40 "$(_documented_assertions | wc -l)"
+}
+
+function test_every_assertion_in_src_is_documented() {
+  local missing
+  missing=$(comm -23 <(_src_assertions) <(_documented_assertions) | tr '\n' ' ')
+
+  assert_empty "$missing"
+}
+
+function test_every_documented_assertion_exists_in_src() {
+  local unknown
+  unknown=$(comm -13 <(_src_assertions) <(_documented_assertions) | tr '\n' ' ')
+
+  assert_empty "$unknown"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1203

`docs_parity_test.sh` checks settings and CLI flags against the docs. The
**assertions** — the framework's main public surface, 94 of them — were not
checked at all. Same drift that left 17 settings undocumented before that test
existed.

Currently 94 in `src/` against 94 documented, so this locks in a property that
holds rather than fixing a break.

## 💡 Changes

- Parity in both directions between public `assert_*` functions and their reference entries
- **Both pages count**: the spy/mock family lives in `docs/test-doubles.md`, the rest in `docs/assertions.md` — checking only the latter reports all 8 as undocumented
- A floor guard on each extractor: two empty extractors would compare equal and pass while checking nothing, the vacuity fixed in #1159 and #1161

## Mutation-verified

| mutation | result |
|---|---|
| new undocumented assertion in `src/` | 1 test fails |
| documented assertion that does not exist | 1 test fails |
| extractor stops matching | 2 tests fail |