### PR TITLE
fix(runner): stop an empty parallel run writing to stdout twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `--parallel` with an empty selection no longer prints `No tests found` onto stdout ahead of the document, which made `--output json` and `--output junit` unparseable; sequential runs of the same selection were valid. On the console the notice appeared twice instead of once. An empty selection is routine in CI — an unpopulated `--shard`, a `--changed` run that touched nothing — which is where `--output` is consumed (#1295)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/state/parallel.sh
+++ b/src/state/parallel.sh
@@ -27,6 +27,13 @@ function bashunit::state::aggregate_parallel_results() {
 
   local script_dir=""
   for script_dir in "$temp_dir_parallel_test_suite"/*; do
+    # nullglob is enabled below, for the inner glob, and so does not cover this
+    # one: when no worker ran, this loop iterates once over the pattern itself.
+    # That phantom directory has no `.result` files, so the branch below printed
+    # `No tests found` onto stdout on top of the notice the summary renders --
+    # twice on the console, and ahead of the document under `--output`, which
+    # made the JSON and the XML of an empty run unparseable.
+    [ -d "$script_dir" ] || continue
     shopt -s nullglob
     # Bash 3.0 compatible: separate declaration and assignment for arrays
     local result_files

--- a/tests/acceptance/bashunit_output_stdout_test.sh
+++ b/tests/acceptance/bashunit_output_stdout_test.sh
@@ -138,3 +138,43 @@ function test_unknown_output_format_lists_the_supported_ones() {
   assert_general_error "" "" "$ec"
   assert_contains "text, tap, json, junit" "$output"
 }
+
+# An empty selection under --parallel used to print `No tests found` onto
+# stdout before the document, which is the one thing --output promises it will
+# not do. `--pass-with-no-tests` exists because an empty selection is a routine
+# CI state -- an unpopulated shard, a changed-files run that touched nothing --
+# so this is the case a pipeline is most likely to meet.
+function test_output_junit_is_well_formed_when_parallel_selects_no_tests() {
+  local empty_dir
+  empty_dir="$(bashunit::temp_dir empty_selection_junit)"
+
+  local output
+  output=$(./bashunit --parallel --env "$TEST_ENV_FILE" --output junit \
+    --pass-with-no-tests "$empty_dir" 2>/dev/null || true)
+
+  assert_same '<?xml version="1.0" encoding="UTF-8"?>' "${output%%$'\n'*}"
+}
+
+function test_output_json_is_valid_when_parallel_selects_no_tests() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local empty_dir
+  empty_dir="$(bashunit::temp_dir empty_selection_json)"
+
+  local stdout
+  stdout=$(./bashunit --parallel --env "$TEST_ENV_FILE" --output json \
+    --pass-with-no-tests "$empty_dir" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+  assert_same "0" "$(printf '%s' "$stdout" | jq '.summary.total')"
+}
+
+# The console rendering of the same run: one notice, as sequential gives.
+function test_an_empty_parallel_run_reports_no_tests_found_once() {
+  local empty_dir
+  empty_dir="$(bashunit::temp_dir empty_selection_console)"
+
+  local output
+  output=$(./bashunit --parallel --env "$TEST_ENV_FILE" "$empty_dir" 2>&1 || true)
+
+  assert_same "1" "$(printf '%s\n' "$output" | grep -c 'No tests found')"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1295

`bashunit --parallel --output json` over an empty selection wrote a coloured `No tests found` to stdout ahead of the document, so it did not parse — while the same selection run sequentially was valid.

| mode | `--output json` | `--output junit` |
|---|---|---|
| `--no-parallel` | valid | valid |
| `--parallel` | **JSONDecodeError** | **not well-formed** |

On the console the same run printed the notice twice rather than once.

An empty selection is routine in CI — an unpopulated `--shard`, a `--changed` run that touched nothing, which is why `--pass-with-no-tests` exists — and CI is where `--output` is consumed. Same family as #1007, which fixed only the `--list` trigger.

## 💡 Changes

- `aggregate_parallel_results` enabled `nullglob` *inside* its loop, for the inner `*.result` glob, leaving the outer one unguarded: with no worker dispatched the loop iterated once over the unexpanded pattern, and that phantom directory took the "no results" branch. It is skipped now, so the notice survives only for a directory that genuinely produced nothing
- Covers the JSON, the JUnit and the console rendering of an empty parallel selection

## 🔍 How it was found

A systematic sequential-vs-`--parallel` sweep, since the architecture map names that disagreement as the signature of this bug class (#1145, #1147): 18 flags and 10 pathological fixtures — syntax error, failing hooks, duplicate function names, undefined and empty providers, mid-body `exit`, a file with no test functions. This was the only divergence; the rest agreed, including every case that previously produced a silent green.