### PR TITLE
fix(console): send run diagnostics to stderr, not stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Two diagnostics no longer print to stdout, where they made `--output json` and `--output junit` unparseable: the duplicate-test-function abort, in every mode, and the replay of a `--parallel` worker's stderr, which meant any test whose `set_up` failed corrupted the report. Both go to stderr now, so they still reach the reader while stdout carries only the document (#1299)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/console/summary.sh
+++ b/src/console/summary.sh
@@ -73,15 +73,20 @@ function bashunit::console_results::print_filter_hint() {
 
 function bashunit::console_results::render_result() {
   if [ "$(bashunit::state::is_duplicated_test_functions_found)" = true ]; then
-    bashunit::console_results::print_execution_time
-    printf "%s%s%s\n" "${_BASHUNIT_COLOR_RETURN_ERROR}" "Duplicate test functions found" "${_BASHUNIT_COLOR_DEFAULT}"
-    printf "File with duplicate functions: %s\n" "$(bashunit::state::get_file_with_duplicated_function_names)"
+    # To stderr: this aborts the run instead of reporting one, so under
+    # `--output json|junit` it was landing on the stream that is supposed to
+    # carry the document -- in every mode, sequential and parallel alike.
     local _dup_detail
     _dup_detail="$(bashunit::state::get_duplicated_function_details)"
     if [ -z "$_dup_detail" ]; then
       _dup_detail="$(bashunit::state::get_duplicated_function_names)"
     fi
-    printf "Duplicate functions: %s\n" "$_dup_detail"
+    {
+      bashunit::console_results::print_execution_time
+      printf "%s%s%s\n" "${_BASHUNIT_COLOR_RETURN_ERROR}" "Duplicate test functions found" "${_BASHUNIT_COLOR_DEFAULT}"
+      printf "File with duplicate functions: %s\n" "$(bashunit::state::get_file_with_duplicated_function_names)"
+      printf "Duplicate functions: %s\n" "$_dup_detail"
+    } >&2
     return 1
   fi
 

--- a/src/console/test_line.sh
+++ b/src/console/test_line.sh
@@ -283,7 +283,11 @@ function bashunit::console_results::print_worker_stderr() {
   local test_file="$1"
   local stderr_file="$2"
 
+  # To stderr, which is where this text came from: on stdout it landed ahead of
+  # the document `--output json|junit` promises that stream is, so a worker that
+  # wrote anything to stderr -- a failing `set_up`, for one -- made the report
+  # unparseable.
   printf "\n%sStderr from %s%s\n" \
-    "$_BASHUNIT_COLOR_SKIPPED" "$test_file" "$_BASHUNIT_COLOR_DEFAULT"
-  sed 's/^/|/' "$stderr_file"
+    "$_BASHUNIT_COLOR_SKIPPED" "$test_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  sed 's/^/|/' "$stderr_file" >&2
 }

--- a/tests/acceptance/bashunit_output_stdout_test.sh
+++ b/tests/acceptance/bashunit_output_stdout_test.sh
@@ -138,3 +138,58 @@ function test_unknown_output_format_lists_the_supported_ones() {
   assert_general_error "" "" "$ec"
   assert_contains "text, tap, json, junit" "$output"
 }
+
+# Two diagnostics used to go to stdout, where --output promises only the
+# document lives. The duplicate-function abort did it in every mode; the
+# worker-stderr replay did it under --parallel, so any test whose set_up failed
+# corrupted the report.
+#
+# The duplicated name is built through printf rather than written twice here:
+# the duplicate check scans a file textually, so two literal definitions would
+# count as duplicates of THIS file (see .claude/rules/testing.md).
+function test_output_json_is_valid_when_a_file_has_duplicate_test_functions() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local dir fn
+  dir="$(bashunit::temp_dir dup_json)"
+  fn="test_same_name"
+  {
+    printf 'function %s() { assert_true true; }\n' "$fn"
+    printf 'function %s() { assert_true true; }\n' "$fn"
+  } >"$dir/dup_test.sh"
+
+  local stdout
+  stdout=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" --output json "$dir/dup_test.sh" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+}
+
+function test_output_json_is_valid_when_a_parallel_worker_writes_stderr() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local dir
+  dir="$(bashunit::temp_dir worker_stderr_json)"
+  {
+    printf 'function %s() { return 1; }\n' "set_up"
+    printf 'function %s() { assert_true true; }\n' "test_needs_set_up"
+  } >"$dir/hook_test.sh"
+
+  local stdout
+  stdout=$(./bashunit --parallel --env "$TEST_ENV_FILE" --output json "$dir/hook_test.sh" 2>/dev/null || true)
+
+  assert_successful_code "$(printf '%s' "$stdout" | jq empty 2>&1)"
+}
+
+# The diagnostics must still reach the user, on stderr.
+function test_the_duplicate_function_abort_is_reported_on_stderr() {
+  local dir fn
+  dir="$(bashunit::temp_dir dup_stderr)"
+  fn="test_same_name_again"
+  {
+    printf 'function %s() { assert_true true; }\n' "$fn"
+    printf 'function %s() { assert_true true; }\n' "$fn"
+  } >"$dir/dup2_test.sh"
+
+  local stderr
+  stderr=$(./bashunit --no-parallel --env "$TEST_ENV_FILE" "$dir/dup2_test.sh" 2>&1 >/dev/null || true)
+
+  assert_contains "Duplicate test functions found" "$stderr"
+}

--- a/tests/unit/console/results_test.sh
+++ b/tests/unit/console/results_test.sh
@@ -432,7 +432,9 @@ function test_render_file_with_duplicated_functions_if_found_true() {
     set_state_value "bashunit::state::get_duplicated_function_names" "duplicate_function_name"
     set_state_value "bashunit::state::get_file_with_duplicated_function_names" "duplicate_file_name.sh"
 
-    bashunit::console_results::render_result || true
+    # 2>&1 >/dev/null: the abort is a diagnostic and goes to stderr, so that
+    # `--output json|junit` keeps stdout for the document alone.
+    bashunit::console_results::render_result 2>&1 >/dev/null || true
   )
 
   assert_contains "Duplicate test functions found" "$render_result"
@@ -471,7 +473,10 @@ function test_only_render_error_result_when_some_duplicated_fails() {
     set_state_value "bashunit::state::get_tests_skipped" "2"
     set_state_value "bashunit::state::get_tests_passed" "3"
 
-    bashunit::console_results::render_result || true
+    # Both streams: the abort itself now goes to stderr, while the assertions
+    # below are about what is NOT rendered -- which would pass vacuously if
+    # stdout were discarded.
+    bashunit::console_results::render_result 2>&1 || true
   )
 
   assert_contains "Duplicate test functions found" "$render_result"


### PR DESCRIPTION
## 🤔 Background

Related #1299

`--output` promises stdout carries the document. Two diagnostics wrote there instead, so the report did not parse:

- **The duplicate-function abort** (`render_result`) — every mode, both formats
- **The parallel worker-stderr replay** (`print_worker_stderr`) — replayed a worker's *stderr* onto *stdout*, so any test whose `set_up` failed corrupted the report. A broken shared fixture is exactly when a CI reporter is most wanted

## 💡 Changes

- Both go to stderr. Neither is a result: one aborts the run instead of reporting it, the other is stderr text by definition. The reader still sees them; stdout carries only the document
- Two unit tests pinned the old stream and now assert the new one — one reads stderr, the other reads both streams, since its assertions are about what is *not* rendered and would pass vacuously against a discarded stdout

## 🔍 How it was found

The document-contract sweep from #1297: every pathological fixture × {sequential, parallel} × {json, junit}, each output actually parsed. With #1295 and #1297 fixed these were the last two red rows; all four combinations pass for both now.