### PR TITLE
fix(cli): make --seed imply --random-order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- `--seed <n>` now implies `--random-order`. The header prints `Randomized with seed: N` so a failing run can be replayed, but typing that seed back on its own selected nothing: the run came back in defined order and green, and the shuffle that caused the failure never happened. An order named explicitly still wins, so `--order-by defined --seed 42` runs in defined order. Same behaviour as RSpec's `--seed`
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -131,7 +131,7 @@ Cypress spell `--pass-with-no-tests`.
 | `--repeat <n>`                 | Run each selected test N times; it fails if any iteration fails |
 | `--random-order`               | Randomize test execution order                   |
 | `--order-by <mode>`            | Execution order: `defined` (default), `defects` or `random` |
-| `--seed <n>`                   | Seed for `--random-order` (reproducible shuffle) |
+| `--seed <n>`                   | Seed the shuffle (reproducible); implies `--random-order` |
 | `--shard <i>/<n>`              | Run shard i of n (split suite across runners)    |
 | `--rerun-failed`               | Replay only the tests that failed on the last run |
 | `--changed [<ref>]`            | Run only the test files changed since `<ref>` (default: `origin/HEAD`, then `HEAD`) |
@@ -830,8 +830,11 @@ dependencies). Disabled by default.
 
 When enabled and no `--seed` is given, a seed is generated and printed in the
 run header so a failing run can be replayed exactly with `--seed <n>`. The same
-seed always produces the same order, and it composes with `--parallel`. `--seed`
-on its own (without `--random-order`) has no effect.
+seed always produces the same order, and it composes with `--parallel`.
+
+`--seed <n>` on its own is enough: a seed names an order and nothing else, so
+giving one turns the random order on. Naming an order explicitly still wins, so
+`--order-by defined --seed 42` runs in defined order.
 
 ::: code-group
 ```bash [Example]
@@ -841,7 +844,7 @@ bashunit test tests/ --random-order
 Randomized with seed: 12345
 
 # replay the exact same order:
-bashunit test tests/ --random-order --seed 12345
+bashunit test tests/ --seed 12345
 ```
 :::
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,7 +361,11 @@ shuffle so a run can be replayed; when unset, a seed is generated and printed in
 the run header. Composes with `--parallel`.
 
 Similar as using `--random-order` / `--seed` options on the
-[command line](/command-line#random-order).
+[command line](/command-line#random-order), with one difference: `--seed` on the
+command line turns the random order on by itself, `BASHUNIT_SEED` does not. A
+seed typed at the prompt is a replay of one run; a seed in a config file is
+read by every run, including the nested ones a suite spawns, so it stays inert
+until `BASHUNIT_RANDOM_ORDER` asks for it.
 
 ::: code-group
 ```bash [Reproducible shuffle]

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -11,6 +11,12 @@ _BASHUNIT_MAIN_SUITE_ARGV=()
 # another one's results is not (#1263).
 _BASHUNIT_MAIN_PATHS_GIVEN=false
 
+# Whether this invocation named a seed, and whether it named an order. A seed
+# selects nothing on its own, so one given without an order asks for the random
+# order it is the seed of; an order the caller named explicitly still wins.
+_BASHUNIT_MAIN_SEED_GIVEN=false
+_BASHUNIT_MAIN_ORDER_GIVEN=false
+
 ##
 # Resolves `--suite <name>` (repeatable) and `--list-suites` before the main
 # parse loop and rewrites argv into _BASHUNIT_MAIN_SUITE_ARGV.
@@ -259,15 +265,18 @@ function bashunit::main::cmd_test() {
     --random-order)
       BASHUNIT_RANDOM_ORDER=true
       export -n BASHUNIT_RANDOM_ORDER
+      _BASHUNIT_MAIN_ORDER_GIVEN=true
       ;;
     --order-by)
       BASHUNIT_ORDER_BY="$2"
       export -n BASHUNIT_ORDER_BY
+      _BASHUNIT_MAIN_ORDER_GIVEN=true
       shift
       ;;
     --seed)
       BASHUNIT_SEED="$2"
       export -n BASHUNIT_SEED
+      _BASHUNIT_MAIN_SEED_GIVEN=true
       shift
       ;;
     --shard)
@@ -564,6 +573,14 @@ function bashunit::main::cmd_test() {
     esac
     shift
   done
+
+  # Decided after the loop, not in the `--seed` branch: the order flag may be
+  # typed on either side of the seed, and only the finished argv says whether
+  # one was given at all.
+  if [ "$_BASHUNIT_MAIN_SEED_GIVEN" = true ] && [ "$_BASHUNIT_MAIN_ORDER_GIVEN" = false ]; then
+    BASHUNIT_RANDOM_ORDER=true
+    export -n BASHUNIT_RANDOM_ORDER
+  fi
 
   bashunit::main::validate_config_or_exit
 

--- a/tests/acceptance/bashunit_random_order_test.sh
+++ b/tests/acceptance/bashunit_random_order_test.sh
@@ -55,3 +55,24 @@ function test_random_order_composes_with_parallel() {
 
   assert_contains "8 passed" "$output"
 }
+
+# The header prints `Randomized with seed: N` so a failing run can be replayed,
+# and replaying it means typing that seed back. On its own it used to select
+# nothing: the run came back in defined order, green, and the shuffle that
+# produced the failure never happened. A seed has no meaning other than an
+# order, so naming one asks for that order -- which is what RSpec's `--seed`
+# does too.
+function test_seed_alone_implies_random_order() {
+  assert_same "$(order_of --random-order --seed 42)" "$(order_of --seed 42)"
+}
+
+function test_seed_alone_reorders_tests() {
+  assert_not_equals "$(order_of)" "$(order_of --seed 42)"
+}
+
+# An order the caller named explicitly still wins, whichever side the seed is
+# typed on -- the implication only fills a gap it was left.
+function test_an_explicit_order_beats_the_seed_implication() {
+  assert_same "$(order_of)" "$(order_of --order-by defined --seed 42)"
+  assert_same "$(order_of)" "$(order_of --seed 42 --order-by defined)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1287

A random-order run prints `Randomized with seed: N` so it can be replayed, and replaying means typing that seed back. On its own it selected nothing — the run came back in defined order, green, and the shuffle that caused the failure never happened. `docs/command-line.md` told users to replay with `--seed <n>` while also saying `--seed` alone has no effect.

## 💡 Changes

- `--seed <n>` turns the random order on by itself. A seed names an order and has no other meaning, so giving one is unambiguous — this is RSpec's behaviour, the one framework with a standalone order seed
- An order named explicitly still wins, whichever side the seed is typed on: `--order-by defined --seed 42` runs in defined order
- `BASHUNIT_SEED` keeps its meaning. A seed at the prompt replays one run; a seed in a config file is read by every run including the nested ones a suite spawns, so it stays inert until `BASHUNIT_RANDOM_ORDER` asks for it — documented rather than left to be discovered
- Docs corrected: the replay example no longer needs both flags