### PR TITLE
release: 0.49.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [0.49.0](https://github.com/TypedDevs/bashunit/compare/0.48.0...0.49.0) - 2026-08-16
+
 ### Added
 - `--pass-with-no-tests` exits 0 when a run selects no tests, for the case where that is deliberate — a CI matrix whose shards are not all populated, or a changed-files run that touched no tests. The run still reports `No tests found`; only the verdict changes. It does not excuse a path that is not on disk. Same flag, same spelling, as jest, vitest, Playwright and Cypress (#1263)
 - `--list-tags` prints the tags of the selected files, one per line, sorted and deduplicated, and runs nothing. Tags live only in `# @tag` comments, so a mistyped `--tag` had no list to check against (#1265)

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   version:
     description: 'bashunit version to install (e.g. "0.37.0"). Defaults to the version pinned at this action ref. Pass "latest" to override.'
     required: false
-    default: '0.48.0'
+    default: '0.49.0'
   directory:
     description: 'Directory, relative to the workspace, where the bashunit binary is installed.'
     required: false

--- a/bashunit
+++ b/bashunit
@@ -35,7 +35,7 @@ function _check_bash_version() {
 _check_bash_version
 
 # shellcheck disable=SC2034
-declare -r BASHUNIT_VERSION="0.48.0"
+declare -r BASHUNIT_VERSION="0.49.0"
 
 # shellcheck disable=SC2155
 # `${x%/*}` rather than `$(dirname "$x")`: one fork on every invocation, and

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bashunit-docs",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "Docs for bashunit a simple testing library for bash scripts",
   "private": true,
   "repository": "git@github.com:TypedDevs/bashunit.git",

--- a/install.sh
+++ b/install.sh
@@ -186,7 +186,7 @@ elif [[ $# -eq 2 ]]; then
 fi
 
 BASHUNIT_GIT_REPO="https://github.com/TypedDevs/bashunit"
-LATEST_BASHUNIT_VERSION="0.48.0"
+LATEST_BASHUNIT_VERSION="0.49.0"
 TAG="$LATEST_BASHUNIT_VERSION"
 
 cd "$(dirname "$0")"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bashunit",
-  "version": "0.48.0",
-  "checksum": "9e27d930a505fcdc46e0c3275ca943d412e5df4b51dc1f5b5219d794d3b1893d",
+  "version": "0.49.0",
+  "checksum": "85e6f6ec564fb4b7611d61a219fec470350fde9ccc1ee7c77528cf0af9f766bd",
   "description": "A simple testing library for bash scripts.",
   "homepage": "https://bashunit.com",
   "repository": {


### PR DESCRIPTION
## 🤔 Background

Cuts 0.49.0. Minor bump: four `feat` commits since 0.48.0 (two days ago), plus two performance changes and seven fixes.

Pre-release validation passed 10/10, including the suite three times in both modes (6/6 clean), and the full suite on alpine, ubuntu and a real Bash 3.0 build.

## 💡 Changes

- Version bumped in the five places plus the CHANGELOG heading, and `package.json`'s checksum refreshed from the new `bin/bashunit`
- **One upgrade note worth leading the release with**: `bashunit empty_dir/` used to exit 0 while silently running `BASHUNIT_DEFAULT_PATH` instead; it now reports `No tests found` and exits 1. A green CI can turn red on upgrade, and the fix is `--pass-with-no-tests` where the empty run is deliberate — the same flag jest, vitest, Playwright and Cypress ship
- Also user-visible: a path that does not exist is refused by name, and `--snapshot-prune` now deletes snapshots whose test file is gone