### PR TITLE
fix(reports): count a file-level hook failure once under --parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- A `--parallel` run no longer counts a file-level hook failure twice in its reports. A failing `set_up_before_script` or `tear_down_after_script`, and a file that fails to source, were written into the JSON, JUnit, HTML and Markdown reports as two failed tests, listed twice, while the console summary of the same run said one — the console was right (#1301)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/reports/collect.sh
+++ b/src/reports/collect.sh
@@ -150,6 +150,26 @@ function bashunit::reports::load_spooled() {
   bashunit::reports::is_enabled || return 0
   [ -f "${REPORTS_OUTPUT_PATH:-}" ] || return 0
 
+  # The spool is the complete record of a parallel run, so it replaces the
+  # arrays rather than appending to them.
+  #
+  # A worker's own arrays die with it, so for a worker's row appending would be
+  # right. But a file-level hook failure is recorded by the PARENT -- see
+  # runner/hooks.sh record_file_hook_failure -- and add_test fills the arrays
+  # for every caller while spooling only under --parallel. That row was
+  # therefore in both places, and replaying it appended a second copy: a failing
+  # set_up_before_script was reported as two failed tests where the console
+  # summary of the same run said one.
+  _BASHUNIT_REPORTS_TEST_FILES=()
+  _BASHUNIT_REPORTS_TEST_NAMES=()
+  _BASHUNIT_REPORTS_TEST_STATUSES=()
+  _BASHUNIT_REPORTS_TEST_DURATIONS=()
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=()
+  _BASHUNIT_REPORTS_TEST_FAILURES=()
+  _BASHUNIT_REPORTS_TEST_LINES=()
+  _BASHUNIT_REPORTS_TEST_RETRIES=()
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=()
+
   local file test_name status duration assertions failure_message line retries test_output n
   while IFS='|' read -r file test_name status duration assertions failure_message line retries test_output; do
     [ -n "$file" ] || continue

--- a/tests/acceptance/bashunit_report_json_test.sh
+++ b/tests/acceptance/bashunit_report_json_test.sh
@@ -54,3 +54,46 @@ function test_report_json_is_not_written_without_the_flag() {
 
   assert_file_not_exists "$report"
 }
+
+# A file-level hook failure is recorded by the parent, not by a worker. Under
+# --parallel `add_test` spools the row *and* fills the parent's arrays, and
+# `load_spooled` then replayed the spool into those same arrays -- so the report
+# counted the failure twice and listed the test twice, while the console
+# summary of the same run said one. The console was right.
+function test_report_json_counts_a_hook_failure_once_under_parallel() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local dir report
+  dir="$(bashunit::temp_dir dup_hook_report)"
+  report="$dir/r.json"
+  {
+    printf 'function %s() { return 1; }\n' "set_up_before_script"
+    printf 'function %s() { assert_true true; }\n' "test_never_runs"
+  } >"$dir/hook_test.sh"
+
+  ./bashunit --parallel --env "$TEST_ENV_FILE" --report-json "$report" \
+    "$dir/hook_test.sh" >/dev/null 2>&1 || true
+
+  assert_same "1" "$(jq '.summary.total' "$report")"
+  assert_same "1" "$(jq '.summary.failed' "$report")"
+  assert_same "1" "$(jq '.tests | length' "$report")"
+}
+
+# The same run's console summary and its report must agree.
+function test_report_json_matches_the_console_summary_under_parallel() {
+  if [ "$JQ_AVAILABLE" = false ]; then bashunit::skip "jq required"; return; fi
+  local dir report output
+  dir="$(bashunit::temp_dir report_console_parity)"
+  report="$dir/r.json"
+  {
+    printf 'function %s() { assert_true true; }\n' "test_ok"
+    printf 'function %s() { return 1; }\n' "tear_down_after_script"
+  } >"$dir/td_test.sh"
+
+  output=$(./bashunit --parallel --env "$TEST_ENV_FILE" --report-json "$report" \
+    "$dir/td_test.sh" 2>&1) || true
+
+  # Console says "1 passed, 1 failed, 2 total"; the report must say the same.
+  assert_same "2" "$(jq '.summary.total' "$report")"
+  assert_same "1" "$(jq '.summary.failed' "$report")"
+  assert_contains "2 total" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1301

Under `--parallel`, a failing `set_up_before_script` was written into the report twice while the console summary of the same run said once:

```console
$ bashunit --parallel --report-json r.json tests/
Tests:      1 failed, 1 total          <- console

$ jq '.summary.total, (.tests|length)' r.json
2
2                                      <- report
```

Sequentially the same fixture reports `1`. Also hits `tear_down_after_script` and a file that fails to source, and every writer reading those arrays — JSON, JUnit, HTML, Markdown — so a CI dashboard shows inflated counts and duplicate entries.

## 💡 Changes

- A file-level hook failure is recorded by the **parent**, not a worker, and `add_test` fills the arrays for every caller while spooling only under `--parallel` — so that row was in both places and `load_spooled` appended a second copy. It now replaces the arrays, the spool being the complete record of a parallel run
- The comment claiming "the parent never reaches this path for a real parallel test" holds for test bodies, which do run in workers, but not for file-level hooks; corrected in place

## 🔍 How it was found

Extending the sweep from #1297/#1299 from document *validity* to document *content*: comparing each pathological fixture's JSON summary between sequential and `--parallel`. Three of eleven disagreed, all the same way. All eleven agree now.