### PR TITLE
docs(patterns): fix swapped assert_file_contains arguments

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -127,7 +127,7 @@ function test_insert_record() {
   create_table "users"
   insert_record "users" "john@example.com"
 
-  assert_file_contains "john@example.com" "$TEST_DB/users.txt"
+  assert_file_contains "$TEST_DB/users.txt" "john@example.com"
 }
 ```
 :::
@@ -252,9 +252,9 @@ function test_log_creates_file() {
 function test_log_writes_timestamp_and_message() {
   log_message "Error occurred" "$TEST_LOG"
 
-  assert_file_contains "Error occurred" "$TEST_LOG"
+  assert_file_contains "$TEST_LOG" "Error occurred"
   # Check for timestamp pattern (YYYY-MM-DD HH:MM:SS)
-  assert_matches "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}" "$TEST_LOG"
+  assert_matches "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}" "$(cat "$TEST_LOG")"
 }
 
 function test_log_appends_multiple_messages() {
@@ -659,7 +659,7 @@ function tear_down() {
 function test_create_user() {
   create_test_user "John Doe" "john@example.com"
 
-  assert_file_contains "John Doe" "$TEST_DB/users.csv"
+  assert_file_contains "$TEST_DB/users.csv" "John Doe"
 }
 ```
 :::


### PR DESCRIPTION
## 🤔 Background

Related #1209

`assert_file_contains` takes `"file" "search"`, but three examples in the guide
users copy from had them reversed:

```bash
assert_file_contains "Error occurred" "$TEST_LOG"     # looks for a file named "Error occurred"
```

Copied verbatim it fails with `Expected 'Error occurred'`, which reads as
missing content rather than backwards arguments.

One line below, `assert_matches "<timestamp regex>" "$TEST_LOG"` matched the
pattern against the **path**, never the contents its comment described.

## 💡 Changes

- Correct the three swapped calls and the `assert_matches` target
- Executed each example before and after: originals fail, corrections pass

Argument order is invisible to the docs-parity guards — every symbol exists and
is spelled correctly — so only running the examples finds it. Same pass that
found #1207.