### PR TITLE
perf(reports): stop encoding every spooled field on its own

### DIFF
--- a/.claude/rules/perf-fork-budget.md
+++ b/.claude/rules/perf-fork-budget.md
@@ -239,3 +239,13 @@ the `RANDOM` state, and `BASHPID` is 4.0+; an ordinal sidesteps that entirely.
 `wait_for_job_slot` already uses `wait -n` on Bash 4.3+ and an adaptive
 sleep-poll fallback — don't "fix" it. The spinner forks `sleep` ~1/s on
 non-tty; not worth chasing.
+
+**Reports are on the per-test path too.** Any `--log-*`/`--report-*` flag makes
+each worker spool a result row, and that row used to base64 each of its nine
+fields on its own — 14 `base64` forks per test counting the parent's decode,
+with a `tr` on each encode. `--log-junit` therefore cost more than the run it
+reported on (300 tests: 1.2s → 9.2s wall, 5.8s → 27.4s CPU). Now only the four
+fields that can hold arbitrary text are encoded and the row is joined with
+0x1F. The main workflow passes no report flag, so CI never showed this; the
+budget is guarded by `bashunit_run_forks_test.sh`. When adding a field to that
+row, ask whether it can hold arbitrary text before reaching for base64.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+- Performance: a `--parallel` run writing a report is about 1.9x faster and costs 1.8x less CPU. Every result row base64-encoded all nine of its fields separately and decoded them the same way — fourteen `base64` forks per test — so `--log-junit`, the usual CI setup, cost several times more than running the tests. Only the four fields that can hold arbitrary text are encoded now (#1289)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/reports/collect.sh
+++ b/src/reports/collect.sh
@@ -2,6 +2,11 @@
 
 # Collected per-test results: the shared arrays every report writer reads, and the API the runner calls to fill them.
 
+# Field separator for the rows parallel workers spool. ASCII unit separator: it
+# cannot appear in base64 output and is not an IFS whitespace character, so a
+# run of them yields empty fields instead of collapsing.
+_BASHUNIT_REPORTS_FIELD_SEP=$'\037'
+
 # Strips ANSI CSI escape sequences (color codes, cursor moves, erase-line, ...)
 # from $1. Shared by every writer's own escape/encode function below as their
 # first step, so the definition of "what is an ANSI escape sequence" for
@@ -114,19 +119,27 @@ function bashunit::reports::add_test() {
   # never reaches this path for a real parallel test, so replaying the spool
   # cannot double-count.
   #
-  # Fields are base64-encoded because a failure message carries newlines and
-  # arbitrary text, either of which would break a delimited line.
+  # Only the four fields that can hold arbitrary text are base64-encoded: a
+  # failure message or a captured output carries newlines, and a path or a test
+  # name (which may end in a provider's arguments) can hold anything. The other
+  # five are a status word and four numbers, produced by this file's own
+  # callers, so the unit separator carries them as they are.
+  #
+  # Encoding all nine cost fourteen `base64` forks per test -- nine here and
+  # five more decoding, each with a `tr` on top -- which made `--log-junit`
+  # several times more expensive than the run it was reporting on. Base64
+  # output is [A-Za-z0-9+/=] and the raw fields are numeric, so no field can
+  # contain the separator and the row stays one line.
   if bashunit::parallel::is_enabled; then
-    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
-      "$(bashunit::helper::encode_base64 "$file")" \
-      "$(bashunit::helper::encode_base64 "$test_name")" \
-      "$(bashunit::helper::encode_base64 "$status")" \
-      "$(bashunit::helper::encode_base64 "$duration")" \
-      "$(bashunit::helper::encode_base64 "$assertions")" \
-      "$(bashunit::helper::encode_base64 "$failure_message")" \
-      "$(bashunit::helper::encode_base64 "$line")" \
-      "$(bashunit::helper::encode_base64 "$retries")" \
-      "$(bashunit::helper::encode_base64 "$test_output")" \
+    local us=$_BASHUNIT_REPORTS_FIELD_SEP
+    local row
+    row="$(bashunit::helper::encode_base64 "$file")$us"
+    row="$row$(bashunit::helper::encode_base64 "$test_name")$us"
+    row="$row$status$us$duration$us$assertions$us"
+    row="$row$(bashunit::helper::encode_base64 "$failure_message")$us"
+    row="$row$line$us$retries$us"
+    row="$row$(bashunit::helper::encode_base64 "$test_output")"
+    printf '%s\n' "$row" \
       >>"${REPORTS_OUTPUT_PATH:-/dev/null}" 2>/dev/null || true
   fi
 
@@ -151,17 +164,21 @@ function bashunit::reports::load_spooled() {
   [ -f "${REPORTS_OUTPUT_PATH:-}" ] || return 0
 
   local file test_name status duration assertions failure_message line retries test_output n
-  while IFS='|' read -r file test_name status duration assertions failure_message line retries test_output; do
+  # The separator is not an IFS whitespace character, so a run of them yields
+  # empty fields rather than collapsing -- which is what an absent failure
+  # message or output has to produce.
+  while IFS="$_BASHUNIT_REPORTS_FIELD_SEP" read -r \
+    file test_name status duration assertions failure_message line retries test_output; do
     [ -n "$file" ] || continue
     local n=${#_BASHUNIT_REPORTS_TEST_FILES[@]}
     _BASHUNIT_REPORTS_TEST_FILES[n]=$(bashunit::helper::decode_base64 "$file")
     _BASHUNIT_REPORTS_TEST_NAMES[n]=$(bashunit::helper::decode_base64 "$test_name")
-    _BASHUNIT_REPORTS_TEST_STATUSES[n]=$(bashunit::helper::decode_base64 "$status")
-    _BASHUNIT_REPORTS_TEST_DURATIONS[n]=$(bashunit::helper::decode_base64 "$duration")
-    _BASHUNIT_REPORTS_TEST_ASSERTIONS[n]=$(bashunit::helper::decode_base64 "$assertions")
+    _BASHUNIT_REPORTS_TEST_STATUSES[n]=$status
+    _BASHUNIT_REPORTS_TEST_DURATIONS[n]=$duration
+    _BASHUNIT_REPORTS_TEST_ASSERTIONS[n]=$assertions
     _BASHUNIT_REPORTS_TEST_FAILURES[n]=$(bashunit::helper::decode_base64 "$failure_message")
-    _BASHUNIT_REPORTS_TEST_LINES[n]=$(bashunit::helper::decode_base64 "$line")
-    _BASHUNIT_REPORTS_TEST_RETRIES[n]=$(bashunit::helper::decode_base64 "$retries")
+    _BASHUNIT_REPORTS_TEST_LINES[n]=$line
+    _BASHUNIT_REPORTS_TEST_RETRIES[n]=$retries
     _BASHUNIT_REPORTS_TEST_OUTPUTS[n]=$(bashunit::helper::decode_base64 "$test_output")
   done <"$REPORTS_OUTPUT_PATH"
 }

--- a/tests/acceptance/bashunit_run_forks_test.sh
+++ b/tests/acceptance/bashunit_run_forks_test.sh
@@ -231,3 +231,54 @@ function test_parallel_result_publishing_does_not_fork_per_test() {
 
   assert_equals "" "$forked"
 }
+
+# Regression guard for the report spool. A worker used to base64 each of the
+# nine fields of a result row separately, and the parent decoded each one the
+# same way -- fourteen `base64` forks per test (and, on the encode side, a `tr`
+# each), so turning on `--log-junit` cost more than running the tests. Only the
+# two fields that can hold arbitrary text need encoding; the rest are a status,
+# some numbers and a path, which a unit separator carries as they are.
+#
+# Counted with a PATH shim rather than a trace: these forks happen inside the
+# `--parallel` workers, which `bash -x` on the parent cannot see.
+function test_reports_do_not_fork_base64_per_field() {
+  if bashunit::check_os::is_windows; then
+    bashunit::skip "process tracing is unreliable under Git Bash" && return
+  fi
+
+  local dir
+  dir="$(bashunit::temp_dir)"
+  local count_file="$dir/base64_calls"
+  local real_base64
+  real_base64="$(command -v base64)"
+
+  {
+    echo '#!/usr/bin/env bash'
+    # The load-time `base64 --help` capability probe is not a per-test cost.
+    echo "case \"\$*\" in --help) ;; *) echo x >> \"$count_file\" ;; esac"
+    echo "exec \"$real_base64\" \"\$@\""
+  } >"$dir/base64"
+  chmod +x "$dir/base64"
+
+  local fixture="$dir/report_forks_test.sh"
+  {
+    echo 'function test_a() { assert_true true; }'
+    echo 'function test_b() { assert_true true; }'
+    echo 'function test_c() { assert_true true; }'
+    echo 'function test_d() { assert_true true; }'
+  } >"$fixture"
+
+  PATH="$dir:$PATH" ./bashunit --parallel --log-junit "$dir/out.xml" "$fixture" \
+    >/dev/null 2>&1
+
+  local calls=0
+  if [ -f "$count_file" ]; then
+    calls="$(grep -c . "$count_file" || true)"
+  fi
+
+  # Four passing tests carry no failure message and no output, so both
+  # arbitrary fields are empty and short-circuit: the row costs one encode for
+  # the file and one for the test name, and the same two decodes. Sixteen is
+  # that, with room for the run's own bookkeeping; it was 56.
+  assert_less_or_equal_than 16 "$calls"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1289

Every `--parallel` worker base64-encoded all nine fields of a result row separately, and the parent decoded them the same way — fourteen `base64` forks per test, with a `tr` on each encode. Turning on `--log-junit`, the usual CI setup, cost several times more than running the tests: a 300-test file went from 1.2s to 9.2s wall and 5.8s to 27.4s CPU.

The main workflow passes no report flag, which is why CI never showed it.

## 💡 Changes

- Only the four fields that can hold arbitrary text are encoded — path, test name (which may carry a data provider's arguments), failure message, captured output. The other five are a status word and four numbers, joined raw on a 0x1F separator
- A passing test's message and output are empty and short-circuit on the existing sentinel, so its row costs two encodes and two decodes instead of fourteen
- **1.9x faster wall, 1.8x less CPU** on the 300-test benchmark; JUnit output verified to carry the same testcases and counts, and multi-line failure messages containing pipes round-trip intact
- Guarded by a PATH-shim census in `bashunit_run_forks_test.sh` — a `bash -x` trace cannot see these, they happen inside the workers