### PR TITLE
fix(snapshot): report a snapshot whose test file is gone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `--list-tags` prints the tags of the selected files, one per line, sorted and deduplicated, and runs nothing. Tags live only in `# @tag` comments, so a mistyped `--tag` had no list to check against; the output is nothing but the names, so it pipes (#1265)
 
 ### Changed
+- `--snapshot-report-unused` and `--snapshot-prune` now see a snapshot whose test **file** was deleted or renamed, which is the most common way a snapshot is orphaned and the one kind neither flag could ever report: no run discovers such a file, so the owner check skipped it forever. A snapshot whose test file exists but was not part of this run is still left alone, so both flags stay safe on a subset of the suite. This widens what `--snapshot-prune` deletes (#1194)
 - A `--tag` matching nothing now names the tags the run saw, or says no test carries one — tags live only in `# @tag` comments and nothing lists them, so a typo had no way back (#1265)
 
 - Performance: per-test cleanup no longer reads the whole of `BASHUNIT_TEMP_DIR`. That directory is shared and survives between runs, so leftovers from an interrupted run taxed every test of every later run — a 100-test file took 978ms against 5000 leftovers and 542ms after, and runtime no longer grows with the directory. A file a test writes there by hand, rather than via `temp_file`/`temp_dir`, is no longer removed for it (#1269)

--- a/docs/snapshots.md
+++ b/docs/snapshots.md
@@ -174,9 +174,21 @@ Nothing was deleted. Run with --snapshot-prune to remove them.
 
 It never deletes anything — a snapshot removed by mistake is re-recorded on the next run
 and never fails again, so an automatic cleanup could quietly turn a real assertion into a
-rubber stamp. Only snapshots belonging to the test files of the run are considered, and
-the flag is refused with `--filter`, `--tag`, `--exclude-tag`, `--shard` and
+rubber stamp. The flag is refused with `--filter`, `--tag`, `--exclude-tag`, `--shard` and
 `--rerun-failed`, whose partial runs would report live files as unused.
+
+Two kinds of snapshot are reported:
+
+- one whose test file **ran** and whose test no longer resolves it — a renamed or deleted
+  test function;
+- one whose test file is **gone from disk** entirely — a renamed or deleted test *file*,
+  the most common way a snapshot is orphaned. No run can discover such a file, so nothing
+  would ever report it otherwise.
+
+A snapshot whose test file exists but was not part of this run is left alone, so running
+`./bashunit --snapshot-report-unused one_test.sh` never reports its neighbours' snapshots.
+"Not selected" and "not on disk" are the distinction, and it is what keeps the flags safe
+on a subset of the suite.
 
 ### Deleting them
 

--- a/src/assert/snapshot.sh
+++ b/src/assert/snapshot.sh
@@ -120,6 +120,12 @@ function bashunit::snapshot::collect_unused() {
   # so it can be attributed to the test file that owns it. Only the files this
   # run discovered are considered: running one file or one directory must not
   # report every snapshot belonging to the files it did not run.
+  #
+  # That leaves one class no run can ever own: a snapshot whose test file was
+  # deleted or renamed. No run discovers it, so the check below skipped it
+  # forever and neither flag could see the most common kind of dead snapshot
+  # (#1194). Disk decides that case, per snapshots dir, in the loop further
+  # down -- an owner that exists but was not selected is still left alone.
   local owners=""
   for path in "$@"; do
     [ -f "$path" ] || continue
@@ -140,9 +146,24 @@ function bashunit::snapshot::collect_unused() {
 
   local unused=""
   local total=0
-  local dir file normalized
+  local dir file normalized parent disk_owners candidate
   while IFS= read -r dir; do
     [ -z "$dir" ] && continue
+    # resolve_file writes "<dir of test file>/snapshots/...", so an owner that
+    # still exists is a regular file one level up. Collected once per directory,
+    # with no fork: glob, parameter expansion and `case`.
+    case "$dir" in
+    */snapshots) parent="${dir%/snapshots}" ;;
+    snapshots) parent="." ;;
+    *) parent="$dir" ;;
+    esac
+    disk_owners=""
+    for candidate in "$parent"/*; do
+      [ -f "$candidate" ] || continue
+      bashunit::helper::normalize_variable_name_to_slot "${candidate##*/}"
+      disk_owners="$disk_owners$_BASHUNIT_HELPER_VARNAME_OUT
+"
+    done
     for file in "$dir"/*.snapshot; do
       [ -f "$file" ] || continue
       normalized="$(bashunit::snapshot::normalize_path "$file")"
@@ -153,7 +174,13 @@ function bashunit::snapshot::collect_unused() {
       owner="${owner%%.*}"
       case "$owners" in
       *"$owner"$'\n'*) ;;
-      *) continue ;;
+      *)
+        # Not selected by this run. Keep it only while its owner is still on
+        # disk; with no such file there is no run that could ever claim it.
+        case "$disk_owners" in
+        *"$owner"$'\n'*) continue ;;
+        esac
+        ;;
       esac
       total=$((total + 1))
       unused="$unused  $normalized

--- a/tests/acceptance/bashunit_snapshot_prune_test.sh
+++ b/tests/acceptance/bashunit_snapshot_prune_test.sh
@@ -61,12 +61,48 @@ function test_prune_deletes_nothing_when_no_snapshot_is_unused() {
 }
 
 function test_prune_leaves_a_snapshot_of_a_file_outside_the_run_alone() {
+  # The owner has to be on disk for this to be the case the name describes: a
+  # file that exists and simply was not selected. This is the guarantee that
+  # keeps prune safe on a path subset (#1194).
+  echo "" >"$WORKDIR/other_test.sh"
   local foreign="$WORKDIR/snapshots/other_test_sh.test_something.snapshot"
   echo "not mine" >"$foreign"
 
   run_prune >/dev/null
 
   assert_file_exists "$foreign"
+}
+
+# The kind no run can own: the test file that named it was deleted or renamed,
+# so no run will ever discover it and the owner check skipped it forever (#1194).
+function test_prune_deletes_a_snapshot_whose_owner_file_is_gone() {
+  local gone="$WORKDIR/snapshots/gone_test_sh.test_something.snapshot"
+  echo "nobody's" >"$gone"
+
+  local output
+  output=$(run_prune)
+
+  assert_file_not_exists "$gone"
+  assert_file_exists "$ALPHA"
+  assert_file_exists "$BETA"
+  assert_contains "gone_test_sh" "$output"
+}
+
+# The failing-run gate has to cover the new class too, or a run that never
+# reached its assertions would delete what it could not have resolved.
+function test_prune_keeps_an_owner_missing_snapshot_when_the_run_fails() {
+  local gone="$WORKDIR/snapshots/gone_test_sh.test_something.snapshot"
+  echo "nobody's" >"$gone"
+  cat >>"$WORKDIR/snap.sh" <<'TEST'
+
+function test_that_fails_too() {
+  assert_same "expected" "actual"
+}
+TEST
+
+  run_prune >/dev/null
+
+  assert_file_exists "$gone"
 }
 
 # A failing run may never have reached the assertions that resolve those

--- a/tests/acceptance/bashunit_snapshot_unused_test.sh
+++ b/tests/acceptance/bashunit_snapshot_unused_test.sh
@@ -40,6 +40,10 @@ function test_reports_nothing_when_every_snapshot_is_used() {
 }
 
 function test_a_snapshot_of_a_test_file_outside_the_run_is_not_reported() {
+  # The owner has to be on disk for this to be the case the name describes.
+  # Without it the snapshot is an orphan, not a file "outside the run", and the
+  # two want opposite answers (#1194).
+  echo "" >"$WORKDIR/other_test.sh"
   echo "not mine" >"$WORKDIR/snapshots/other_test_sh.test_something.snapshot"
 
   local output
@@ -48,6 +52,18 @@ function test_a_snapshot_of_a_test_file_outside_the_run_is_not_reported() {
 
   assert_not_contains "other_test_sh" "$output"
   assert_contains "snap_sh.test_snapshot_deleted.snapshot" "$output"
+}
+
+# The kind no run can own: the test file that named it was deleted or renamed,
+# so no run will ever discover it and the owner check skipped it forever (#1194).
+function test_reports_a_snapshot_whose_owner_file_is_gone() {
+  echo "nobody's" >"$WORKDIR/snapshots/gone_test_sh.test_something.snapshot"
+
+  local output
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    --snapshot-report-unused snap.sh 2>&1) || true
+
+  assert_contains "gone_test_sh.test_something.snapshot" "$output"
 }
 
 function test_the_report_does_not_delete_anything() {

--- a/tests/functional/snapshots/doubles_test_sh_.test_mock_ps_when_executing_a_script.snapshot
+++ b/tests/functional/snapshots/doubles_test_sh_.test_mock_ps_when_executing_a_script.snapshot
@@ -1,3 +1,0 @@
-firefox                      2.0
-Xorg                         1.6
-jetbrains-toolbox            1.3

--- a/tests/functional/snapshots/doubles_test_sh_.test_mock_ps_when_executing_a_sourced_function.snapshot
+++ b/tests/functional/snapshots/doubles_test_sh_.test_mock_ps_when_executing_a_sourced_function.snapshot
@@ -1,3 +1,0 @@
-firefox                      2.0
-Xorg                         1.6
-jetbrains-toolbox            1.3


### PR DESCRIPTION
## 🤔 Background

Related #1194

`--snapshot-report-unused` and `--snapshot-prune` exist to find snapshots no test uses, and could not see the most common kind: one whose owning test **file** was deleted or renamed. `collect_unused` keeps a snapshot only when its owner prefix matches a file the run discovered, and no run can ever discover a file that is gone.

A previous attempt was reverted because the rule collided with `test_a_snapshot_of_a_test_file_outside_the_run_is_not_reported` — whose fixture never created that file, making it the orphan shape rather than the case its name describes. Per the maintainer's option 2, the fixture is corrected and the guarantee is kept where it belongs.

## 💡 Changes

- Disk decides the case the run's file list cannot: selected by this run keeps today's logic, an owner present but unselected is still left alone, and an owner matching nothing on disk is an orphan. No new fork — glob, parameter expansion and `case`
- Both "outside the run" tests now create the owner file, so they pin the guarantee that keeps prune safe on a path subset; both were green before and after
- Running the new report over this repo surfaced two more real leftovers (a stale `doubles_test_sh_` naming variant) and nothing else across the whole suite; they are deleted here as the demonstration
- This widens what `--snapshot-prune` deletes, so it lands as a CHANGELOG **Changed** entry, with docs saying what "not selected" vs "not on disk" means