### PR TITLE
feat(cli): explain --env when a space in the path caused the failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--verbose` warns on Bash 3.x that coverage does not count lines run inside a subshell, so a percentage that reads lower there than on Bash 4+ explains itself (#1112)
 
 ### Changed
+- `--env` with a space in the path explains itself. The flag takes `"file arg1 arg2"` and splits on the first space, so `--env "my boot.sh"` reported `cannot read the bootstrap file: 'my'` — a path the user never typed, for a file that is right there. It now says the value was split and that `BASHUNIT_BOOTSTRAP` takes the path whole; a genuinely missing file keeps the terse message (#1247)
 - A `--filter` that selects nothing now explains why instead of ending on a bare `No tests found`: filters match the test **function name**, case-sensitively, while the report prints a humanized title, so feeding back the name you just read (`--filter "User login"` for `test_user_login`) silently matched nothing. The run names the test it most likely meant, resolving both the capitalisation and the spaces
 - `bashunit doc <filter>` says `No assertion matches '<filter>'` instead of printing nothing, which was indistinguishable from a broken install. Mirrors the existing `--custom` wording; the exit code stays 0 because `doc` is informational (#1201)
 - `install.sh` destination errors no longer advise a `-d` flag that does not exist — the script takes positional arguments, so following the advice produced `Invalid arguments`. The one message whose job is to tell you how to recover pointed at a form the parser rejects (#1221)

--- a/src/main/bench.sh
+++ b/src/main/bench.sh
@@ -80,9 +80,7 @@ function bashunit::main::cmd_bench() {
       # A missing bootstrap used to leak a raw `source` error, abort the rest of
       # the parse and exit 0 with no tests run at all (#875).
       if [ ! -f "$boot_file" ] || [ ! -r "$boot_file" ]; then
-        printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
-          "${_BASHUNIT_COLOR_FAILED}" "$boot_file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
-        exit 1
+        bashunit::main::report_unreadable_bootstrap "$boot_file" "$2"
       fi
       # Export all variables from the env file so they're available in subshells
       # (e.g., process substitution used in load_test_files)

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -319,9 +319,7 @@ function bashunit::main::cmd_test() {
       # A missing bootstrap used to leak a raw `source` error, abort the rest of
       # the parse and exit 0 with no tests run at all (#875).
       if [ ! -f "$boot_file" ] || [ ! -r "$boot_file" ]; then
-        printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
-          "${_BASHUNIT_COLOR_FAILED}" "$boot_file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
-        exit 1
+        bashunit::main::report_unreadable_bootstrap "$boot_file" "$2"
       fi
       # Export all variables from the env file so they're available in subshells
       # (e.g., process substitution used in load_test_files)

--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -46,6 +46,35 @@ function bashunit::main::report_path_is_a_directory() {
 }
 
 
+##
+# Reports an unreadable bootstrap file and exits.
+#
+# `-e/--env/--boot` takes "file arg1 arg2", so it splits its value on the first
+# space. That is deliberate, and it makes a path containing a space unusable --
+# but the plain message then names a truncated path the user never typed
+# (`--env "my boot.sh"` reported `'my'`), telling them a file that is right
+# there does not exist. When the whole value is readable, say what happened and
+# name the way out: BASHUNIT_BOOTSTRAP is not split (#1247).
+# Arguments: $1 - the file after the split, $2 - the whole flag value
+##
+function bashunit::main::report_unreadable_bootstrap() {
+  local boot_file=$1
+  local raw=${2-}
+
+  printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
+    "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+
+  if [ "$raw" != "$boot_file" ] && [ -r "$raw" ]; then
+    printf "%s--env splits its value on the first space to pass bootstrap arguments,%s\n" \
+      "$_BASHUNIT_COLOR_FAINT" "$_BASHUNIT_COLOR_DEFAULT" >&2
+    printf "%sso a path containing one cannot be used. Set BASHUNIT_BOOTSTRAP='%s' instead.%s\n" \
+      "$_BASHUNIT_COLOR_FAINT" "$raw" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  fi
+
+  exit 1
+}
+
+
 function bashunit::main::require_writable_path_or_exit() {
   local path=$1
   local parent=${1%/*}

--- a/tests/acceptance/bashunit_init_test.sh
+++ b/tests/acceptance/bashunit_init_test.sh
@@ -177,6 +177,76 @@ function test_an_env_flag_file_that_exits_says_so() {
   assert_contains "bootstrap" "$output"
 }
 
+# `--env` takes "file arg1 arg2", so it splits its value on the first space.
+# That is deliberate, and it makes a path containing a space unusable -- but
+# the message named a truncated path the user never typed:
+#
+#   Error: cannot read the bootstrap file: 'my'.
+#
+# for `--env "my boot.sh"`. The file is right there, so the reader is told
+# their existing file does not exist. Explain the split and name the way out.
+function test_an_env_path_with_a_space_explains_the_split() {
+  pushd "$TMP_DIR" >/dev/null
+  printf 'BASHUNIT_SHOW_HEADER=false\n' >"my boot.sh"
+  printf 'function test_ok() { assert_same 1 1; }\n' >t_test.sh
+
+  local ec=0
+  local output
+  output=$("$BASHUNIT_PATH" --no-parallel --env "my boot.sh" t_test.sh 2>&1) || ec=$?
+  popd >/dev/null
+
+  assert_general_error "" "" "$ec"
+  assert_contains "space" "$output"
+  assert_contains "BASHUNIT_BOOTSTRAP" "$output"
+}
+
+# The advice has to work: the env var is not split, so it takes the path whole.
+function test_the_bootstrap_env_var_accepts_a_path_with_a_space() {
+  pushd "$TMP_DIR" >/dev/null
+  printf 'BASHUNIT_SHOW_HEADER=false\n' >"my boot.sh"
+  printf 'function test_ok() { assert_same 1 1; }\n' >t_test.sh
+
+  local ec=0
+  local output
+  output=$(BASHUNIT_BOOTSTRAP="my boot.sh" "$BASHUNIT_PATH" --no-parallel t_test.sh 2>&1) || ec=$?
+  popd >/dev/null
+
+  assert_same 0 "$ec"
+  assert_contains "1 passed" "$output"
+}
+
+# A genuinely missing file, with no space involved, keeps the plain message:
+# the explanation must not fire where it would be noise.
+function test_a_missing_env_file_without_a_space_stays_terse() {
+  pushd "$TMP_DIR" >/dev/null
+  printf 'function test_ok() { assert_same 1 1; }\n' >t_test.sh
+
+  local ec=0
+  local output
+  output=$("$BASHUNIT_PATH" --no-parallel --env absent.sh t_test.sh 2>&1) || ec=$?
+  popd >/dev/null
+
+  assert_general_error "" "" "$ec"
+  assert_contains "cannot read the bootstrap file" "$output"
+  assert_not_contains "BASHUNIT_BOOTSTRAP" "$output"
+}
+
+# Passing arguments after the file is the reason for the split, so it must keep
+# working: the file resolves and the explanation stays quiet.
+function test_env_arguments_after_the_file_still_work() {
+  pushd "$TMP_DIR" >/dev/null
+  printf 'BASHUNIT_BOOT_ARG="$1"\n' >boot.sh
+  printf 'function test_ok() { assert_same 1 1; }\n' >t_test.sh
+
+  local ec=0
+  local output
+  output=$("$BASHUNIT_PATH" --no-parallel --env "boot.sh hello" t_test.sh 2>&1) || ec=$?
+  popd >/dev/null
+
+  assert_same 0 "$ec"
+  assert_not_contains "cannot read the bootstrap file" "$output"
+}
+
 # A healthy --env file must still be sourced and its values reach the run.
 function test_a_healthy_env_flag_file_still_loads() {
   pushd "$TMP_DIR" >/dev/null


### PR DESCRIPTION
## 🤔 Background

Related #1247

`-e/--env/--boot` takes `"file arg1 arg2"` and splits on the first space — deliberate, and it makes a path containing a space unusable. The message then named a truncated path the user never typed:

```console
$ bashunit --env "my boot.sh" t_test.sh
Error: cannot read the bootstrap file: 'my'.
```

Checking whether `my boot.sh` exists only confirms that it does, so the error reads as simply wrong.

## 💡 Changes

- Keep the split; explain it exactly when it is the cause — the value contains a space **and** the whole value is readable — and name `BASHUNIT_BOOTSTRAP`, which is not split
- Verified that route accepts a spaced path before recommending it; that check is now its own test, since advice that does not work is what #1221 and #1229 were about
- Move the reporter into `validate.sh` with the other shared parser validation: `test.sh` and `bench.sh` carried identical copies of the parse and the message, and both now emit the explanation

Three guards keep it from becoming noise: a genuinely missing file with no space stays terse, `--env "boot.sh arg"` still passes arguments, and the env var still loads. All three passed before the fix — only the diagnostic was red.