### PR TITLE
test(install): run install.sh in a sandbox instead of the repository

### DIFF
--- a/tests/acceptance/install_test.sh
+++ b/tests/acceptance/install_test.sh
@@ -9,6 +9,7 @@ HAS_DOWNLOADER=0
 HAS_GIT=0
 
 function set_up_before_script() {
+  INSTALL_ROOT_DIR="$(pwd)"
   if bashunit::env::active_internet_connection; then
     ACTIVE_INTERNET=0
   else
@@ -26,14 +27,22 @@ function tear_down_after_script() {
   set -e
 }
 
+# `install.sh` resolves its destination relative to its own location (it runs
+# `cd "$(dirname "$0")"`), so running the repository's copy wrote `lib/`,
+# `tmp_install/`, `tmp_deps/` and `tmp_lib/` into the repository itself. Three
+# consequences, all real: a killed run left debris in the working tree, only
+# `lib/` is gitignored so the rest showed up as untracked files, and two suites
+# running at once raced the same `lib/bashunit` -- one installing 0.19.0 while
+# the other installed latest, which fails as a version mismatch that looks like
+# a regression and passes on re-run.
+#
+# Give each test its own copy of the script and run it there. Every relative
+# path in the tests then resolves inside that directory, so the assertions stay
+# as they were, and `bashunit::temp_dir` cleans up.
 function set_up() {
-  rm -f ./lib/bashunit
-  rm -rf ./tmp_install ./tmp_deps ./tmp_lib
-}
-
-function tear_down() {
-  rm -f ./lib/bashunit
-  rm -rf ./tmp_install ./tmp_deps ./tmp_lib
+  SANDBOX="$(bashunit::temp_dir)"
+  cp "$INSTALL_ROOT_DIR/install.sh" "$SANDBOX/install.sh"
+  cd "$SANDBOX" || return 1
 }
 
 function test_install_downloads_the_latest_version() {


### PR DESCRIPTION
## 🤔 Background

Related #1241

`install.sh` resolves its destination relative to its own location (`cd "$(dirname "$0")"`), so nine tests running the repository's copy wrote `lib/`, `tmp_install/`, `tmp_deps/` and `tmp_lib/` **into the repository**, cleaning them up in `tear_down`.

That races across concurrent runs — one test installs `0.19.0` into `lib/bashunit` while another installs latest into the same path, so the loser fails with a version mismatch that reads like a regression and passes on re-run. A killed run also leaves debris, and only `lib/` is gitignored, so the rest shows up as untracked files.

## 💡 Changes

- Give each test its own copy of the script and run it there — the pattern four tests in this file already use
- Because every relative path then resolves inside that directory, **no assertion changed**; only `set_up` did, and `bashunit::temp_dir` handles cleanup
- Use a file-specific `INSTALL_ROOT_DIR`, since six other test files use `ROOT_DIR` in the same shared shell

Verified three ways: the 13 tests pass unchanged, a full suite run leaves `git status` clean with no `lib/`, `tmp_install/`, `tmp_deps/` or `tmp_lib/` behind, and two concurrent runs of the file both pass.