### PR TITLE
feat(cli): add --list-tags to print the tags of the selected files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,7 @@ BASHUNIT_COVERAGE_DIFF=             # Default: empty (restrict coverage to lines
 BASHUNIT_EXCLUDE_FILTER=            # Default: empty (skip tests whose name matches)
 BASHUNIT_LIST_TESTS=                # Default: false (print the tests that would run, run none)
 BASHUNIT_LIST_FORMAT=               # Default: text (--list rendering: text or json)
+BASHUNIT_LIST_TAGS=                 # Default: false (print the tags of the selected files, run none)
 BASHUNIT_STOP_ON_ASSERTION_FAILURE= # Default: true (stop test on first assertion fail)
 BASHUNIT_STRICT_MODE=               # Default: false (enable set -euo pipefail)
 BASHUNIT_LOGIN_SHELL=               # Default: false (source login shell profiles)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- `--list-tags` prints the tags of the selected files, one per line, sorted and deduplicated, and runs nothing. Tags live only in `# @tag` comments, so a mistyped `--tag` had no list to check against; the output is nothing but the names, so it pipes (#1265)
+
 ### Changed
 - A `--tag` matching nothing now names the tags the run saw, or says no test carries one — tags live only in `# @tag` comments and nothing lists them, so a typo had no way back (#1265)
 
@@ -9,6 +12,7 @@
 
 ### Fixed
 - A test that both fails an assertion and hits a shell error no longer reports the failure text with the diagnostic glued onto the end; the error message is the diagnostic alone (#1267)
+- `--list` under `--parallel` no longer prints `No tests found` in the middle of the ids: a listing dispatches no worker, so there is nothing to aggregate (#1007)
 
 ## [0.48.0](https://github.com/TypedDevs/bashunit/compare/0.47.0...0.48.0) - 2026-08-14
 

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -103,6 +103,7 @@ _bashunit() {
     '--changed[Run only the test files changed since a git ref]::ref:' \
     '(--list --dry-run)'{--list,--dry-run}'[Print the tests that would run, then exit]' \
     '--list-format[Rendering for --list]:format:(text json)' \
+    '--list-tags[Print the tags of the selected files, one per line, then exit]' \
     '--snapshot-update[Rewrite existing snapshots from the actual value]' \
     '--no-snapshot-create[Fail instead of recording a missing snapshot]' \
     '--snapshot-prune[Delete snapshot files no test resolved]' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -17,7 +17,8 @@ _BASHUNIT_COMPLETIONS_DOC_OPTS="--custom -e --env --boot -h --help"
 _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --changed --coverage --coverage-exclude \
 --coverage-diff --coverage-min --coverage-paths --coverage-report --coverage-report-cobertura --coverage-report-html \
 --debug --detailed --dry-run --env --exclude-filter --exclude-tag --fail-on-flaky --fail-on-risky --failures-only \
---filter --gha-annotations --help --jobs --list --list-format --list-suites --log-gha --log-junit --login --no-color \
+--filter --gha-annotations --help --jobs --list --list-format --list-suites --list-tags \
+--log-gha --log-junit --login --no-color \
 --no-coverage-report --no-output --no-output-on-failure --no-parallel \
 --no-progress --no-snapshot-create --order-by --output --parallel --profile \
 --random-order --repeat --report-html \

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -95,6 +95,7 @@ bashunit test tests/ --parallel --simple
 | `--changed [<ref>]`            | Run only the test files changed since `<ref>` (default: `origin/HEAD`, then `HEAD`) |
 | `--list`, `--dry-run`          | Print the tests that would run, then exit         |
 | `--list-format <fmt>`          | Rendering for `--list`: `text` (default) or `json` |
+| `--list-tags`                  | Print the tags of the selected files, one per line, then exit |
 | `--snapshot-update`            | Rewrite existing snapshots from the actual value |
 | `--no-snapshot-create`         | Fail on a missing snapshot instead of recording it |
 | `--snapshot-report-unused`     | List snapshot files no test resolved (deletes nothing) |
@@ -267,6 +268,8 @@ Use [`--list`](#list) to check what an expression actually selects:
 ```bash
 bashunit --list --tag 'db&&!slow' tests/
 ```
+
+…and [`--list-tags`](#list-tags) to see which tag names exist in the first place.
 
 ### Sandbox
 
@@ -982,6 +985,35 @@ to is a property of the run.
 ```
 
 An unsupported format is rejected rather than silently falling back to `text`.
+
+#### List tags
+
+> `bashunit test --list-tags`
+
+Print the tags carried by the selected files, one per line, sorted and without
+duplicates, then exit without running anything.
+
+```bash
+./bashunit --list-tags tests/
+# api
+# db
+# slow
+```
+
+Tags exist only inside `# @tag` / `# @tags` comments, so a mistyped `--tag`
+selects nothing and leaves you guessing the right name. This is the list to
+check against — and, being nothing but the names on stdout (not even the
+`N tests` count `--list` writes to stderr), it pipes:
+
+```bash
+./bashunit --list-tags tests/ | while read -r tag; do
+  printf '%s: ' "$tag"; ./bashunit --list --tag "$tag" tests/ | wc -l
+done
+```
+
+It implies `--list`: the answer comes from scanning the selected files, and
+nothing may run to produce it. A selection carrying no tag prints nothing and
+exits **0**, like any other query.
 
 ### Rerun failed
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -400,6 +400,16 @@ default.
 
 Similar as using `--list` / `--list-format` options on the [command line](/command-line#list).
 
+## List tags
+
+> `BASHUNIT_LIST_TAGS=true|false`
+
+Print the tags carried by the selected files, one per line, and exit without running
+anything. Disabled by default. It implies `BASHUNIT_LIST_TESTS`: the answer comes from
+scanning the selected files, and nothing may run to produce it.
+
+Similar as using `--list-tags` option on the [command line](/command-line#list-tags).
+
 ## Snapshot update
 
 > `BASHUNIT_SNAPSHOT_UPDATE=true|false`

--- a/src/config/env.sh
+++ b/src/config/env.sh
@@ -297,6 +297,8 @@ _BASHUNIT_DEFAULT_EXCLUDE_FILTER=""
 _BASHUNIT_DEFAULT_LIST_TESTS="false"
 # Rendering for --list: text (one id per line) or json
 _BASHUNIT_DEFAULT_LIST_FORMAT="text"
+# Print the distinct tags carried by the selected files and exit
+_BASHUNIT_DEFAULT_LIST_TAGS="false"
 # Rewrite existing snapshots from the actual value instead of comparing
 _BASHUNIT_DEFAULT_SNAPSHOT_UPDATE="false"
 # Record a snapshot the first time it is asserted (false = a missing one fails)
@@ -387,6 +389,7 @@ export _BASHUNIT_GHA_ANNOTATIONS_CLAIMED=1
 : "${BASHUNIT_EXCLUDE_FILTER:=$_BASHUNIT_DEFAULT_EXCLUDE_FILTER}"
 : "${BASHUNIT_LIST_TESTS:=$_BASHUNIT_DEFAULT_LIST_TESTS}"
 : "${BASHUNIT_LIST_FORMAT:=$_BASHUNIT_DEFAULT_LIST_FORMAT}"
+: "${BASHUNIT_LIST_TAGS:=$_BASHUNIT_DEFAULT_LIST_TAGS}"
 # No bare SNAPSHOT_UPDATE alias either: rewriting files on disk is the last
 # setting that should be reachable by a generic name from the environment.
 : "${BASHUNIT_SNAPSHOT_UPDATE:=$_BASHUNIT_DEFAULT_SNAPSHOT_UPDATE}"
@@ -707,6 +710,10 @@ function bashunit::env::is_snapshot_update_enabled() {
 
 function bashunit::env::is_list_enabled() {
   [ "$BASHUNIT_LIST_TESTS" = "true" ]
+}
+
+function bashunit::env::is_list_tags_enabled() {
+  [ "$BASHUNIT_LIST_TAGS" = "true" ]
 }
 
 function bashunit::env::is_fail_on_risky_enabled() {

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -154,6 +154,7 @@ Options:
   --changed [<ref>]           Run only the test files changed since <ref> (default: origin/HEAD, then HEAD)
   --list, --dry-run           Print the tests that would run, then exit without running them
   --list-format <fmt>         Rendering for --list: text (default) or json
+  --list-tags                 Print the tags of the selected files, one per line, then exit
   --snapshot-update           Rewrite existing snapshots from the actual value (combine with --filter)
   --no-snapshot-create        Fail on a missing snapshot instead of recording it (for CI)
   --snapshot-report-unused    List snapshot files no test resolved (full runs only, deletes nothing)

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -288,6 +288,14 @@ function bashunit::main::cmd_test() {
       export -n BASHUNIT_LIST_FORMAT
       shift
       ;;
+    --list-tags)
+      # Implies --list: the answer comes from scanning the selected files, and
+      # nothing may run to produce it.
+      BASHUNIT_LIST_TAGS=true
+      BASHUNIT_LIST_TESTS=true
+      export -n BASHUNIT_LIST_TAGS
+      export -n BASHUNIT_LIST_TESTS
+      ;;
     --snapshot-update)
       BASHUNIT_SNAPSHOT_UPDATE=true
       export -n BASHUNIT_SNAPSHOT_UPDATE

--- a/src/runner/discovery.sh
+++ b/src/runner/discovery.sh
@@ -239,7 +239,10 @@ function bashunit::runner::load_test_files() {
     bashunit::runner::restore_workdir
   done
 
-  if bashunit::parallel::is_enabled; then
+  # A listing dispatched no worker, so there is nothing to wait for and no
+  # result file to aggregate -- and aggregating an empty per-script dir prints
+  # "No tests found" into what must be a clean list of ids (#1007).
+  if bashunit::parallel::is_enabled && ! bashunit::env::is_list_enabled; then
     wait
     bashunit::runner::spinner &
     local spinner_pid=$!

--- a/src/runner/list.sh
+++ b/src/runner/list.sh
@@ -95,21 +95,32 @@ function bashunit::runner::list_functions() {
 }
 
 ##
-# Closes the listing: the JSON document, or the count on stderr so that stdout
-# stays a clean list of ids for piping.
+# Emits the tags every scanned file carried, one per line and sorted, and
+# nothing else -- not even the count on stderr, which would be noise in
+# `--list-tags | while read`. The names are already deduplicated by the map
+# builder; `sort -u` keeps that true whatever accumulates them.
+##
+function bashunit::runner::list_render_tags() {
+  [ -z "$_BASHUNIT_SEEN_TAGS" ] && return 0
+
+  local tag
+  # Comma separated because a tag may contain spaces (`# @tag needs a db`), the
+  # same split every other consumer uses (src/helper/tags.sh:137).
+  local old_ifs="$IFS"
+  IFS=','
+  for tag in $_BASHUNIT_SEEN_TAGS; do
+    printf '%s\n' "$tag"
+  done | sort -u
+  IFS="$old_ifs"
+}
+
+##
+# Closes the listing: the tag names, the JSON document, or the count on stderr
+# so that stdout stays a clean list of ids for piping.
 ##
 function bashunit::runner::list_render_summary() {
-  # One tag per line, sorted and deduplicated, and nothing else -- not even the
-  # count on stderr, which would be noise in `--list-tags | while read`.
   if bashunit::env::is_list_tags_enabled; then
-    [ -z "$_BASHUNIT_SEEN_TAGS" ] && return 0
-    local _tag
-    local _old_ifs=$IFS
-    IFS=','
-    for _tag in $_BASHUNIT_SEEN_TAGS; do
-      printf '%s\n' "$_tag"
-    done | sort -u
-    IFS=$_old_ifs
+    bashunit::runner::list_render_tags
     return 0
   fi
 

--- a/src/runner/list.sh
+++ b/src/runner/list.sh
@@ -30,6 +30,15 @@ function bashunit::runner::list_functions() {
 
   bashunit::runner::order_functions_for_script "$script" "$fns"
 
+  # --list-tags wants only the names, and gets them from the same scan: the map
+  # builder accumulates every tag it sees into _BASHUNIT_SEEN_TAGS (#1265). No
+  # test ids are emitted, so the answer can be piped straight into another
+  # command.
+  if bashunit::env::is_list_tags_enabled; then
+    bashunit::helper::build_tags_map "$script"
+    return 0
+  fi
+
   local wants_json=false
   if [ "$BASHUNIT_LIST_FORMAT" = "json" ]; then
     wants_json=true
@@ -90,6 +99,20 @@ function bashunit::runner::list_functions() {
 # stays a clean list of ids for piping.
 ##
 function bashunit::runner::list_render_summary() {
+  # One tag per line, sorted and deduplicated, and nothing else -- not even the
+  # count on stderr, which would be noise in `--list-tags | while read`.
+  if bashunit::env::is_list_tags_enabled; then
+    [ -z "$_BASHUNIT_SEEN_TAGS" ] && return 0
+    local _tag
+    local _old_ifs=$IFS
+    IFS=','
+    for _tag in $_BASHUNIT_SEEN_TAGS; do
+      printf '%s\n' "$_tag"
+    done | sort -u
+    IFS=$_old_ifs
+    return 0
+  fi
+
   if [ "$BASHUNIT_LIST_FORMAT" = "json" ]; then
     printf '{"count":%s,"tests":[%s]}\n' \
       "$_BASHUNIT_LIST_COUNT" "$_BASHUNIT_LIST_JSON_ITEMS"

--- a/tests/acceptance/bashunit_list_tags_test.sh
+++ b/tests/acceptance/bashunit_list_tags_test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# `--list-tags` answers "which tags exist here?". Tags live only inside `# @tag`
+# comments and nothing listed them: `--list --list-format json` reports the tags
+# of the tests it *selected*, which is empty exactly when a mistyped --tag left
+# you looking for the right name (#1265).
+#
+# The fixtures deliberately do not end in *test.sh — anything that does under
+# tests/ is picked up by the real suite — so every run below passes explicit
+# file paths rather than the fixture directory.
+
+FIXTURES_PATH="./tests/acceptance/fixtures/list"
+ALPHA="$FIXTURES_PATH/alpha.sh"
+TAGGED="$FIXTURES_PATH/tagged.sh"
+MULTITAG="$FIXTURES_PATH/multitag.sh"
+
+function test_list_tags_prints_each_tag_once_sorted() {
+  local output
+  output="$(./bashunit --list-tags "$TAGGED" "$MULTITAG" 2>/dev/null)"
+
+  assert_same "\
+fast
+fileTag
+needs a db
+slow" "$output"
+}
+
+# A tag may contain spaces (`# @tag needs a db`), so tags are one per line and
+# split on commas only — never re-split on whitespace.
+function test_list_tags_keeps_a_tag_containing_spaces_on_one_line() {
+  local output
+  output="$(./bashunit --list-tags "$MULTITAG" 2>/dev/null)"
+
+  assert_contains "needs a db" "$output"
+}
+
+# Only the tags of the selected files, so it can answer "what is in here?".
+function test_list_tags_covers_only_the_selected_files() {
+  local output
+  output="$(./bashunit --list-tags "$TAGGED" 2>/dev/null)"
+
+  assert_same "\
+fast
+slow" "$output"
+}
+
+# Nothing but the tags: no banner, no test ids, and not even the `N tests` the
+# plain --list writes to stderr, which would be noise in `--list-tags | while read`.
+function test_list_tags_prints_nothing_else_on_either_stream() {
+  local output
+  output="$(./bashunit --list-tags "$TAGGED" 2>&1)"
+
+  assert_same "\
+fast
+slow" "$output"
+}
+
+# A query, not a run: like --list, neither a test body nor a script hook runs.
+function test_list_tags_runs_no_test_body_and_no_script_hook() {
+  local marker="$FIXTURES_PATH/.marker"
+  rm -f "$marker"
+
+  local output
+  output="$(./bashunit --list-tags "$FIXTURES_PATH/side_effect.sh" "$TAGGED" 2>/dev/null)"
+
+  # The untagged fixture contributes nothing, so the tags of the second file are
+  # what proves the scan happened at all -- otherwise "no marker" would only
+  # mean the command failed before reaching the fixture.
+  assert_same "\
+fast
+slow" "$output"
+  assert_file_not_exists "$marker"
+}
+
+# An empty answer is a valid answer and exits 0, like the other query flags --
+# unlike a real run, where selecting nothing is an error.
+function test_an_untagged_selection_prints_nothing_and_exits_zero() {
+  local output
+  local exit_code=0
+  output="$(./bashunit --list-tags "$ALPHA" 2>&1)" || exit_code=$?
+
+  assert_equals 0 "$exit_code"
+  assert_empty "$output"
+}
+
+# --list-tags implies --list, so the run is a query in --parallel too.
+function test_list_tags_prints_only_the_tags_in_parallel() {
+  local output
+  output="$(./bashunit --parallel --list-tags "$TAGGED" 2>&1)"
+
+  assert_same "\
+fast
+slow" "$output"
+}

--- a/tests/acceptance/bashunit_list_test.sh
+++ b/tests/acceptance/bashunit_list_test.sh
@@ -152,6 +152,18 @@ function test_list_writes_no_report_file() {
   assert_file_not_exists "$report"
 }
 
+# A listing dispatches no worker, so --parallel must not aggregate the empty
+# per-script dirs it left behind: that printed "No tests found" in the middle of
+# the ids, which a `--list | while read` consumer would take for a test id.
+function test_list_prints_the_same_ids_under_parallel() {
+  local sequential parallel
+  sequential="$(./bashunit --no-parallel --list "$ALPHA" 2>&1)"
+  parallel="$(./bashunit --parallel --list "$ALPHA" 2>&1)"
+
+  assert_same "$sequential" "$parallel"
+  assert_not_contains "No tests found" "$parallel"
+}
+
 function test_list_format_json_emits_valid_json_with_the_documented_fields() {
   if ! command -v jq >/dev/null 2>&1; then
     bashunit::skip "jq is required to validate the JSON shape" && return


### PR DESCRIPTION
## 🤔 Background

Related #1265

Tags live only inside `# @tag` comments and nothing lists them: `--list --list-format json` reports the tags of the tests it *selected*, which is empty exactly when a mistyped `--tag` left you looking for the right name. #1266 names them in the error; this answers the question directly.

## 💡 Changes

- `--list-tags` prints the tags of the selected files, one per line, sorted and deduplicated, and runs nothing. It implies `--list`: the answer comes from scanning the selected files, and nothing may run to produce it
- Output is nothing but the names on stdout — not even the `N tests` count `--list` writes to stderr — so it pipes into another command
- Fixes a pre-existing `--list` bug found while testing: under `--parallel` the empty per-script temp dirs were aggregated and reported `No tests found` between the ids
- Documented in the CLI reference and configuration pages, `--help` and both completion scripts

https://claude.ai/code/session_019VfkLGMvHdFHdPzzNm7Kok