### PR TITLE
docs(patterns): stop showing assertions that can never fail

### DIFF
--- a/docs/common-patterns.md
+++ b/docs/common-patterns.md
@@ -154,7 +154,7 @@ function tear_down_after_script() {
 }
 
 function test_server_responds_to_ping() {
-  assert_successful_code "curl -s http://localhost:8080/ping"
+  assert_exec "curl -s http://localhost:8080/ping"
 }
 
 function test_server_returns_json() {
@@ -426,7 +426,7 @@ function test_script_fails_on_error() {
 
 function test_error_handled_gracefully() {
   # Script should catch and handle expected errors
-  assert_successful_code "./src/resilient_script.sh"
+  assert_exec "./src/resilient_script.sh"
 }
 ```
 :::
@@ -539,7 +539,7 @@ function test_json_is_valid() {
   output=$(./src/generate_report.sh --format json)
 
   # Use jq to validate JSON (mock it if jq not available)
-  assert_successful_code "echo '$output' | jq . > /dev/null"
+  assert_exec "echo '$output' | jq . > /dev/null"
 }
 ```
 :::
@@ -769,11 +769,11 @@ function set_up() {
 
 # Test private function directly after sourcing
 function test_private_validate_input_accepts_numbers() {
-  assert_successful_code "_validate_input 123"
+  assert_exec "_validate_input 123"
 }
 
 function test_private_validate_input_rejects_text() {
-  assert_general_error "_validate_input abc"
+  assert_exec "_validate_input abc" --exit 1
 }
 
 # Test through public interface
@@ -809,7 +809,7 @@ function data_provider_valid_emails() {
 }
 
 function test_valid_email_formats() {
-  assert_successful_code "validate_email '$1'"
+  assert_exec "validate_email '$1'"
 }
 
 function data_provider_invalid_emails() {
@@ -820,7 +820,7 @@ function data_provider_invalid_emails() {
 }
 
 function test_invalid_email_formats() {
-  assert_general_error "validate_email '$1'"
+  assert_exec "validate_email '$1'" --exit 1
 }
 ```
 :::


### PR DESCRIPTION
## 🤔 Background

Related #1211

`assert_successful_code` / `assert_general_error` read `$?` and do **not** run a
string handed to them. Seven examples in the guide users copy from passed one
anyway, so the assertion could never fail:

```
assert_successful_code "false"                         ✓ Passed
assert_successful_code "definitely_not_a_command_xyz"  ✓ Passed
```

A copied "test the server responds to ping" test verified nothing. Worse than
#1209, where swapped arguments at least failed loudly.

## 💡 Changes

- Replace the seven with `assert_exec`, which executes the string and — since #1208 — handles a non-zero exit under `--strict`. Verified with shell functions, a pipeline, and both modes

## Deliberately left alone

`assert_successful_code "$(sync_with_the_api)"` elsewhere is **correct**: the
substitution runs the command, so `$?` carries. Both shapes executed to confirm:

| shape | failing command |
|---|---|
| `"$(failing_fn)"` | ✗ Failed — correct |
| `"failing_fn"` | ✓ Passed — vacuous |