### PR TITLE
fix(cli): stop watch taking an option's value as the watched path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `bashunit watch` no longer takes an option's value as the path it polls. Only `-f/--filter` was known to consume a value, so `bashunit watch --tag slow tests/` polled a directory named `slow` and passed the real path to `--tag`; when the value happened to name a real directory it polled the wrong one without saying so. Options may now appear in any position (#1291)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -1500,10 +1500,8 @@ bashunit bench --filter "parse"
 
 Dedicated watch subcommand that uses **OS file-event notifications** (no
 polling) to re-run tests as soon as a `.sh` file changes. Any option accepted
-by `bashunit test` is also accepted here, **but put the path first**: apart from
-`-f/--filter`, an option's value is otherwise taken as the watch path, so
-`bashunit watch --tag slow` watches a directory named `slow`. Write
-`bashunit watch tests/ --tag slow`.
+by `bashunit test` is also accepted here, in any position: the path is whichever
+argument is not an option or an option's value.
 
 When neither `inotifywait` nor `fswatch` is installed, it no longer fails:
 it falls back to a **pure-shell polling loop** and prints a short notice.

--- a/src/main/subcommands.sh
+++ b/src/main/subcommands.sh
@@ -114,16 +114,16 @@ function bashunit::main::cmd_watch() {
       bashunit::console_header::print_watch_help
       exit 0
       ;;
-    -f | --filter)
-      # Forward the filter flag and its value to the underlying test run
-      extra_args[${#extra_args[@]}]="$1"
-      shift || true
-      if [ $# -gt 0 ]; then
-        extra_args[${#extra_args[@]}]="$1"
-      fi
-      ;;
     -*)
+      # Forward the option, and its value too when it takes one: otherwise the
+      # value falls to the positional branch below and becomes the watched path.
       extra_args[${#extra_args[@]}]="$1"
+      if bashunit::main::option_takes_value "$1"; then
+        shift || true
+        if [ $# -gt 0 ]; then
+          extra_args[${#extra_args[@]}]="$1"
+        fi
+      fi
       ;;
     *)
       if [ -z "$path" ]; then

--- a/src/main/validate.sh
+++ b/src/main/validate.sh
@@ -132,6 +132,37 @@ function bashunit::main::require_existing_path_or_exit() {
 }
 
 
+##
+# Whether a `test` option consumes the argument after it as its value.
+#
+# `watch` is the caller: it has to tell an option's value apart from the path it
+# polls, and knowing only `-f/--filter` meant every other value landed in the
+# positional branch -- `watch --tag slow tests/` polled a directory named
+# `slow`, and silently polled the wrong one whenever the value named a real
+# directory.
+#
+# Kept in step with cmd_test's parser by tests/unit/main/option_values_test.sh,
+# which derives the list from that parser rather than repeating it.
+#
+# Arguments: $1 - the option as typed
+# Returns: 0 when it takes a value, 1 otherwise
+##
+function bashunit::main::option_takes_value() {
+  case "$1" in
+  -a | --assert | -e | --env | --boot | -f | --filter | --exclude-filter | \
+    --tag | --exclude-tag | --sandbox-allow | --output | --list-format | \
+    -j | --jobs | -r | --retry | --repeat | --test-timeout | --order-by | \
+    --seed | --shard | --suite | --coverage-min | --coverage-paths | \
+    --coverage-exclude | --coverage-diff | --log-junit | --log-gha | \
+    --gha-annotations | --report-html | --report-json | --report-junit | \
+    --report-md | --report-tap)
+    return 0
+    ;;
+  esac
+  return 1
+}
+
+
 function bashunit::main::require_writable_path_or_exit() {
   local path=$1
   local parent=${1%/*}

--- a/tests/unit/cli/watch_test.sh
+++ b/tests/unit/cli/watch_test.sh
@@ -116,3 +116,35 @@ function test_cmd_watch_defaults_path_to_dot() {
   assert_contains "." "$output"
   assert_contains "--filter my_test" "$output"
 }
+
+# Only `-f/--filter` used to be known as taking a value, so every other
+# option's value fell through to the positional branch and became the path
+# being watched. `bashunit watch --tag slow tests/` polled a directory named
+# `slow`; when the value happened to name a real one it polled that silently.
+function test_cmd_watch_does_not_take_an_option_value_as_the_path() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "--tag" "slow" "tests/")
+
+  assert_same "tests/ --tag slow" "$output"
+}
+
+function test_cmd_watch_forwards_every_value_taking_option_with_its_value() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "--jobs" "4" "--output" "tap" "tests/")
+
+  assert_same "tests/ --jobs 4 --output tap" "$output"
+}
+
+# A flag that takes no value must still not swallow the path after it.
+function test_cmd_watch_keeps_a_valueless_flag_from_eating_the_path() {
+  bashunit::mock bashunit::watch::run echo
+
+  local output
+  output=$(bashunit::main::cmd_watch "--parallel" "tests/")
+
+  assert_same "tests/ --parallel" "$output"
+}

--- a/tests/unit/main/option_values_test.sh
+++ b/tests/unit/main/option_values_test.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Anti-drift contract: bashunit::main::option_takes_value must know exactly the
+# options cmd_test consumes a value for. `watch` uses it to tell an option's
+# value apart from the path it polls, so an option missing from it silently
+# becomes a watched directory rather than an error.
+#
+# The expected set is derived from cmd_test's own parser instead of being
+# repeated here: an option takes a value there precisely when its case arm ends
+# in an unconditional `shift`.
+
+# Options whose case arm in the parse loop shifts. Two sources, because --suite
+# is resolved by the pre-scan in apply_suites and removed from argv before the
+# main loop sees it.
+function option_values_expected() {
+  {
+    awk '/# Parse test-specific options/,/^  done$/' src/main/test.sh
+    awk '/^function bashunit::main::apply_suites\(\)/,/^}$/' src/main/test.sh
+  } |
+    awk '
+      /^[[:space:]]+--?[a-zA-Z][a-zA-Z0-9-]*( \| --?[a-zA-Z][a-zA-Z0-9-]*)*\)$/ {
+        arm = $0
+        sub(/\)$/, "", arm)
+        gsub(/[[:space:]]/, "", arm)
+        next
+      }
+      # Only an unconditional shift at the arm body indent counts: --debug
+      # shifts one level deeper, inside a conditional, and takes an optional
+      # value rather than a required one.
+      /^      shift$/ { if (arm != "") print arm }
+      /^[[:space:]]+;;$/ { arm = "" }
+    ' |
+    tr '|' '\n' | LC_ALL=C sort -u
+}
+
+# The options the predicate itself lists.
+function option_values_declared() {
+  awk '/^function bashunit::main::option_takes_value\(\)/,/^}$/' src/main/validate.sh |
+    awk '/case /,/esac/' |
+    grep -oE '(^|[ |])--?[a-zA-Z][a-zA-Z0-9-]*' |
+    tr -d ' |' | LC_ALL=C sort -u
+}
+
+function test_the_predicate_knows_every_option_cmd_test_takes_a_value_for() {
+  local missing=""
+  local flag
+  while IFS= read -r flag; do
+    [ -z "$flag" ] && continue
+    if ! bashunit::main::option_takes_value "$flag"; then
+      missing="$missing $flag"
+    fi
+  done <<EOF
+$(option_values_expected)
+EOF
+
+  assert_same "" "$missing"
+}
+
+# The other direction, so a removed option does not leave a stale entry that
+# makes watch swallow the path after it.
+function test_the_predicate_lists_nothing_cmd_test_does_not_take_a_value_for() {
+  local expected
+  expected="$(option_values_expected)"
+
+  local stale=""
+  local flag
+  while IFS= read -r flag; do
+    [ -z "$flag" ] && continue
+    # Matched a whole line at a time: a plain substring test would find `-f`
+    # inside `--filter` and hide a stale short option.
+    case "
+$expected
+" in
+    *"
+$flag
+"*) ;;
+    *) stale="$stale $flag" ;;
+    esac
+  done <<EOF
+$(option_values_declared)
+EOF
+
+  assert_same "" "$stale"
+}
+
+function test_a_valueless_option_is_not_reported_as_taking_one() {
+  local wrong=""
+  local flag
+  for flag in --parallel --strict --simple --detailed --list --rerun-failed; do
+    if bashunit::main::option_takes_value "$flag"; then
+      wrong="$wrong $flag"
+    fi
+  done
+
+  assert_same "" "$wrong"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1291

`cmd_watch` knew only `-f/--filter` as consuming a value, so every other option's value fell through to the positional branch and became the path being polled. `bashunit watch --tag slow tests/` polled a directory named `slow` and handed the real path to `--tag`. That case is loud only because of the path validation added in #1263; whenever a value happens to name a real directory, `watch` polls the wrong one and drops the option silently.

## 💡 Changes

- Options may now appear in any position; only a true positional becomes the path
- The set of value-taking options lives in one shared predicate instead of a second hardcoded list that can drift out of step with `cmd_test`
- An anti-drift test derives the expected set from `cmd_test`'s own parser — an option takes a value there precisely when its case arm ends in an unconditional `shift` — and checks both directions, so neither a new option nor a removed one can slip through. Mutation-tested: dropping `--tag` and adding a bogus entry each fail it by name
- Docs drop the "put the path first" caveat