### PR TITLE
docs(changelog): consolidate and tighten the unreleased notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,36 +2,27 @@
 
 ## Unreleased
 
-### Changed
-- Performance: cold start is about 9ms faster, roughly 15%. Building the colour palette cost one subshell fork per colour, sixteen of them — the largest single cost in a startup. Every invocation paid it, including `--version` and `--help`
-- `--seed <n>` now implies `--random-order`. The header prints `Randomized with seed: N` so a failing run can be replayed, but typing that seed back on its own selected nothing: the run came back in defined order and green, and the shuffle that caused the failure never happened. An order named explicitly still wins, so `--order-by defined --seed 42` runs in defined order. Same behaviour as RSpec's `--seed`
-- Performance: a `--parallel` run writing a report is about 1.9x faster and costs 1.8x less CPU. Every result row base64-encoded all nine of its fields separately and decoded them the same way — fourteen `base64` forks per test — so `--log-junit`, the usual CI setup, cost several times more than running the tests. Only the four fields that can hold arbitrary text are encoded now (#1289)
-### Fixed
-- `bashunit watch` no longer takes an option's value as the path it polls. Only `-f/--filter` was known to consume a value, so `bashunit watch --tag slow tests/` polled a directory named `slow` and passed the real path to `--tag`; when the value happened to name a real directory it polled the wrong one without saying so. Options may now appear in any position (#1291)
 ### Added
-- `-u` as the short form of `--snapshot-update`. Re-running with `-u` after a deliberate output change is the reflex jest and vitest already teach, and both spell it the same way (#1293)
+- `-u` as the short form of `--snapshot-update`, the spelling jest and vitest both use (#1293)
+
+### Changed
+- `--seed <n>` now implies `--random-order`. Replaying a failure with the seed the header printed used to select nothing, so the run came back in defined order and green. An order named explicitly still wins, as in RSpec (#1287)
+- Performance: cold start is about 9ms faster, roughly 15%. The colour palette cost one subshell fork per colour, and every invocation paid it — `--version` included (#1285)
+- Performance: a `--parallel` run writing a report is about 1.9x faster and uses 1.8x less CPU. Each result row cost fourteen `base64` forks per test, so `--log-junit` cost several times more than running the tests (#1289)
+
 ### Fixed
-- `--parallel` with an empty selection no longer prints `No tests found` onto stdout ahead of the document, which made `--output json` and `--output junit` unparseable; sequential runs of the same selection were valid. On the console the notice appeared twice instead of once. An empty selection is routine in CI — an unpopulated `--shard`, a `--changed` run that touched nothing — which is where `--output` is consumed (#1295)
-### Fixed
-- A test file with a `tear_down_after_script` no longer makes `--output junit` malformed. The blank line printed after that hook went to stdout ahead of the document, so the XML declaration was not at byte 0 and the report did not parse; the hook did not have to fail, an ordinary one was enough. `--output json` carried the same stray byte but tolerates leading whitespace (#1297)
-### Fixed
-- Two diagnostics no longer print to stdout, where they made `--output json` and `--output junit` unparseable: the duplicate-test-function abort, in every mode, and the replay of a `--parallel` worker's stderr, which meant any test whose `set_up` failed corrupted the report. Both go to stderr now, so they still reach the reader while stdout carries only the document (#1299)
-### Fixed
-- A `--parallel` run no longer counts a file-level hook failure twice in its reports. A failing `set_up_before_script` or `tear_down_after_script`, and a file that fails to source, were written into the JSON, JUnit, HTML and Markdown reports as two failed tests, listed twice, while the console summary of the same run said one — the console was right (#1301)
-### Fixed
-- `bashunit bench` now exits non-zero when a benchmark file fails to source or its `set_up_before_script` fails. It printed the error and exited 0, so the failure reached a human reading the log and never reached CI; a file with a syntax error silently lost every `bench_` function after it and still reported success. A benchmark that merely returns non-zero still exits 0 — a benchmark measures time and has no assertion concept (#1303)
-### Fixed
-- A failure message containing a ``` fence no longer breaks the `--report-md` summary. The message is fenced unescaped, which is right only while the fence is longer than any run of backticks inside it — a hook printing a bare fence closed the block early, so the text after it rendered as prose and the trailing fence opened an unterminated one, swallowing every later section of the page appended to `$GITHUB_STEP_SUMMARY` (#1305)
-### Fixed
-- A comma or colon in a test title no longer breaks its GitHub Actions annotation. GitHub splits an annotation's properties on `,`, so a `set_test_title` holding one ended the title there and turned the rest into an invented property; a file path containing a comma did the same. Property values now encode `:` and `,` as the spec requires, on top of the `%`, `\r` and `\n` the message already encoded (#1307)
-### Fixed
-- `--output tap` now escapes a `#` in a test description, as `--report-tap` already did. TAP reads an unescaped `#` as the start of a directive, so a failing test titled `... # SKIP ...` was handed to the consumer as a skip — a `not ok` carrying a SKIP directive is not a failure, and it left CI silently. The `# SKIP` and `# TODO` directives bashunit writes itself are unaffected (#1309)
-### Fixed
-- The Cobertura coverage report escapes XML metacharacters in a path. A file whose name held `&`, `<` or `>` went into `filename=`, `class name=`, `package name=` and `<source>` raw, so the document did not parse — and Cobertura is what GitLab, Azure and Jenkins render coverage from, which then silently show nothing. The HTML report gained this in #1254; this writer had no escaper at all (#1311)
-### Fixed
-- The JUnit report escapes the file path. `testsuite name=`, `testcase classname=` and `file=` were interpolated raw, so a test file whose name contained `"`, `&` or `<` closed the attribute early and the document stopped parsing — under both `--report-junit` and `--output junit`. The test name and the failure message were already escaped (#1313)
+- `--output json` and `--output junit` are no longer corrupted by console text on stdout, which left the document unparseable. Four sources: an empty `--parallel` selection (#1295), the blank line after a `tear_down_after_script` (#1297), the duplicate-function abort, and a `--parallel` worker's stderr replay (#1299)
+- `--parallel` reports no longer count a file-level hook failure twice. JSON, JUnit, HTML and Markdown listed it as two failed tests while the console summary of the same run said one (#1301)
+- `bashunit bench` exits non-zero when a benchmark file fails to source or its `set_up_before_script` fails. It printed the error and exited 0, so the failure never reached CI, and a syntax error silently dropped every `bench_` function after it (#1303)
+- `--output tap` escapes `#` in a test description, as `--report-tap` already did. A failing test titled `... # SKIP ...` reached the consumer as a skip and left CI silently (#1309)
+- `bashunit watch` no longer takes an option's value as the path it polls: `watch --tag slow tests/` polled a directory named `slow`. Options may now appear in any position (#1291)
+- The JUnit report escapes the file path; a name holding `"`, `&` or `<` closed the attribute early and the document stopped parsing (#1313)
+- The Cobertura report escapes XML metacharacters in a path, so GitLab, Azure and Jenkins render coverage instead of silently showing nothing (#1311)
+- GitHub Actions annotations encode `:` and `,` in their property values; a comma in a test title ended the title there and invented a property (#1307)
+- A ``` fence in a failure message no longer truncates the `--report-md` summary, which is appended to `$GITHUB_STEP_SUMMARY` (#1305)
+
 ### Security
-- A test file's path is no longer evaluated as shell. The per-test EXIT trap was built by interpolating the path into the trap string, and a trap body is re-evaluated when it fires, so a path containing a command substitution ran it — the surrounding double quotes stopped word splitting but not substitution. Any run over a tree whose filenames someone else controls, which is what CI does with a checked-out branch, executed that command. The same mangling also swallowed part of the path, so such a file's assertions never ran and it was reported `risky` instead of failing
+- A test file's path is no longer evaluated as shell. The per-test EXIT trap interpolated the path into the trap string, and a trap body is re-evaluated when it fires, so a filename holding a command substitution executed it — reachable by any run over a tree whose filenames someone else controls, which is what CI does with a checked-out branch. The same mangling meant such a file's assertions never ran and it was reported `risky` instead of failing (#1315)
 
 ### Removed
 - `bashunit learn`, the interactive tutorial. Nobody used it, and it was broken for most of the nine months it shipped without anyone reporting it. Learning bashunit belongs in the docs at https://bashunit.com, not in a subsystem inside the runner — which is also 6% of the distributable. Calling it now says it was removed and points there (#1256, #1258)


### PR DESCRIPTION
## 🤔 Background

Merging sixteen PRs one at a time left `## Unreleased` with **eleven separate `### Fixed` headings**, one per PR, and three entries with no issue reference.

## 💡 Changes

- One section per kind, ordered Added / Changed / Fixed / Security / Removed
- Entries trimmed to the user-visible fact and its consequence
- The four stdout-contract fixes folded into a single bullet — they are one defect with four sources (#1295, #1297, #1299)
- Added the missing references: #1285, #1287, #1315. All eighteen issue refs verified present after the rewrite