### PR TITLE
fix(runner): keep the tear_down blank line out of machine output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- A test file with a `tear_down_after_script` no longer makes `--output junit` malformed. The blank line printed after that hook went to stdout ahead of the document, so the XML declaration was not at byte 0 and the report did not parse; the hook did not have to fail, an ordinary one was enough. `--output json` carried the same stray byte but tolerates leading whitespace (#1297)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/runner/hooks.sh
+++ b/src/runner/hooks.sh
@@ -359,10 +359,20 @@ function bashunit::runner::run_tear_down_after_script() {
     bashunit::console_results::print_hook_completed "tear_down_after_script" "$duration_ms"
   fi
 
-  # Add blank line after tear_down output
+  # Add blank line after tear_down output.
+  #
+  # Same guards as the early-return path above, json and junit included: this
+  # line is console decoration, and under `--output` it landed on stdout ahead
+  # of the document. XML wants its declaration at byte 0, so an ordinary
+  # tear_down_after_script -- the hook did not have to fail -- was enough to
+  # make the report malformed. JSON tolerates leading whitespace, which is why
+  # only the XML showed it. tap is still excluded on purpose: it streams line
+  # by line, so a blank line between files is valid there.
   if ! bashunit::env::is_simple_output_enabled &&
     ! bashunit::env::is_failures_only_enabled &&
     ! bashunit::env::is_no_progress_enabled &&
+    ! bashunit::env::is_json_output_enabled &&
+    ! bashunit::env::is_junit_output_enabled &&
     ! bashunit::parallel::is_enabled; then
     echo ""
   fi

--- a/tests/acceptance/bashunit_output_stdout_test.sh
+++ b/tests/acceptance/bashunit_output_stdout_test.sh
@@ -138,3 +138,21 @@ function test_unknown_output_format_lists_the_supported_ones() {
   assert_general_error "" "" "$ec"
   assert_contains "text, tap, json, junit" "$output"
 }
+
+# The blank line printed after a file's tear_down_after_script is console
+# decoration, and it went to stdout ahead of the document. JSON tolerates
+# leading whitespace so only the XML showed it, but the stray byte was in both.
+# An ordinary lifecycle hook is enough -- the hook does not have to fail.
+function test_output_junit_is_well_formed_with_a_tear_down_after_script() {
+  local dir
+  dir="$(bashunit::temp_dir junit_tear_down)"
+  {
+    echo 'function test_ok() { assert_true true; }'
+    echo 'function tear_down_after_script() { :; }'
+  } >"$dir/td_test.sh"
+
+  local output
+  output=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output junit "$dir/td_test.sh" 2>/dev/null || true)
+
+  assert_same '<?xml version="1.0" encoding="UTF-8"?>' "${output%%$'\n'*}"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1297

`--output` promises stdout is the document. A file with a `tear_down_after_script` wrote a blank line there first, so the XML declaration was no longer at byte 0:

```console
$ bashunit --no-parallel --output junit tests/ | od -c | head -1
0000000  \n   <   ?   x   m   l       v   e   r   s   i   o   n   =   "
ExpatError: XML or text declaration not at start of entity
```

The hook did not have to fail — an ordinary `tear_down_after_script() { :; }` was enough, which makes this ordinary usage rather than an edge case. `--parallel` skipped the line entirely, so the modes also disagreed.

## 💡 Changes

- The blank line after `tear_down_after_script` now carries the same machine-format guards its sibling path already had. `tap` stays excluded on purpose: it streams line by line, so a blank line between files is valid there and its snapshots record it
- `--output json` carried the same stray byte and only parsed because JSON tolerates leading whitespace; it is gone from that stream too

## 🔍 How it was found

Extending the sweep from #1295 to assert the *document contract* rather than the console summary: every pathological fixture × {sequential, parallel} × {json, junit}, each one actually parsed. Two further unrelated cases from that table are filed separately.