### PR TITLE
feat(cli): refuse a test path that does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - `--list-tags` prints the tags of the selected files, one per line, sorted and deduplicated, and runs nothing. Tags live only in `# @tag` comments, so a mistyped `--tag` had no list to check against; the output is nothing but the names, so it pipes (#1265)
 
 ### Changed
+- A test path that does not exist is now named and refused before anything runs, instead of reporting `No tests found` — the answer an empty selection gives, which sent a mistyped `bashunit tsets/` after test naming, filters and the discovery glob rather than the typo. Every genuinely-empty case still says `No tests found`: a directory with no test files, a `--filter` or `--tag` matching nothing, an empty `--shard`, `--changed` with no changes, and a glob the shell left unexpanded (#1263)
+- A path argument that selects no test file no longer falls back to `BASHUNIT_DEFAULT_PATH`. Zero files read as "no path was given", so `bashunit empty_dir/` ran the default suite and exited 0 — reporting a pass for tests the caller never asked for (#1263)
 - `--snapshot-report-unused` and `--snapshot-prune` now see a snapshot whose test **file** was deleted or renamed, which is the most common way a snapshot is orphaned and the one kind neither flag could ever report: no run discovers such a file, so the owner check skipped it forever. A snapshot whose test file exists but was not part of this run is still left alone, so both flags stay safe on a subset of the suite. This widens what `--snapshot-prune` deletes (#1194)
 - A `--tag` matching nothing now names the tags the run saw, or says no test carries one — tags live only in `# @tag` comments and nothing lists them, so a typo had no way back (#1265)
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -54,6 +54,28 @@ bashunit test tests/ --parallel --simple
 ```
 :::
 
+A path you name is the one that runs. Two answers follow from that, and they are
+deliberately different:
+
+```
+$ bashunit tsets/
+Error: no such path: 'tsets/'.
+
+$ bashunit tests/without_any_test/
+ No tests found
+```
+
+An empty result is a real answer — a directory with no test files, a `--filter`
+or `--tag` matching nothing, an empty `--shard`, `--changed` with no changes —
+and all of those keep saying `No tests found` and exit non-zero. A path that is
+not on disk is a mistyped invocation instead, so it is named before anything
+runs. A pattern the shell left unexpanded (`tests/zz*_test.sh`) counts as an
+empty result, not a missing path.
+
+A path that selects nothing never falls back to
+[`BASHUNIT_DEFAULT_PATH`](#environment-bootstrap): `bashunit empty_dir/` reports
+`No tests found` rather than quietly running the default suite.
+
 ### Test Options
 
 | Option                         | Description                                      |

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -11,16 +11,30 @@ function bashunit::main::exec_tests() {
   # Bash 3.0 compatible: collect files into array
   local test_files
   local test_files_count=0
+  # load_test_files falls back to BASHUNIT_DEFAULT_PATH when handed no files,
+  # which is right only when the caller named no path. When they named one that
+  # selected nothing, the fallback answered a question they did not ask -- with
+  # a green run over the default suite (#1263). Skip discovery entirely there
+  # and let the empty selection render as "No tests found".
   local _line
-  while IFS= read -r _line; do
-    [ -z "$_line" ] && continue
-    test_files[test_files_count]="$_line"
-    test_files_count=$((test_files_count + 1))
-  done < <(bashunit::helper::load_test_files "$filter" "$@")
+  if [ "$#" -gt 0 ] || [ "${_BASHUNIT_MAIN_PATHS_GIVEN:-false}" != true ]; then
+    while IFS= read -r _line; do
+      [ -z "$_line" ] && continue
+      test_files[test_files_count]="$_line"
+      test_files_count=$((test_files_count + 1))
+    done < <(bashunit::helper::load_test_files "$filter" "$@")
+  fi
 
   bashunit::internal_log "exec_tests" "filter:$filter" "files:${test_files[*]:-}"
 
-  if [ "$test_files_count" -eq 0 ]; then
+  # Only when the caller named no path at all: with nothing to go on, the help
+  # dump is the answer. A path they DID name that holds no test files is an
+  # empty selection instead, so it falls through to "No tests found" -- the same
+  # shape an empty shard has. Without that distinction zero files here meant
+  # "use BASHUNIT_DEFAULT_PATH", and `bashunit empty_dir/` ran the default
+  # suite and exited 0, reporting a pass for tests the caller never asked for
+  # and never saw named (#1263).
+  if [ "$test_files_count" -eq 0 ] && [ "${_BASHUNIT_MAIN_PATHS_GIVEN:-false}" != true ]; then
     printf "%sError: At least one file path is required.%s\n" "${_BASHUNIT_COLOR_FAILED}" "${_BASHUNIT_COLOR_DEFAULT}"
     bashunit::console_header::print_help
     exit 1

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -5,6 +5,12 @@
 # The argv the suite pre-scan produces, read by cmd_test below.
 _BASHUNIT_MAIN_SUITE_ARGV=()
 
+# Whether the caller named a path of their own. Zero test files then means "what
+# you asked for holds no tests", which is an answer; without it the run falls
+# back to BASHUNIT_DEFAULT_PATH, and asking for one directory and being given
+# another one's results is not (#1263).
+_BASHUNIT_MAIN_PATHS_GIVEN=false
+
 ##
 # Resolves `--suite <name>` (repeatable) and `--list-suites` before the main
 # parse loop and rewrites argv into _BASHUNIT_MAIN_SUITE_ARGV.
@@ -572,6 +578,7 @@ function bashunit::main::cmd_test() {
       args_count="$raw_args_count"
     else
       # Test mode: process file paths and extract inline filters
+      _BASHUNIT_MAIN_PATHS_GIVEN=true
       local arg
       for arg in "${raw_args[@]+"${raw_args[@]}"}"; do
         local parsed_path parsed_filter
@@ -585,6 +592,26 @@ function bashunit::main::cmd_test() {
           inline_filter="$parsed_filter"
           inline_filter_file="$parsed_path"
         fi
+
+        # An empty result is a real answer; a path that is not there is a wrong
+        # invocation, and `bashunit tsets/` used to give the first answer to the
+        # second question -- sending the reader after test naming, filters and
+        # the discovery glob rather than the typo in front of them (#1263).
+        #
+        # A `*` is exempt: nullglob is off, so a pattern the shell could not
+        # expand arrives literally, and matching nothing is an empty selection.
+        # find_files_recursive decides glob-ness on `*` alone; use the same test
+        # here or the two disagree about what a path even is.
+        case "$parsed_path" in
+        *"*"*) ;;
+        *)
+          if [ ! -e "$parsed_path" ]; then
+            printf "%sError: no such path: '%s'.%s\n" \
+              "${_BASHUNIT_COLOR_FAILED}" "$parsed_path" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+            exit 1
+          fi
+          ;;
+        esac
 
         local file
         while IFS= read -r file; do

--- a/tests/acceptance/bashunit_invalid_path_test.sh
+++ b/tests/acceptance/bashunit_invalid_path_test.sh
@@ -53,6 +53,56 @@ function test_bashunit_fails_when_seed_is_not_a_number() {
   assert_contains "--seed" "$output"
 }
 
+# `bashunit tsets/` used to read as "your tests did not match", sending the
+# reader after test naming, filters and the discovery glob rather than the typo
+# in front of them. An empty result is a real answer; a path that is not there
+# is a wrong invocation, and only the second one is worth interrupting for
+# (#1263).
+function test_bashunit_names_a_test_path_that_does_not_exist() {
+  local ec=0
+  local output
+  output=$(./bashunit --env "$TEST_ENV_FILE" definitely/not/here 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "definitely/not/here" "$output"
+  assert_not_contains "No tests found" "$output"
+}
+
+function test_bashunit_names_a_missing_path_among_several() {
+  local ec=0
+  local output
+  output=$(./bashunit --env "$TEST_ENV_FILE" "$TEST_FILE" definitely/not/here 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "definitely/not/here" "$output"
+}
+
+# Everything genuinely empty keeps the answer it had: the directory is there,
+# it simply holds no tests.
+function test_bashunit_still_reports_no_tests_found_for_an_empty_directory() {
+  local empty_dir
+  empty_dir="$(bashunit::temp_dir)"
+
+  local ec=0
+  local output
+  output=$(./bashunit --env "$TEST_ENV_FILE" "$empty_dir" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No tests found" "$output"
+}
+
+# A glob the shell could not expand arrives here literally, and matching nothing
+# is an empty selection rather than a typo -- so it must not be read as a
+# missing path.
+function test_bashunit_still_reports_no_tests_found_for_a_glob_matching_nothing() {
+  local ec=0
+  local output
+  output=$(./bashunit --env "$TEST_ENV_FILE" 'tests/acceptance/fixtures/tests_path/zz*_test.sh' 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No tests found" "$output"
+}
+
 function test_bashunit_still_accepts_an_existing_bootstrap_file() {
   local boot_file
   boot_file="$(bashunit::temp_file)"

--- a/tests/acceptance/bashunit_path_test.sh
+++ b/tests/acceptance/bashunit_path_test.sh
@@ -23,9 +23,30 @@ function test_bashunit_with_env_default_path() {
   assert_successful_code "$(./bashunit --no-parallel --env "$TEST_ENV_FILE_WITH_PATH")"
 }
 
+# 2>&1 because the answer is now on stderr, where a wrong invocation belongs
+# (the same stream abort_unknown_option uses). Without it this snapshot records
+# an empty string and pins nothing.
 function test_bashunit_argument_overloads_default_path() {
   local path="tests/acceptance/fixtures/wrong_path"
 
-  assert_match_snapshot "$(./bashunit --no-parallel "$path" --env "$TEST_ENV_FILE_WITH_PATH")"
-  assert_general_error "$(./bashunit --no-parallel "$path" --env "$TEST_ENV_FILE_WITH_PATH")"
+  assert_match_snapshot "$(./bashunit --no-parallel "$path" --env "$TEST_ENV_FILE_WITH_PATH" 2>&1)"
+  assert_general_error "$(./bashunit --no-parallel "$path" --env "$TEST_ENV_FILE_WITH_PATH" 2>&1)"
+}
+
+# The override has to hold when the argument selects NOTHING, which is where it
+# used to give way: zero files read as "no path was given", so the default path
+# ran instead and the run passed. Asking for one directory and being handed
+# another one's results is the worst shape of all -- green, and about tests the
+# caller never named (#1263).
+function test_an_argument_selecting_nothing_does_not_fall_back_to_the_default_path() {
+  local empty_dir
+  empty_dir="$(bashunit::temp_dir)"
+
+  local ec=0
+  local output
+  output=$(./bashunit --no-parallel "$empty_dir" --env "$TEST_ENV_FILE_WITH_PATH" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "No tests found" "$output"
+  assert_not_contains "Assert greater and less than" "$output"
 }

--- a/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
+++ b/tests/acceptance/snapshots/bashunit_path_test_sh.test_bashunit_argument_overloads_default_path.snapshot
@@ -1,4 +1,1 @@
-[90mTests:     [0m 0 total
-[90mAssertions:[0m 0 total
-
-[41m[30m[1m No tests found [0m
+[31mError: no such path: 'tests/acceptance/fixtures/wrong_path'.[0m


### PR DESCRIPTION
## 🤔 Background

Related #1263

`bashunit tsets/` answered `No tests found` — the answer an *empty selection* gives — so a typo read as "your tests did not match", sending the reader after test naming, filters and the discovery glob. Per the maintainer's call on that issue, a path that is not on disk is a wrong invocation and is named before discovery runs; every genuinely-empty case keeps the convention exactly as it is.

Writing the "still says No tests found" half turned up something worse: zero files after expansion read as *no path was given*, so `bashunit empty_dir/` fell back to `BASHUNIT_DEFAULT_PATH`, ran the default suite and exited **0** — a pass reported for tests the caller never asked for. `test_bashunit_argument_overloads_default_path` only appeared to cover that because its path did not exist either.

## 💡 Changes

- A positional path that is not on disk is named and refused before anything runs; a directory with no tests, an empty `--filter`/`--tag`/`--shard`/`--changed`, and a glob the shell left unexpanded all still say `No tests found`
- A path that selects nothing no longer falls back to `BASHUNIT_DEFAULT_PATH`
- The error goes to stderr, matching `abort_unknown_option` and the unknown-suite error; that left the overload test's snapshot empty, so it captures stderr and pins the wording now