### PR TITLE
docs(benchmarks): document the no-benchmarks-found failure

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -71,6 +71,12 @@ Run benchmarks using the `bench` command:
 
 If no file is provided, bashunit uses [`BASHUNIT_DEFAULT_PATH`](/configuration) to locate all `*bench.sh` files.
 
+A run that finds nothing to measure — a path that does not exist, or a file
+holding no `bench_` function — reports `No benchmarks found` and **exits
+non-zero**, the same way `bashunit test` reports `No tests found`. A typo in the
+path or in the prefix would otherwise leave a green CI job that benchmarked
+nothing, which is easy to miss when the whole output is numbers.
+
 ## Output Formats
 
 ### Simple Output


### PR DESCRIPTION
## 🤔 Background

#1200 made `bench` report `No benchmarks found` and exit non-zero when there is
nothing to measure. The guide never mentioned it.

The existing exit-condition list in that page is specific to **baseline
comparison** ("slower than baseline × tolerance", "missing baseline"), so the
new discovery-level failure would be misplaced there. It goes in **Running
Benchmarks**, next to how files are discovered.

## 💡 Changes

- Document the failure and why it exists: a typo in the path or the `bench_` prefix would otherwise leave a green CI job that benchmarked nothing

Found by sweeping the guides for behaviour changed today, after the quickstart
turned out to still describe `init`'s pre-#1176 handling of `.env`. Docs↔code
*name* parity is guarded now; prose describing *behaviour* is not, and only
reading it catches this.