### PR TITLE
docs(quickstart): describe what init now does to .env

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -51,8 +51,9 @@ It creates, in the current directory:
 - `.github/workflows/tests.yml` — a CI workflow using the official action
 - `.env` — with `BASHUNIT_BOOTSTRAP=tests/bootstrap.sh`, which is what makes the bootstrap load
 
-If `.env` already sets `BASHUNIT_BOOTSTRAP`, `init` comments that line out and appends the
-new one, so check the diff before committing.
+If `.env` already sets `BASHUNIT_BOOTSTRAP` to that same file, `init` leaves it alone and
+says so, so re-running is safe. If it points somewhere else, the old line is commented out
+and the new one appended — check the diff before committing.
 
 Alternatively, create your tests manually:
 


### PR DESCRIPTION
## 🤔 Background

#1176 made `bashunit init` idempotent in `.env`: when it already points
`BASHUNIT_BOOTSTRAP` at the same file, init says so and changes nothing; only a
**differing** value is commented out and replaced.

The CHANGELOG recorded that. This page still described the old unconditional
comment-and-append, which would have told a user to expect a diff that no
longer happens.

## 💡 Changes

- Describe both branches accurately, and note that re-running is safe

Found by following the quickstart literally, as a new user would. Every other
step — `init`, the manual test file, `./lib/bashunit tests`, the default path,
`--filter`, `--parallel` — behaves exactly as documented, sample output
included.