### PR TITLE
fix(bench): fail the run when a benchmark file fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- `bashunit bench` now exits non-zero when a benchmark file fails to source or its `set_up_before_script` fails. It printed the error and exited 0, so the failure reached a human reading the log and never reached CI; a file with a syntax error silently lost every `bench_` function after it and still reported success. A benchmark that merely returns non-zero still exits 0 — a benchmark measures time and has no assertion concept (#1303)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/main/run.sh
+++ b/src/main/run.sh
@@ -367,6 +367,15 @@ function bashunit::main::exec_benchmarks() {
     fi
   fi
 
+  # A file that failed to source, or whose set_up_before_script failed, is
+  # recorded as a failure and printed -- but the exit code consulted only "no
+  # benchmarks found" and the baseline gate, so a failure alongside a file that
+  # did run left the run green. The error reached the human reading the log and
+  # never reached CI, which is the worst of the two.
+  if [ "$(bashunit::state::get_tests_failed)" -gt 0 ]; then
+    exit 1
+  fi
+
   bashunit::internal_log "Finished benchmarks"
 }
 

--- a/src/runner/bench.sh
+++ b/src/runner/bench.sh
@@ -13,11 +13,45 @@ function bashunit::runner::load_bench_files() {
     unset BASHUNIT_CURRENT_TEST_ID
     bashunit::helper::generate_id "${bench_file}"
     export BASHUNIT_CURRENT_SCRIPT_ID="$_BASHUNIT_HELPER_ID_OUT"
+    # Sourcing status is checked, the same way the test loop checks it: a bench
+    # file with a syntax error used to lose every function after the error and
+    # leave the run green, reporting only whatever parsed.
+    local source_err_file source_err source_status
+    source_err_file="$_BASHUNIT_RUN_OUTPUT_DIR/bench_source_err"
+    : >"$source_err_file" 2>/dev/null || source_err_file=/dev/null
     # shellcheck source=/dev/null
-    source "$bench_file"
+    source "$bench_file" 2>"$source_err_file"
+    source_status=$?
     # Reset the loop's shell-mode invariant; a bench file may set -euo at top
     # level and sourcing runs that in this shell (see the test loop) (#836).
     set +euo pipefail
+
+    source_err=""
+    if [ -s "$source_err_file" ]; then
+      source_err="$(cat "$source_err_file")"
+    fi
+    # A non-zero status, or a syntax-error line on stderr: bash reports a syntax
+    # error and carries on, so the status alone does not catch it. `case`, not
+    # grep, to stay fork-free -- same test the test loop makes.
+    local source_failed=false
+    if [ "$source_status" -ne 0 ]; then
+      source_failed=true
+    else
+      case "$source_err" in
+      *"syntax error"* | *"unexpected EOF"*) source_failed=true ;;
+      esac
+    fi
+    if [ "$source_failed" = true ]; then
+      local message="$source_err"
+      if [ -z "$message" ]; then
+        message="Failed to source '$bench_file' (exit $source_status)"
+      fi
+      bashunit::runner::record_file_hook_failure "source" "$bench_file" "$message" 1 true
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      bashunit::cleanup_script_temp_files
+      bashunit::runner::restore_workdir
+      continue
+    fi
     # Update function cache after sourcing new bench file (compgen is a builtin)
     _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
     # Call hook directly (not with `if !`) to preserve errexit behavior inside the hook

--- a/tests/acceptance/bashunit_bench_test.sh
+++ b/tests/acceptance/bashunit_bench_test.sh
@@ -60,3 +60,41 @@ function test_bench_fails_when_a_file_holds_no_bench_function() {
   assert_general_error "" "" "$ec"
   assert_contains "No benchmarks found" "$output"
 }
+
+# `bench` exits on "No benchmarks found" and on a baseline regression, and
+# consulted nothing else -- so a file that failed alongside one that ran left
+# the run green. The error is printed either way, which is what makes it a
+# silent green rather than a silent failure: a human reading the log sees it,
+# CI does not. `test` exits non-zero for both of these shapes.
+function test_bench_fails_when_a_files_set_up_before_script_fails() {
+  local dir
+  dir="$(bashunit::temp_dir bench_hook_fail)"
+  printf 'function bench_works() { :; }\n' >"$dir/a_bench.sh"
+  {
+    printf 'function %s() { return 1; }\n' "set_up_before_script"
+    printf 'function bench_never() { :; }\n'
+  } >"$dir/b_bench.sh"
+
+  local ec=0
+  local output
+  output=$(./bashunit bench "$dir" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+  assert_contains "Set up before script" "$output"
+}
+
+function test_bench_fails_when_a_file_cannot_be_sourced() {
+  local dir
+  dir="$(bashunit::temp_dir bench_source_fail)"
+  printf 'function bench_works() { :; }\n' >"$dir/a_bench.sh"
+  {
+    printf 'function bench_ok() { :; }\n'
+    printf 'function broken( {\n'
+  } >"$dir/b_bench.sh"
+
+  local ec=0
+  local output
+  output=$(./bashunit bench "$dir" 2>&1) || ec=$?
+
+  assert_general_error "" "" "$ec"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1303

`bashunit bench` printed a file-level failure and then exited 0. Same scenario, both subcommands — one good file plus one whose `set_up_before_script` fails:

```console
$ bashunit bench benchmarks/
✗ Error: Set up before script
bench_works    1    1    6
EXIT=0            <- bench

$ bashunit tests/
EXIT=1            <- test
```

A syntax error was worse: every `bench_` function after it vanished from the table and nothing was reported as failed at all.

## 💡 Changes

- `load_bench_files` checks the sourcing status and matches the captured stderr for `syntax error` / `unexpected EOF`, as the test loop does — bash reports a syntax error and carries on with a zero status, so the status alone does not catch it. `case`, not `grep`, to stay fork-free
- `cmd_bench` consults the failure counter. It exited non-zero only for "No benchmarks found" and the baseline gate, so the existing `set_up_before_script` failure path could not affect the verdict — it only looked correct when the failure left nothing to run and "No benchmarks found" fired instead
- A benchmark that merely returns non-zero still exits 0: a benchmark measures time and has no assertion concept

## 🔍 How it was found

Applying the pathological-fixture sweep from #1295/#1297/#1299/#1301 to `bench`, which has its own runner and reports and is far less exercised than `test`.