### PR TITLE
fix(runner): stop evaluating a test file's path as shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Security
+- A test file's path is no longer evaluated as shell. The per-test EXIT trap was built by interpolating the path into the trap string, and a trap body is re-evaluated when it fires, so a path containing a command substitution ran it — the surrounding double quotes stopped word splitting but not substitution. Any run over a tree whose filenames someone else controls, which is what CI does with a checked-out branch, executed that command. The same mangling also swallowed part of the path, so such a file's assertions never ran and it was reported `risky` instead of failing
+
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)
 

--- a/src/runner/exec.sh
+++ b/src/runner/exec.sh
@@ -245,9 +245,18 @@ function bashunit::runner::execute_test_body() {
   # execute_test_hook, the redirect leaks into the EXIT trap,
   # causing export_subshell_context output to be lost.
   exec 5>&1
-  # shellcheck disable=SC2064
+  # The path travels in a variable, never interpolated into the trap string. A
+  # trap body is re-evaluated by the shell when it fires, so a path holding
+  # `` `cmd` `` or `$(cmd)` used to RUN it -- the surrounding double quotes stop
+  # word splitting but not command substitution. A file's name is data, and the
+  # exposure was a CI job running `bashunit tests/` over a checked-out branch:
+  # whoever could add a file to the tree chose the command.
+  #
+  # Single quotes below, so nothing expands until the trap fires, and then only
+  # as an ordinary parameter expansion -- which does not re-scan its value.
+  _BASHUNIT_RUNNER_EXIT_FILE=$test_file
   # shellcheck disable=SC2154 # assigned inside the trap body, read by cleanup_on_exit (runner/hooks.sh)
-  trap "exit_code=\$?; bashunit::runner::cleanup_on_exit \"$test_file\" \"\$exit_code\"" EXIT
+  trap 'exit_code=$?; bashunit::runner::cleanup_on_exit "$_BASHUNIT_RUNNER_EXIT_FILE" "$exit_code"' EXIT
   bashunit::state::initialize_assertions_count
 
   if bashunit::env::is_login_shell_enabled; then

--- a/tests/acceptance/bashunit_hostile_path_test.sh
+++ b/tests/acceptance/bashunit_hostile_path_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A test file's path is data, never code. The per-test EXIT trap used to be
+# built by interpolating the path into the trap string, and a trap body is
+# re-evaluated by the shell when it fires -- so a path holding a command
+# substitution ran it. Double quotes around the interpolation stopped word
+# splitting but not substitution.
+#
+# The exposure is a CI job checking out a branch and running `bashunit tests/`:
+# whoever can add a file to the tree chooses the command.
+
+function set_up_before_script() {
+  BASHUNIT_BIN="$(pwd)/bashunit"
+}
+
+function set_up() {
+  WORKDIR="$(bashunit::temp_dir hostile_path)"
+  mkdir -p "$WORKDIR/tests"
+}
+
+# `touch INJECTED` is relative, so the marker would land in the run's cwd.
+function test_a_backtick_in_a_test_path_is_not_executed() {
+  local nasty="$WORKDIR/tests/x\`touch INJECTED\`y_test.sh"
+  printf 'function test_probe() { assert_same "1" "1"; }\n' >"$nasty"
+
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file tests/) >/dev/null 2>&1 || true
+
+  assert_file_not_exists "$WORKDIR/INJECTED"
+}
+
+function test_a_dollar_paren_in_a_test_path_is_not_executed() {
+  local nasty="$WORKDIR/tests/x\$(touch INJECTED2)y_test.sh"
+  printf 'function test_probe2() { assert_same "1" "1"; }\n' >"$nasty"
+
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file tests/) >/dev/null 2>&1 || true
+
+  assert_file_not_exists "$WORKDIR/INJECTED2"
+}
+
+# The same path under --parallel, where the trap is set inside a worker.
+function test_a_backtick_in_a_test_path_is_not_executed_in_parallel() {
+  local nasty="$WORKDIR/tests/x\`touch INJECTED3\`y_test.sh"
+  printf 'function test_probe3() { assert_same "1" "1"; }\n' >"$nasty"
+
+  (cd "$WORKDIR" && "$BASHUNIT_BIN" --parallel --skip-env-file tests/) >/dev/null 2>&1 || true
+
+  assert_file_not_exists "$WORKDIR/INJECTED3"
+}
+
+# And the test still actually runs: the assertion must be counted, not lost to a
+# mangled path. The substitution used to swallow part of the name, so the file
+# that got sourced was not the one on disk and the test reported risky.
+function test_a_test_in_a_hostile_path_still_runs_its_assertions() {
+  local nasty="$WORKDIR/tests/x\`echo hi\`y_test.sh"
+  printf 'function test_counts() { assert_same "a" "b"; }\n' >"$nasty"
+
+  local output
+  output=$(cd "$WORKDIR" && "$BASHUNIT_BIN" --no-parallel --skip-env-file tests/ 2>&1) || true
+
+  assert_contains "1 failed" "$output"
+  assert_not_contains "risky" "$output"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1315

The per-test EXIT trap was built by interpolating the test file's path into the trap string:

```bash
trap "exit_code=\$?; bashunit::runner::cleanup_on_exit \"$test_file\" \"\$exit_code\"" EXIT
```

A trap body is re-evaluated by the shell when it fires, so a path containing a command substitution ran it. The double quotes stopped word splitting but not substitution. A filename is data; the exposure is any run over a tree whose filenames someone else controls, which is what CI does with a checked-out branch.

A second effect from the same cause: the substitution consumed part of the name, so the path that got sourced was not the file on disk — that test's assertions never ran and it was reported `risky` instead of failing. Verified: the repro case now reports `2 failed` where it previously said `1 failed, 1 risky`.

## 💡 Changes

- The path travels in a variable and the trap body is single-quoted, so nothing expands until the trap fires and then only as an ordinary parameter expansion, which does not re-scan its value
- Regression tests cover the backtick and `$( … )` forms, sequential and `--parallel`, plus the invariant that a test in such a path still runs its assertions
- `src/coverage/engine.sh` also installs traps from variables, but those carry bashunit's own code rather than external data; this was the only site interpolating a path

## 🔍 How it was found

Extending the report sweep to hostile **paths**: a file named with a backtick was silently reported `risky` instead of failing, and tracing that led to the trap.