### PR TITLE
fix(reports): grow the markdown fence past backticks in the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- A failure message containing a ``` fence no longer breaks the `--report-md` summary. The message is fenced unescaped, which is right only while the fence is longer than any run of backticks inside it — a hook printing a bare fence closed the block early, so the text after it rendered as prose and the trailing fence opened an unterminated one, swallowing every later section of the page appended to `$GITHUB_STEP_SUMMARY` (#1305)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/reports/markdown.sh
+++ b/src/reports/markdown.sh
@@ -108,9 +108,27 @@ function bashunit::reports::__md_failures() {
       printf '`%s`\n\n' "$file"
     fi
     # Not escaped: a fence renders its contents literally, which is the point.
-    echo '```'
+    #
+    # That holds only while the fence is longer than any run of backticks in the
+    # message. A hook printing a bare ``` closed the block early, so the text
+    # after it rendered as prose and the trailing fence opened a new,
+    # unterminated one -- swallowing every later section of a report that is
+    # appended to $GITHUB_STEP_SUMMARY. CommonMark closes a fence only with one
+    # at least as long, so grow it past the longest run present.
+    #
+    # The loop is fork-free and terminates: the message is finite, so some
+    # length is not a substring of it. A message holding ```` contains ``` too,
+    # which is why testing for containment (not equality) gets the longest run.
+    local fence='```'
+    while :; do
+      case "$message" in
+      *"$fence"*) fence="$fence"'`' ;;
+      *) break ;;
+      esac
+    done
+    printf '%s\n' "$fence"
     printf '%s\n' "$message"
-    echo '```'
+    printf '%s\n' "$fence"
     echo ""
   done
 }

--- a/tests/acceptance/bashunit_report_md_test.sh
+++ b/tests/acceptance/bashunit_report_md_test.sh
@@ -119,3 +119,38 @@ function test_the_slowest_tests_appear_only_with_profile() {
   assert_not_contains "## Slowest tests" "$(cat "$REPORT_DIR/plain.md")"
   assert_contains "## Slowest tests" "$(cat "$REPORT_DIR/profiled.md")"
 }
+
+# The failure block is a fenced code block, and the message goes in unescaped
+# because a fence renders its contents literally -- but only while the fence is
+# longer than any run of backticks inside it. A hook that printed a bare ``` cut
+# the block short: the text after it rendered as prose and the trailing fence
+# opened a new, unterminated block, swallowing every later section. This report
+# is appended to $GITHUB_STEP_SUMMARY, so that is the job page.
+function test_a_backtick_fence_in_a_message_does_not_break_the_code_block() {
+  local dir
+  dir="$(bashunit::temp_dir md_fence)"
+  {
+    printf 'function %s() {\n' "set_up_before_script"
+    printf "  printf 'oops\\\\n\`\`\`\\\\nnot code\\\\n'\n"
+    printf '  return 1\n'
+    printf '}\n'
+    printf 'function test_never_runs() { assert_true true; }\n'
+  } >"$dir/fence_test.sh"
+
+  ./bashunit --no-parallel --no-color --env "$TEST_ENV_FILE" \
+    --report-md "$dir/summary.md" "$dir/fence_test.sh" >/dev/null 2>&1 || true
+
+  # The delimiter is the LONGEST backtick-only line: a shorter run inside the
+  # message is content, not a delimiter. Counting every backtick-only line would
+  # call the fixed document broken, since the message keeps its own ``` line.
+  # An odd number of delimiters means a block was left open.
+  local delimiters
+  delimiters="$(awk '
+    /^`+$/ { if (length($0) > max) { max = length($0); n = 0 }
+             if (length($0) == max) n++ }
+    END { print n + 0 }' "$dir/summary.md")"
+
+  assert_same "0" "$((delimiters % 2))"
+  # And it did have to grow past the run inside the message.
+  assert_not_empty "$(grep -c '^````$' "$dir/summary.md")"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1305

`--report-md` fences each failure message unescaped, because a fence renders its contents literally — true only while the fence is longer than any run of backticks inside it. A hook printing a bare fence closed the block early, so the text after it rendered as prose and the trailing fence opened a new, unterminated one. Every later section of the report was swallowed.

That report is auto-appended to `$GITHUB_STEP_SUMMARY`, so it corrupts the Actions job summary — the page the report exists to be read on.

## 💡 Changes

- The opening fence grows past the longest run of backticks present, which is how CommonMark closes a fence. Fork-free and terminating: the message is finite, and testing *containment* rather than equality finds the longest run, since a message holding four backticks contains three too
- The regression test asserts the property, not the implementation: the **longest** backtick-only line is the delimiter, and it must appear an even number of times. Counting every backtick-only line would call the fixed document broken, since the message keeps its own inner fence

## 🔍 Notes

The diff-rendered case survived by luck — `assert_same` wraps changed lines as `[-...-]`, which is not a bare delimiter. Undiffed messages (hook failures, source failures) reach the report intact, which is why this showed up in a hook fixture.

HTML was swept at the same time and is clean: `<script>` is escaped and there are no stray ampersands. The Markdown summary table has no message column, so no `|` injection either.