### PR TITLE
test(parallel): assert the machine document on stdout, not on both streams

### DIFF
--- a/tests/acceptance/bashunit_parallel_output_noise_test.sh
+++ b/tests/acceptance/bashunit_parallel_output_noise_test.sh
@@ -27,6 +27,21 @@ function _run() { # $@ = flags
   (cd "$WORKDIR" && "$BASHUNIT_BIN" "$@" t_test.sh 2>&1) || true
 }
 
+# Same run, stdout only. What a machine --output format promises is that
+# *stdout* is the document; stderr is where diagnostics belong and a consumer
+# redirects stdout on its own (`bashunit --output json > run.json`).
+#
+# Merging the streams made these assertions depend on the shell as well as on
+# bashunit. Bash 3.x prints "wait_for: No record of process <pid>" when a
+# SIGCHLD lands while it is waiting on a child it has already reaped -- a
+# spurious message about a process that simply finished, from bash's internal
+# wait, not from any `wait` this project writes. Under load on a Bash 3.0
+# runner it arrived first and displaced the `{`, failing a test about bashunit
+# over something bashunit never printed (#1274).
+function _run_stdout() { # $@ = flags
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" "$@" t_test.sh 2>/dev/null) || true
+}
+
 # A command substitution is a pipe, so this is the CI shape: the spinner never
 # drew and nothing should have been erased.
 function test_a_piped_parallel_run_carries_no_carriage_return() {
@@ -85,7 +100,7 @@ function test_stop_on_failure_keeps_json_output_parseable() {
   _stop_on_failure_project
 
   local output
-  output="$(_run --parallel --stop-on-failure --output json)"
+  output="$(_run_stdout --parallel --stop-on-failure --output json)"
 
   assert_not_contains "Stop on failure" "$output"
   assert_same "{" "${output%%$'\n'*}"
@@ -95,7 +110,7 @@ function test_stop_on_failure_keeps_the_xml_declaration_first() {
   _stop_on_failure_project
 
   local output
-  output="$(_run --parallel --stop-on-failure --output junit)"
+  output="$(_run_stdout --parallel --stop-on-failure --output junit)"
 
   assert_not_contains "Stop on failure" "$output"
   assert_same '<?xml version="1.0" encoding="UTF-8"?>' "${output%%$'\n'*}"


### PR DESCRIPTION
## 🤔 Background

Related #1274

The two `--output json` / `--output junit` cases read the run with `2>&1` and then assert on its first line. That made them depend on the shell as well as on bashunit: Bash 3.x prints `wait_for: No record of process <pid>` when a SIGCHLD lands while it is waiting on a child it has already reaped, and under load on a Bash 3.0 runner that line arrived first and displaced the `{`. Clean `main` went red 5 times in 6 under CPU starvation — over something bashunit never printed.

That message is not from any `wait` this project writes: `wait_for` is bash's *internal* wait for every foreground child, so suppressing our two bare `wait`s does nothing. I tried exactly that first; the message survives unchanged, which is what sent me to the real defect.

## 💡 Changes

- The two document tests read **stdout**. What bashunit promises is that stdout is the document; stderr is for diagnostics and a consumer redirects stdout itself (`bashunit --output json > run.json`). Asserting on the merged stream asserted something bashunit cannot deliver on Bash 3.x
- They still assert the human `Stop on failure` line is absent from stdout — **verified by mutation**: removing the `is_machine_output_enabled` guard in `run.sh` reds both, so the guarantee they were written for is intact
- Measured on a real Bash 3.0 build, full suite, `--parallel --simple --strict`: **before 2 red in 8; after 1 red in 24**, and 6 of 6 clean under the `--cpus=1` starvation that gave the baseline 5 in 6