### PR TITLE
fix(reports): escape the file path in the JUnit report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- The JUnit report escapes the file path. `testsuite name=`, `testcase classname=` and `file=` were interpolated raw, so a test file whose name contained `"`, `&` or `<` closed the attribute early and the document stopped parsing — under both `--report-junit` and `--output junit`. The test name and the failure message were already escaped (#1313)
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/reports/junit.sh
+++ b/src/reports/junit.sh
@@ -104,9 +104,15 @@ function bashunit::reports::print_junit_xml() {
     escaped_name=$(bashunit::reports::__xml_escape "$name")
     bashunit::reports::__junit_classname "$file"
     classname=$_BASHUNIT_REPORTS_CLASSNAME_OUT
+    # The path-derived attributes need escaping too: a path holding `"` closes
+    # the attribute early and the document stops parsing, and `&`/`<` break it
+    # the same way. The name and the message above have always been escaped.
+    classname=$(bashunit::reports::__xml_escape "$classname")
+    local escaped_file
+    escaped_file=$(bashunit::reports::__xml_escape "$file")
 
     local case_xml="    <testcase classname=\"$classname\" name=\"$escaped_name\"
-        file=\"$file\" time=\"$test_time\">
+        file=\"$escaped_file\" time=\"$test_time\">
 "
 
     if [ "$status" = "failed" ]; then
@@ -182,7 +188,9 @@ retries\">$escaped_flaky</flakyFailure>
       local suite_time_s
       bashunit::reports::__ms_to_s "${suite_time[$s]}"
       suite_time_s=$_BASHUNIT_REPORTS_MS_TO_S_OUT
-      echo "  <testsuite name=\"${suite_files[$s]}\" tests=\"${suite_tests[$s]}\"" \
+      local escaped_suite
+      escaped_suite=$(bashunit::reports::__xml_escape "${suite_files[$s]}")
+      echo "  <testsuite name=\"$escaped_suite\" tests=\"${suite_tests[$s]}\"" \
         "failures=\"${suite_failures[$s]}\" skipped=\"${suite_skipped[$s]}\" errors=\"0\"" \
         "time=\"$suite_time_s\" timestamp=\"$timestamp\">"
       printf '%s' "${cases[$s]}"

--- a/tests/acceptance/bashunit_log_junit_test.sh
+++ b/tests/acceptance/bashunit_log_junit_test.sh
@@ -62,3 +62,24 @@ function test_bashunit_report_junit_is_alias_of_log_junit() {
   assert_file_contains "$report" "<testsuite"
   rm "$report"
 }
+
+# __xml_escape is applied to the test name and the failure message, but the
+# path-derived attributes -- testsuite name=, testcase classname= and file= --
+# were interpolated raw. A path holding `"` closes the attribute early and the
+# document stops parsing; `&` and `<` do the same. Same shape as #1307 and
+# #1311: the escaper exists, it just was not reaching every site.
+function test_junit_escapes_a_quote_in_the_file_path() {
+  local dir
+  dir="$(bashunit::temp_dir junit_quote_path)"
+  printf 'function test_ok() { assert_true true; }\n' >"$dir/say \"hi\"_test.sh"
+
+  ./bashunit --no-parallel --no-color --env "$TEST_ENV_FILE" \
+    --report-junit "$dir/r.xml" "$dir/say \"hi\"_test.sh" >/dev/null 2>&1 || true
+
+  assert_file_exists "$dir/r.xml"
+  local content
+  content="$(cat "$dir/r.xml")"
+  # The raw quote must not survive inside an attribute value.
+  assert_not_contains 'name="tests/say "hi"' "$content"
+  assert_contains '&quot;hi&quot;' "$content"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1313

`__xml_escape` is applied to the test name and the failure message, but the path-derived attributes were interpolated raw:

```xml
<testsuite name="tests/say "hi"_test.sh" tests="1" ...>
```
```
ExpatError: not well-formed (invalid token): line 8, column 30
```

`&` and `<` in a path break it identically. Affects `--report-junit` and `--output junit`. Filenames may legally contain all three on macOS and Linux, and the path also feeds `classname`, which is what CI reporters group by.

## 💡 Changes

- The existing escaper is applied at the three path-derived sites: `testsuite name=`, `testcase classname=`, `testcase file=`. Nothing else changes

## 🔍 How it was found

Extending the report-writer sweep to hostile **paths** rather than hostile messages. `--list --list-format json` and `--report-json` handle the same paths correctly — `tests/say \"hi\"_test.sh` and `tests/back\\slash_test.sh` come out properly escaped and parse — so JUnit was the outlier.

Third instance of one pattern: #1307 (GHA properties), #1311 (Cobertura attributes), now JUnit. In each the escaper existed and was correct; it simply did not reach every interpolation site.