### PR TITLE
test(sandbox): pin the two documented boundaries

### DIFF
--- a/tests/acceptance/bashunit_sandbox_test.sh
+++ b/tests/acceptance/bashunit_sandbox_test.sh
@@ -102,3 +102,31 @@ function test_an_invalid_sandbox_allow_value_is_rejected() {
   assert_general_error "" "" "$ec"
   assert_contains "invalid --sandbox-allow value" "$output"
 }
+
+# A child process inherits the narrowed PATH, so an unmocked command is not
+# merely unreported there -- it is unresolvable. That is what makes
+# `sh -c 'curl …'` useless as an escape off Windows.
+#
+# It holds because the sandbox *replaces* PATH rather than prepending to it.
+# Verified by mutation: prepending the sandbox dir instead fails this test and
+# nothing else. (Dropping the `export` does not -- PATH is exported already.)
+function test_a_child_process_cannot_resolve_an_unmocked_command() {
+  local output
+  output=$(run_fixture "--sandbox" "test_sandbox_child_process_cannot_resolve_the_command")
+
+  assert_contains "1 passed" "$output"
+  # `command -v` printed nothing: the child could not find it.
+  assert_empty "$(cat "$PROBE_LOG")"
+}
+
+# The documented limitation. Pinned so it stays a deliberate boundary: an
+# absolute path bypasses PATH, so the sandbox cannot see it.
+function test_an_absolute_path_bypasses_the_sandbox_as_documented() {
+  local output
+  SANDBOX_PROBE_ABS="$PROBE_DIR/bashunit_sandbox_probe"
+  export SANDBOX_PROBE_ABS
+  output=$(run_fixture "--sandbox" "test_sandbox_absolute_path_is_not_blocked")
+
+  assert_contains "1 passed" "$output"
+  assert_contains "the real command ran" "$(cat "$PROBE_LOG")"
+}

--- a/tests/acceptance/fixtures/test_bashunit_sandbox.sh
+++ b/tests/acceptance/fixtures/test_bashunit_sandbox.sh
@@ -32,3 +32,19 @@ function test_sandbox_after_unmock_the_command_is_blocked_again() {
   bashunit_sandbox_probe >"${SANDBOX_PROBE_LOG:?log required}" 2>/dev/null
   assert_same "ok" "ok"
 }
+
+# The boundary the docs draw. A child process inherits the narrowed PATH, so it
+# cannot resolve the command at all -- that is what makes `sh -c 'curl …'`
+# useless as an escape on Linux and macOS. It holds because the sandbox replaces
+# PATH rather than prepending to it.
+function test_sandbox_child_process_cannot_resolve_the_command() {
+  sh -c 'command -v bashunit_sandbox_probe' >"${SANDBOX_PROBE_LOG:?log required}" 2>/dev/null
+  assert_same "ok" "ok"
+}
+
+# The documented limitation, pinned so it stays a known boundary rather than a
+# surprise: an absolute path skips PATH entirely and is not blocked.
+function test_sandbox_absolute_path_is_not_blocked() {
+  "${SANDBOX_PROBE_ABS:?abs path required}" >"${SANDBOX_PROBE_LOG:?log required}" 2>/dev/null
+  assert_same "ok" "ok"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1260

`--sandbox` had 9 acceptance tests and none for either boundary the docs draw — both security-adjacent, both able to regress silently:

- **A child process cannot resolve an unmocked command.** `sh -c 'command -v probe'` returns empty under `--sandbox`: the narrowed PATH is inherited, so the command is unreachable rather than merely unreported. That is what makes `sh -c 'curl …'` useless as an escape off Windows.
- **An absolute path bypasses the sandbox** — documented as a limitation, now pinned so it stays deliberate.

## 💡 Changes

- Two acceptance tests plus their fixture entries

## The mechanism is not what it looks like

Removing `export PATH` from `src/runner/sandbox.sh` changes **nothing** — `PATH` is exported already, so that mutation is a no-op and every test still passes. My first version of the comment claimed the property depended on it.

It actually holds because the sandbox **replaces** PATH rather than prepending:

```bash
PATH="$_BASHUNIT_SANDBOX_DIR"        ->  PATH="$_BASHUNIT_SANDBOX_DIR:$PATH"
```

fails the child-process test and nothing else. Both facts are recorded in the comment — a comment naming the wrong dependency is worse than none, since the next person mutates what it names, sees green, and concludes the test is worthless.

Fixture safety checked: every test in the file filters, so the two added fixture entries are only reached via their own filters, and the fixture is not collected by the suite (does not match `*[tT]est.sh`, and `fixtures/` is excluded by path).