### PR TITLE
feat(cli): accept -u as the short form of --snapshot-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- `-u` as the short form of `--snapshot-update`. Re-running with `-u` after a deliberate output change is the reflex jest and vitest already teach, and both spell it the same way (#1293)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/completions/_bashunit
+++ b/completions/_bashunit
@@ -104,7 +104,7 @@ _bashunit() {
     '(--list --dry-run)'{--list,--dry-run}'[Print the tests that would run, then exit]' \
     '--list-format[Rendering for --list]:format:(text json)' \
     '--list-tags[Print the tags of the selected files, one per line, then exit]' \
-    '--snapshot-update[Rewrite existing snapshots from the actual value]' \
+    '(-u --snapshot-update)'{-u,--snapshot-update}'[Rewrite existing snapshots from the actual value]' \
     '--no-snapshot-create[Fail instead of recording a missing snapshot]' \
     '--snapshot-prune[Delete snapshot files no test resolved]' \
     '--snapshot-report-unused[List snapshot files no test resolved]' \

--- a/completions/bashunit.bash
+++ b/completions/bashunit.bash
@@ -25,7 +25,7 @@ _BASHUNIT_COMPLETIONS_TEST_OPTS="--assert --boot --changed --coverage --coverage
 --report-json --report-junit --report-md --report-tap --rerun-failed --retry --run-all \
 --sandbox --sandbox-allow \
 --seed --shard --show-incomplete --show-output --show-skipped --simple \
---skip-env-file --snapshot-prune --snapshot-report-unused --snapshot-update \
+--skip-env-file --snapshot-prune --snapshot-report-unused --snapshot-update -u \
 --pass-with-no-tests --stop-on-failure --strict --suite --tag \
 --test-timeout --verbose \
 --watch -R -S -a -e -f -h -j -l -p -r -s -vvv -w"

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -138,7 +138,7 @@ Cypress spell `--pass-with-no-tests`.
 | `--list`, `--dry-run`          | Print the tests that would run, then exit         |
 | `--list-format <fmt>`          | Rendering for `--list`: `text` (default) or `json` |
 | `--list-tags`                  | Print the tags of the selected files, one per line, then exit |
-| `--snapshot-update`            | Rewrite existing snapshots from the actual value |
+| `-u, --snapshot-update`        | Rewrite existing snapshots from the actual value |
 | `--no-snapshot-create`         | Fail on a missing snapshot instead of recording it |
 | `--snapshot-report-unused`     | List snapshot files no test resolved (deletes nothing) |
 | `--snapshot-prune`             | Delete the snapshot files no test resolved (full runs only) |
@@ -876,7 +876,7 @@ steps:
 
 ### Snapshot update
 
-> `bashunit test --snapshot-update`
+> `bashunit test -u|--snapshot-update`
 
 Re-record snapshots: every snapshot assertion whose file already exists is
 overwritten with the value this run produced, and reported as a recorded
@@ -891,8 +891,11 @@ never fails.
 Scope it with `--filter` to re-record a single test:
 
 ```bash
-./bashunit --snapshot-update --filter "renders the header" tests/
+./bashunit -u --filter "renders the header" tests/
 ```
+
+`-u` is the same short form jest and vitest use for their own update flag, so
+the reflex carries over.
 
 Notes:
 

--- a/src/console/header.sh
+++ b/src/console/header.sh
@@ -155,7 +155,7 @@ Options:
   --list, --dry-run           Print the tests that would run, then exit without running them
   --list-format <fmt>         Rendering for --list: text (default) or json
   --list-tags                 Print the tags of the selected files, one per line, then exit
-  --snapshot-update           Rewrite existing snapshots from the actual value (combine with --filter)
+  -u, --snapshot-update       Rewrite existing snapshots from the actual value (combine with --filter)
   --no-snapshot-create        Fail on a missing snapshot instead of recording it (for CI)
   --snapshot-report-unused    List snapshot files no test resolved (full runs only, deletes nothing)
   --snapshot-prune            Delete the snapshot files no test resolved (full runs only)

--- a/src/main/test.sh
+++ b/src/main/test.sh
@@ -308,7 +308,7 @@ function bashunit::main::cmd_test() {
       export -n BASHUNIT_LIST_TAGS
       export -n BASHUNIT_LIST_TESTS
       ;;
-    --snapshot-update)
+    -u | --snapshot-update)
       BASHUNIT_SNAPSHOT_UPDATE=true
       export -n BASHUNIT_SNAPSHOT_UPDATE
       ;;

--- a/tests/acceptance/bashunit_snapshot_update_test.sh
+++ b/tests/acceptance/bashunit_snapshot_update_test.sh
@@ -82,3 +82,14 @@ function test_snapshot_update_still_records_a_missing_snapshot() {
 
   assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
 }
+
+# `-u` is what jest (`-u, --updateSnapshot`) and vitest (`-u, --update`) call
+# it, and re-running with it is reflex for anyone arriving from either. The
+# long form stays; this is the spelling that does not have to be looked up.
+function test_u_is_the_short_form_of_snapshot_update() {
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file \
+    -u snap.sh) >/dev/null 2>&1 || true
+
+  assert_same "alpha value" "$(cat "$SNAPSHOT_ALPHA")"
+  assert_same "beta value" "$(cat "$SNAPSHOT_BETA")"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1293

`--snapshot-update` gets retyped more than most flags — it is what you reach for the moment a deliberate output change turns a snapshot red — and it had no short form. jest (`-u, --updateSnapshot`) and vitest (`-u, --update`) agree on `-u`, so that is what anyone arriving from either types first; today it is an unknown option and the run fails.

## 💡 Changes

- `-u` accepted as an alias; the long form is unchanged. `-u` was unclaimed among the short options in use
- Both completion scripts updated, which their parity test enforces, plus the help text and the docs

Same reasoning as `--pass-with-no-tests`: adopt the ecosystem's spelling rather than invent a third one.