### PR TITLE
fix(coverage): escape XML metacharacters in the cobertura report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- The Cobertura coverage report escapes XML metacharacters in a path. A file whose name held `&`, `<` or `>` went into `filename=`, `class name=`, `package name=` and `<source>` raw, so the document did not parse — and Cobertura is what GitLab, Azure and Jenkins render coverage from, which then silently show nothing. The HTML report gained this in #1254; this writer had no escaper at all (#1311)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/coverage/report_cobertura.sh
+++ b/src/coverage/report_cobertura.sh
@@ -5,6 +5,32 @@
 # consume: GitLab MR visualisation, Azure PublishCodeCoverageResults and the
 # Jenkins Coverage plugin.
 
+##
+# Escapes a path for an XML attribute or element body. `&` first, or the
+# entities written after it would have their own ampersands escaped again.
+#
+# `sed`, not `${text//&/&amp;}`: Bash 5.2 reads a bare `&` in the REPLACEMENT as
+# "the matched text", so that spelling yields `<lt;` there while producing
+# `&lt;` on 3.2, and escaping it for 5.2 emits a literal backslash on 3.2. There
+# is no spelling correct across the supported range, which is why report_html.sh
+# escapes through sed too (#1096, #1254).
+#
+# The `case` keeps it fork-free for the paths that need nothing, which is nearly
+# all of them -- this runs once per file and once per package. The result goes
+# into the slot below rather than being echoed, like __cobertura_rate: a
+# `$(...)` capture would fork once per file even for the paths the `case` clears.
+##
+_BASHUNIT_COBERTURA_ESCAPED_OUT=""
+function bashunit::coverage::__cobertura_escape() {
+  case "$1" in
+  *[\&\<\>\"]*)
+    _BASHUNIT_COBERTURA_ESCAPED_OUT=$(printf '%s' "$1" |
+      sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
+    ;;
+  *) _BASHUNIT_COBERTURA_ESCAPED_OUT="$1" ;;
+  esac
+}
+
 # Turns hit/total counts into a "0.87"-style rate, written into the slot
 # below. Derived from the same integer percentage the console report prints,
 # so the two can never disagree; the literal dot keeps it locale-immune.
@@ -137,7 +163,13 @@ condition-coverage=\"${cond_pct}% (${taken}/${arms})\"/>
     bashunit::coverage::__cobertura_rate "$file_br_taken" "$file_br"
     class_branch_rate=$_BASHUNIT_COBERTURA_RATE_OUT
 
-    pkg_classes[p]="${pkg_classes[p]}        <class name=\"$class_name\" filename=\"$rel\" \
+    local esc_class esc_rel
+    bashunit::coverage::__cobertura_escape "$class_name"
+    esc_class=$_BASHUNIT_COBERTURA_ESCAPED_OUT
+    bashunit::coverage::__cobertura_escape "$rel"
+    esc_rel=$_BASHUNIT_COBERTURA_ESCAPED_OUT
+
+    pkg_classes[p]="${pkg_classes[p]}        <class name=\"$esc_class\" filename=\"$esc_rel\" \
 line-rate=\"$class_line_rate\" branch-rate=\"$class_branch_rate\" complexity=\"0.0\">
           <methods/>
           <lines>
@@ -159,7 +191,8 @@ $lines_xml          </lines>
       "branches-covered=\"$total_br_taken\" branches-valid=\"$total_br\"" \
       "complexity=\"0.0\" version=\"${BASHUNIT_VERSION:-0}\" timestamp=\"$timestamp\">"
     echo "  <sources>"
-    echo "    <source>$PWD</source>"
+    bashunit::coverage::__cobertura_escape "$PWD"
+    echo "    <source>$_BASHUNIT_COBERTURA_ESCAPED_OUT</source>"
     echo "  </sources>"
     echo "  <packages>"
 
@@ -170,7 +203,8 @@ $lines_xml          </lines>
       pkg_line_rate=$_BASHUNIT_COBERTURA_RATE_OUT
       bashunit::coverage::__cobertura_rate "${pkg_br_taken[$s]}" "${pkg_br_total[$s]}"
       pkg_branch_rate=$_BASHUNIT_COBERTURA_RATE_OUT
-      echo "    <package name=\"${pkg_names[$s]}\" line-rate=\"$pkg_line_rate\"" \
+      bashunit::coverage::__cobertura_escape "${pkg_names[$s]}"
+      echo "    <package name=\"$_BASHUNIT_COBERTURA_ESCAPED_OUT\" line-rate=\"$pkg_line_rate\"" \
         "branch-rate=\"$pkg_branch_rate\" complexity=\"0.0\">"
       echo "      <classes>"
       printf '%s' "${pkg_classes[$s]}"

--- a/tests/acceptance/bashunit_coverage_cobertura_test.sh
+++ b/tests/acceptance/bashunit_coverage_cobertura_test.sh
@@ -100,3 +100,36 @@ function test_cobertura_uncreatable_path_fails_fast() {
 function test_cobertura_appears_in_the_help() {
   assert_contains "--coverage-report-cobertura" "$(./bashunit test --help)"
 }
+
+# The report is XML, and every attribute it writes carries a path: filename=,
+# class name=, package name= and the <source> body. A path holding `&`, `<` or
+# `>` went in raw, so the document did not parse -- and GitLab, Azure and
+# Jenkins are exactly the consumers that then show nothing. The HTML report was
+# given this treatment in #1254; this writer was missed.
+function test_cobertura_escapes_xml_metacharacters_in_a_path() {
+  local dir
+  dir="$(cd "$(bashunit::temp_dir cobertura_amp)" && pwd)"
+  (
+    cd "$dir" || exit 1
+    {
+      echo '#!/usr/bin/env bash'
+      echo 'function covered() { COVERED_OUT="covered"; }'
+    } >'a&b.sh'
+    {
+      echo "source \"$dir/a&b.sh\""
+      echo 'function test_covered() { covered; assert_not_empty "$COVERED_OUT"; }'
+    } >suite_test.sh
+  ) >/dev/null 2>&1
+
+  (
+    cd "$dir" || exit 1
+    BASHUNIT_COVERAGE_PATHS="$dir" BASHUNIT_COVERAGE_REPORT="" \
+      "$OLDPWD/bashunit" --no-parallel --coverage \
+      --coverage-report-cobertura "$dir/cob.xml" ./suite_test.sh
+  ) >/dev/null 2>&1 || true
+
+  assert_file_exists "$dir/cob.xml"
+  # The raw ampersand must be an entity, and the document must parse.
+  assert_not_contains 'a&b.sh"' "$(cat "$dir/cob.xml")"
+  assert_contains 'a&amp;b.sh' "$(cat "$dir/cob.xml")"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1311

`--coverage-report-cobertura` writes XML and interpolates paths raw, so a file named `a&b.sh` produced `filename="src/a&b.sh"` and a document that does not parse:

```
ExpatError: not well-formed (invalid token): line 9, column 27
```

Cobertura is what the CI platforms with built-in coverage UIs consume — GitLab MR visualisation, Azure `PublishCodeCoverageResults`, the Jenkins Coverage plugin — so an unparseable report means the view silently shows nothing.

## 💡 Changes

- Escapes `&`, `<`, `>` and `"` at all four sites that carry a path: `filename=`, `class name=`, `package name=` and the `<source>` body. The HTML report gained an escaper in #1254; this writer had none
- Through `sed`, not `${text//&/&amp;}`: Bash 5.2 reads a bare `&` in the REPLACEMENT as "the matched text", so that spelling yields `<lt;` there while producing `&lt;` on 3.2, and escaping it for 5.2 emits a literal backslash on 3.2 (#1096)
- A `case` guard keeps it fork-free for the paths that need nothing, which is nearly all of them, and the result goes to a return slot — a `$(...)` capture would fork once per file regardless