### PR TITLE
docs(skipping): warn that '&& return' breaks a conditional skip

### DIFF
--- a/docs/skipping-incomplete.md
+++ b/docs/skipping-incomplete.md
@@ -98,6 +98,22 @@ Called from inside a test's own `$(...)` subshell, these helpers end that
 subshell only — the same as any `exit`. Call them from the test body.
 :::
 
+::: warning Do not add `&& return` here
+`bashunit::skip` only marks the test — execution continues, which is why it is
+written `bashunit::skip "reason" && return`. The conditional skips stop the test
+themselves, so they need no `return`, and adding one breaks them:
+
+```bash
+bashunit::skip_if "[ 1 -eq 2 ]" "not met" && return   # ✗ ends the test even though
+                                                      #   the condition did not hold
+assert_same 1 1                                       #   never runs
+```
+
+When the condition does not hold, `skip_if` returns `0`, so `&& return` fires and
+the test finishes having asserted nothing. It is reported as **risky** rather
+than passing, which is the only hint you get.
+:::
+
 ## bashunit::todo
 > `bashunit::todo "[pending]"`
 


### PR DESCRIPTION
## 🤔 Background

Related #1213

The two skip families need **opposite** call shapes, and nothing said so:

| function | stops itself | needs `&& return` | with `&& return` when *not* skipping |
|---|---|---|---|
| `skip` | no — marks only | **yes** | n/a |
| `skip_if` / `skip_unless*` | yes (`exit 0`) | **no** | **test ends having asserted nothing** |

```bash
bashunit::skip_if "[ 1 -eq 2 ]" "not met" && return   # condition false…
assert_same 1 1                                       # …yet this never runs
```

`skip_if` ends on a false `if`, so it returns `0`, `&& return` fires, and the
test finishes empty. It surfaces as **risky** rather than passing — the only
hint you get.

## 💡 Changes

- Warning in `docs/skipping-incomplete.md` next to the conditional skips

Found by writing the idiom myself while executing the guide: three tests came
out risky instead of passing. The documented examples were already correct —
what was missing is why the shape differs.