### PR TITLE
fix(reports): encode reserved chars in GHA annotation properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- A comma or colon in a test title no longer breaks its GitHub Actions annotation. GitHub splits an annotation's properties on `,`, so a `set_test_title` holding one ended the title there and turned the rest into an invented property; a file path containing a comma did the same. Property values now encode `:` and `,` as the spec requires, on top of the `%`, `\r` and `\n` the message already encoded (#1307)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/reports/gha.sh
+++ b/src/reports/gha.sh
@@ -18,6 +18,24 @@ function bashunit::reports::__gha_encode() {
   printf '%s' "$text"
 }
 
+##
+# A property VALUE carries a stricter rule than the message: GitHub splits the
+# property list on `,` and a key from its value on `=`, and the spec also
+# reserves `:`. A `set_test_title` holding a comma therefore ended the title
+# there and turned the remainder into an invented property.
+#
+# Built on the message encoder, so `%` is already encoded first and the `%3A`
+# and `%2C` added here stay literal -- and it inherits the `[%]` workaround for
+# Bash 3.0 reading a bare `%` after `//` as anchor-to-end (#1121).
+##
+function bashunit::reports::__gha_encode_property() {
+  local text
+  text=$(bashunit::reports::__gha_encode "$1")
+  text="${text//:/%3A}"
+  text="${text//,/%2C}"
+  printf '%s' "$text"
+}
+
 # Echoes GitHub Actions workflow-command annotations to stdout.
 # Arguments: $1 - "failed-only" to emit just errors (default: all reportable).
 function bashunit::reports::print_gha_annotations() {
@@ -58,14 +76,17 @@ function bashunit::reports::print_gha_annotations() {
       continue
     fi
 
-    local location="file=${file}"
+    # `line` is an integer this file produced, so it needs no encoding; `file`
+    # and `name` are user-supplied and do.
+    local location="file=$(bashunit::reports::__gha_encode_property "$file")"
     if [ -n "$line" ]; then
       location="${location},line=${line}"
     fi
 
-    local encoded_message
+    local encoded_message encoded_name
     encoded_message=$(bashunit::reports::__gha_encode "$message")
-    echo "::${level} ${location},title=${name}::${encoded_message}"
+    encoded_name=$(bashunit::reports::__gha_encode_property "$name")
+    echo "::${level} ${location},title=${encoded_name}::${encoded_message}"
   done
 }
 

--- a/tests/acceptance/bashunit_gha_annotations_test.sh
+++ b/tests/acceptance/bashunit_gha_annotations_test.sh
@@ -118,3 +118,34 @@ function test_an_unknown_mode_is_a_usage_error() {
   assert_contains "sometimes" "$output"
   assert_contains "auto, always, never" "$output"
 }
+
+# GitHub splits an annotation's properties on `,` and its key from its value on
+# `=`, so a property VALUE carries a stricter rule than the message: `:` and `,`
+# must be percent-encoded too. A custom title containing a comma ended the title
+# there and turned the rest into an invented property.
+function test_a_comma_in_a_custom_title_does_not_split_the_properties() {
+  local dir
+  dir="$(bashunit::temp_dir gha_title_comma)"
+  {
+    printf 'function test_titled() {\n'
+    printf '  bashunit::set_test_title "Rejects a,b when x:y is set"\n'
+    printf '  assert_same "expected" "actual"\n'
+    printf '}\n'
+  } >"$dir/title_test.sh"
+
+  local output
+  output="$(_BASHUNIT_GHA_ANNOTATIONS_CLAIMED='' GITHUB_STEP_SUMMARY='' GITHUB_ACTIONS=true \
+    ./bashunit --no-parallel --no-color \
+    --env "$TEST_ENV_FILE" "$dir/title_test.sh")" || true
+
+  local annotation
+  annotation="$(printf '%s\n' "$output" | grep '^::error' | head -1)"
+  # Everything before the `::` that starts the message is the property list.
+  local props="${annotation%%::*}"
+  props="${annotation#::error }"
+  props="${props%%::*}"
+
+  assert_not_contains "a,b" "$props"
+  assert_contains "%2C" "$props"
+  assert_contains "%3A" "$props"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1307

GitHub parses a workflow command as `::level prop=value,prop=value::message`, splitting the properties on `,`. `file=` and `title=` were interpolated raw, so a title containing a comma ended the title there:

```
::error file=t_test.sh,line=1,title=Rejects a,b when x:y is set::✗ Failed: ...
```

parses as

```
'title' -> 'Rejects a'
'b when x:y is set' -> ''
```

`set_test_title` takes arbitrary text, so a comma in a title is ordinary usage; a file path containing one breaks `file=` the same way.

## 💡 Changes

- A property encoder adds `%3A` and `%2C` on top of the message rule, which the spec requires for property values only. It builds on the existing message encoder, so `%` is still encoded first and the sequences it adds stay literal — and it inherits the `[%]` workaround for Bash 3.0 reading a bare `%` after `//` as anchor-to-end (#1121)
- Applied to `file=` and `title=`. `line=` is an integer bashunit produces and needs nothing
- The message keeps its raw commas and colons, which is correct: only property values carry the stricter rule