### PR TITLE
fix(coverage): cover every line of a multi-line statement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -45,3 +45,10 @@ max_line_length = unset
 
 [src/coverage/html_file.sh]
 max_line_length = unset
+
+# Snapshots are byte-exact recordings of terminal output, ANSI escapes and all.
+# editorconfig-checker 4.0.0 reads the ESC byte in four of them as Latin-1 and
+# fails a charset it cannot detect on a file that is pure ASCII. Nothing here is
+# hand-written, so there is no encoding to pin.
+[tests/acceptance/snapshots/**]
+charset = unset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixed
+- Coverage counts every line of a multi-line statement as covered once the statement has run, not only the line Bash reported it on. An array literal written one element per line used to cost one uncovered line per element — and on Bash 3.2, where the assignment is reported on its closing `)`, the hit was discarded outright and the whole array read as uncovered. Multi-line strings and heredoc bodies had the same gap; a multi-line `$( )` is left alone, since its interior lines are commands that are tracked in their own right (#1338)
+
 ## [0.50.1](https://github.com/TypedDevs/bashunit/compare/0.50.0...0.50.1) - 2026-08-22
 
 ### Fixed

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -426,6 +426,41 @@ These lines are not counted toward coverage:
 - Control flow keywords (`then`, `else`, `fi`, `do`, `done`, `esac`, `in`)
 - Case statement patterns (`--option)`, `*)`) and terminators (`;;`, `;&`, `;;&`)
 
+### Statements That Span Several Lines
+
+Bash reports one executed statement to the tracer on a single line, even when
+the statement is written over several. bashunit spreads that hit across every
+line the statement occupies, so a statement that ran is covered on all of them:
+
+- backslash continuations (`printf '%s' \` … )
+- array literals (`commands=(` … `)`)
+- multi-line quoted strings
+- heredoc bodies (`cat <<EOF` … `EOF`)
+
+```bash
+commands=(          # covered
+  "start"           # covered
+  "stop"            # covered
+)                   # not executable
+```
+
+Every line still counts toward the denominator, so a multi-line statement that
+never runs reports as several uncovered lines, exactly as it did before.
+
+A multi-line command substitution is deliberately **not** treated this way:
+
+```bash
+result=$(
+  compute_a
+  compute_b
+)
+```
+
+`compute_a` and `compute_b` are commands in their own right and are tracked
+individually, so crediting them from the line that opened the substitution
+would report lines that never ran. (Before Bash 4 the tracer does not reach a
+subshell at all — see [Subshell Behavior](#subshell-behavior).)
+
 ## Branch Coverage
 
 Beyond line and function coverage, bashunit emits **branch coverage** records in the LCOV report so reviewers can see whether each `else`/`elif` arm and each `case` pattern was exercised. Branch records are produced automatically; no extra flags are needed.

--- a/src/coverage/html_file.sh
+++ b/src/coverage/html_file.sh
@@ -44,14 +44,7 @@ function escape(t) {
 }
 
 END {
-  # The DEBUG trap attributes a multi-line statement to its starting line, so
-  # the count carries forward across the backslash chain (#722).
-  carry = 0
-  for (ln = 1; ln <= total; ln++) {
-    h = (ln in hits) ? hits[ln] : 0
-    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
-    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
-  }
+  bu_propagate(sl, hits, total)
 
   for (ln = 1; ln <= total; ln++) {
     row_class = ""
@@ -113,12 +106,7 @@ FILENAME == hitsfile {
 }
 
 END {
-  carry = 0
-  for (ln = 1; ln <= total; ln++) {
-    h = (ln in hits) ? hits[ln] : 0
-    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
-    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
-  }
+  bu_propagate(sl, hits, total)
 
   bu_fn_reset()
   for (ln = 1; ln <= total; ln++) { bu_fn_line(sl[ln], ln) }

--- a/src/coverage/lines.sh
+++ b/src/coverage/lines.sh
@@ -322,9 +322,12 @@ function bashunit::coverage::scan_line() {
     _BASHUNIT_COVERAGE_SCAN_CONTINUES=1
   fi
 
+  # A local copy, written back once: the global's name is longer than most of
+  # the statements that touch it.
+  local stack="$_BASHUNIT_COVERAGE_SCAN_STACK"
   local rest="$line" prev="" head tail char top
   while [ -n "$rest" ]; do
-    top="${_BASHUNIT_COVERAGE_SCAN_STACK#"${_BASHUNIT_COVERAGE_SCAN_STACK%?}"}"
+    top="${stack#"${stack%?}"}"
     case "$top" in
     'S') head="${rest%%[\']*}" ;;
     'D') head="${rest%%[\"\\$]*}" ;;
@@ -340,26 +343,32 @@ function bashunit::coverage::scan_line() {
     char="${tail%"${tail#?}"}"
     rest="${tail#?}"
 
+    # Nothing but the closing quote is reported inside `'..'`.
     if [ "$top" = 'S' ]; then
-      _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}"
+      stack="${stack%?}"
       prev="$char"
       continue
     fi
 
+    # A backslash escapes the next character in both remaining contexts. Inside
+    # `'..'` it is literal, and the branch above has already taken that case.
+    case "$char" in
+    [\\])
+      prev="${rest%"${rest#?}"}"
+      rest="${rest#?}"
+      continue
+      ;;
+    esac
+
     if [ "$top" = 'D' ]; then
       case "$char" in
-      '"') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}" ;;
-      [\\])
-        prev="${rest%"${rest#?}"}"
-        rest="${rest#?}"
-        continue
-        ;;
+      '"') stack="${stack%?}" ;;
       '$')
         # `"$(cmd 'a"b')"`: a command substitution reopens an unquoted context,
         # so the quotes inside it are not the outer string's.
         case "$rest" in
         '('*)
-          _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}C"
+          stack="${stack}C"
           rest="${rest#?}"
           prev='('
           continue
@@ -372,32 +381,27 @@ function bashunit::coverage::scan_line() {
     fi
 
     case "$char" in
-    [\\])
-      prev="${rest%"${rest#?}"}"
-      rest="${rest#?}"
-      continue
-      ;;
-    "'") _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}S" ;;
-    '"') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}D" ;;
+    "'") stack="${stack}S" ;;
+    '"') stack="${stack}D" ;;
     '#')
       # `#` only opens a comment at the start of a word, so `${x#y}` and
-      # `${#arr[@]}` are not comments.
+      # `${#arr[@]}` are not comments. The rest of the line is not shell text.
       case "$prev" in
-      '' | ' ' | '	' | ';' | '&' | '|') return 0 ;;
+      '' | ' ' | '	' | ';' | '&' | '|') break ;;
       esac
       ;;
     '(')
       # An array literal is the one parenthesis whose contents are words of a
       # single statement, and it is the one that opens right after a `=`.
       case "$prev" in
-      '$') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}C" ;;
-      '=') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}A" ;;
-      *) _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}P" ;;
+      '$') stack="${stack}C" ;;
+      '=') stack="${stack}A" ;;
+      *) stack="${stack}P" ;;
       esac
       ;;
     ')')
       # A case arm's `)` closes nothing, and popping an empty stack is a no-op.
-      _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}"
+      stack="${stack%?}"
       ;;
     '<')
       case "$rest" in
@@ -418,6 +422,8 @@ function bashunit::coverage::scan_line() {
     esac
     prev="$char"
   done
+
+  _BASHUNIT_COVERAGE_SCAN_STACK="$stack"
 
   return 0
 }

--- a/src/coverage/lines.sh
+++ b/src/coverage/lines.sh
@@ -217,6 +217,224 @@ function bashunit::coverage::_ends_with_continuation() {
   [ $((${#trailing} % 2)) -eq 1 ]
 }
 
+# The multi-line statement scanner (#1338).
+#
+# A backslash chain is not the only way one statement covers several physical
+# lines, and the DEBUG trap reports the whole statement on ONE of them -- which
+# one depends on the Bash version. For `local commands=(` .. `)`, Bash 3.2
+# reports the closing `)` (a line the classifier calls non-executable, so the
+# hit was discarded entirely) and Bash 5.x reports the opening line. Either way
+# the rest of the statement read as uncovered.
+#
+# So the reader needs to know which lines belong to one statement. This is a
+# small shell lexer: it consumes a line at a time and carries its state forward,
+# the way the classifier consumes a line at a time without one.
+#
+# The state is a stack of open contexts, innermost last, one character each:
+#
+#   S  a single-quoted string      D  a double-quoted string
+#   A  an array literal `name=(`   C  a command substitution `$(`
+#   P  any other parenthesis
+#
+# plus a pending heredoc delimiter. A line is *open* -- the statement continues
+# onto the next line -- when the stack holds an S, D or A, when a heredoc is
+# pending, or when it ends with a backslash continuation.
+#
+# C and P deliberately do NOT open a span. The lines inside a multi-line `$( )`
+# are real commands that get their own DEBUG hits, so crediting them from the
+# line that opened the substitution would report lines that never ran. They are
+# still tracked, because their parentheses have to balance for the ones that do.
+_BASHUNIT_COVERAGE_SCAN_STACK=""
+_BASHUNIT_COVERAGE_SCAN_HEREDOC=""
+_BASHUNIT_COVERAGE_SCAN_HEREDOC_TAB=0
+_BASHUNIT_COVERAGE_SCAN_CONTINUES=0
+
+##
+# Clears the scanner state. Call once before the first line of a file.
+##
+function bashunit::coverage::scan_reset() {
+  _BASHUNIT_COVERAGE_SCAN_STACK=""
+  _BASHUNIT_COVERAGE_SCAN_HEREDOC=""
+  _BASHUNIT_COVERAGE_SCAN_HEREDOC_TAB=0
+  _BASHUNIT_COVERAGE_SCAN_CONTINUES=0
+}
+
+# Records the delimiter of a heredoc from the text that follows `<<`. The
+# quoting of a delimiter only decides whether the body expands, so it is
+# stripped: `<<'EOF'`, `<<"EOF"`, `<<\EOF` and `<<EOF` all end at `EOF`.
+# Arguments: $1 - the rest of the line after `<<`
+function bashunit::coverage::_scan_heredoc_start() {
+  local rest="$1"
+
+  _BASHUNIT_COVERAGE_SCAN_HEREDOC_TAB=0
+  case "$rest" in
+  '-'*)
+    _BASHUNIT_COVERAGE_SCAN_HEREDOC_TAB=1
+    rest="${rest#-}"
+    ;;
+  esac
+  rest="${rest#"${rest%%[![:space:]]*}"}"
+
+  local word="${rest%%[[:space:];&|<>)]*}"
+  word="${word//\\/}"
+  word="${word//\'/}"
+  word="${word//\"/}"
+  _BASHUNIT_COVERAGE_SCAN_HEREDOC="$word"
+}
+
+##
+# Advances the scanner over one source line.
+#
+# Only the characters that can change the state are visited: the line is cut to
+# the next one of them with a single parameter expansion, so the loop runs once
+# per quote, paren, backslash, `#` or `<` rather than once per character.
+# Arguments: $1 - the source line
+##
+function bashunit::coverage::scan_line() {
+  local line="$1"
+
+  _BASHUNIT_COVERAGE_SCAN_CONTINUES=0
+
+  # A heredoc body is data, not shell text: nothing in it changes the state, and
+  # its terminator is the last line of the span.
+  if [ -n "$_BASHUNIT_COVERAGE_SCAN_HEREDOC" ]; then
+    local body="$line"
+    if [ "$_BASHUNIT_COVERAGE_SCAN_HEREDOC_TAB" -eq 1 ]; then
+      body="${body#"${body%%[!	]*}"}"
+    fi
+    if [ "$body" = "$_BASHUNIT_COVERAGE_SCAN_HEREDOC" ]; then
+      _BASHUNIT_COVERAGE_SCAN_HEREDOC=""
+    fi
+    return 0
+  fi
+
+  # With nothing open, a line holding no quote, backslash, `(` or `<` cannot
+  # change the state: a `)` pops an empty stack and a `#` only ends a walk that
+  # would have done nothing. One glob test skips the walk for most lines.
+  if [ -z "$_BASHUNIT_COVERAGE_SCAN_STACK" ]; then
+    case "$line" in
+    *[\'\"\\\(\<]*) : ;;
+    *) return 0 ;;
+    esac
+  fi
+
+  if bashunit::coverage::_ends_with_continuation "$line"; then
+    _BASHUNIT_COVERAGE_SCAN_CONTINUES=1
+  fi
+
+  local rest="$line" prev="" head tail char top
+  while [ -n "$rest" ]; do
+    top="${_BASHUNIT_COVERAGE_SCAN_STACK#"${_BASHUNIT_COVERAGE_SCAN_STACK%?}"}"
+    case "$top" in
+    'S') head="${rest%%[\']*}" ;;
+    'D') head="${rest%%[\"\\$]*}" ;;
+    *) head="${rest%%[\'\"\\#()<]*}" ;;
+    esac
+    [ "$head" = "$rest" ] && break
+
+    # `prev` is what sits immediately left of the character we stopped on: it is
+    # the last character of the skipped text, or -- when nothing was skipped --
+    # the character the previous iteration stopped on.
+    [ -n "$head" ] && prev="${head#"${head%?}"}"
+    tail="${rest#"$head"}"
+    char="${tail%"${tail#?}"}"
+    rest="${tail#?}"
+
+    if [ "$top" = 'S' ]; then
+      _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}"
+      prev="$char"
+      continue
+    fi
+
+    if [ "$top" = 'D' ]; then
+      case "$char" in
+      '"') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}" ;;
+      [\\])
+        prev="${rest%"${rest#?}"}"
+        rest="${rest#?}"
+        continue
+        ;;
+      '$')
+        # `"$(cmd 'a"b')"`: a command substitution reopens an unquoted context,
+        # so the quotes inside it are not the outer string's.
+        case "$rest" in
+        '('*)
+          _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}C"
+          rest="${rest#?}"
+          prev='('
+          continue
+          ;;
+        esac
+        ;;
+      esac
+      prev="$char"
+      continue
+    fi
+
+    case "$char" in
+    [\\])
+      prev="${rest%"${rest#?}"}"
+      rest="${rest#?}"
+      continue
+      ;;
+    "'") _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}S" ;;
+    '"') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}D" ;;
+    '#')
+      # `#` only opens a comment at the start of a word, so `${x#y}` and
+      # `${#arr[@]}` are not comments.
+      case "$prev" in
+      '' | ' ' | '	' | ';' | '&' | '|') return 0 ;;
+      esac
+      ;;
+    '(')
+      # An array literal is the one parenthesis whose contents are words of a
+      # single statement, and it is the one that opens right after a `=`.
+      case "$prev" in
+      '$') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}C" ;;
+      '=') _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}A" ;;
+      *) _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK}P" ;;
+      esac
+      ;;
+    ')')
+      # A case arm's `)` closes nothing, and popping an empty stack is a no-op.
+      _BASHUNIT_COVERAGE_SCAN_STACK="${_BASHUNIT_COVERAGE_SCAN_STACK%?}"
+      ;;
+    '<')
+      case "$rest" in
+      '<<'*)
+        # A here-string has no body.
+        rest="${rest#??}"
+        prev='<'
+        continue
+        ;;
+      '<'*)
+        rest="${rest#?}"
+        bashunit::coverage::_scan_heredoc_start "$rest"
+        prev='<'
+        continue
+        ;;
+      esac
+      ;;
+    esac
+    prev="$char"
+  done
+
+  return 0
+}
+
+##
+# Whether the statement on the last scanned line continues onto the next one.
+# Returns: 0 when the line is open, 1 when the statement ended with it
+##
+function bashunit::coverage::scan_is_open() {
+  [ "$_BASHUNIT_COVERAGE_SCAN_CONTINUES" -eq 1 ] && return 0
+  [ -n "$_BASHUNIT_COVERAGE_SCAN_HEREDOC" ] && return 0
+  case "$_BASHUNIT_COVERAGE_SCAN_STACK" in
+  *[SDA]*) return 0 ;;
+  esac
+  return 1
+}
+
 # Get all line hits for a file in one pass (performance optimization)
 # Output format: one "lineno:count" per line
 
@@ -398,19 +616,27 @@ function bashunit::coverage::get_all_line_hits() {
   local total=$_i
   [ "$maxln" -gt "$total" ] && total=$maxln
 
-  # Propagate each start line's count forward across its continuation chain.
-  local carry=0 idx h
+  # Group the lines into statement spans and give every line of a span the
+  # highest count recorded anywhere in it. Span-max rather than a forward carry
+  # because the trap may have attributed the statement to the LAST line of the
+  # span -- which is what Bash 3.2 does with an array literal (#1338). For a
+  # backslash chain, where only the first line can carry a hit, it produces
+  # exactly what the forward carry did (#722).
+  local idx start=1 max=0 fill h
+  bashunit::coverage::scan_reset
   for ((idx = 1; idx <= total; idx++)); do
     h=${counts[idx]:-0}
-    if [ "$carry" -gt 0 ] && [ "$h" -lt "$carry" ]; then
-      h=$carry
-      counts[idx]=$h
+    [ "$h" -gt "$max" ] && max=$h
+    bashunit::coverage::scan_line "${src[idx - 1]:-}"
+    bashunit::coverage::scan_is_open && continue
+
+    if [ "$max" -gt 0 ] && [ "$start" -lt "$idx" ]; then
+      for ((fill = start; fill <= idx; fill++)); do
+        counts[fill]=$max
+      done
     fi
-    if [ "$h" -gt 0 ] && bashunit::coverage::_ends_with_continuation "${src[idx - 1]:-}"; then
-      carry=$h
-    else
-      carry=0
-    fi
+    start=$((idx + 1))
+    max=0
   done
 
   local ln

--- a/src/coverage/rules_awk.sh
+++ b/src/coverage/rules_awk.sh
@@ -106,6 +106,149 @@ function bu_ends_with_continuation(line,   lead, i, n) {
   }
   return (n % 2) == 1
 }
+
+# The multi-line statement scanner, as awk. Mirrors
+# bashunit::coverage::scan_reset / scan_line / scan_is_open, which is the
+# reference and carries the full explanation of the state machine (#1338).
+#
+# _bu_st[1.._bu_sp] is the context stack, innermost last: S single-quoted,
+# D double-quoted, A array literal, C command substitution, P other paren.
+# The quote character itself has to be built with sprintf: this program lives
+# in a shell single-quoted string and so cannot contain one.
+function bu_scan_reset() {
+  _bu_sp = 0
+  _bu_hd = ""
+  _bu_hdtab = 0
+  _bu_cont = 0
+  _bu_sq = sprintf("%c", 39)
+  split("", _bu_st)
+}
+
+# Records the delimiter of a heredoc from the text following `<<`. The quoting
+# of a delimiter only decides whether the body expands, so it is stripped.
+function bu_scan_heredoc(rest,   word) {
+  _bu_hdtab = 0
+  if (substr(rest, 1, 1) == "-") { _bu_hdtab = 1; rest = substr(rest, 2) }
+  sub(/^[ \t]+/, "", rest)
+  word = rest
+  sub(/[ \t;&|<>)].*$/, "", word)
+  gsub(/\\/, "", word)
+  gsub(/"/, "", word)
+  gsub(_bu_sq, "", word)
+  _bu_hd = word
+}
+
+function bu_scan_line(line,   i, n, c, prev, top, body) {
+  _bu_cont = 0
+
+  if (_bu_hd != "") {
+    body = line
+    if (_bu_hdtab) { sub(/^\t+/, "", body) }
+    if (body == _bu_hd) { _bu_hd = "" }
+    return
+  }
+
+  # Same early-out as the reference: with nothing open, a line holding none of
+  # these characters cannot change the state. index() is a C-speed pass where
+  # the walk below is an interpreted one.
+  if (_bu_sp == 0 && index(line, _bu_sq) == 0 && index(line, "\"") == 0 &&
+      index(line, "\\") == 0 && index(line, "(") == 0 && index(line, "<") == 0) {
+    return
+  }
+
+  if (bu_ends_with_continuation(line)) { _bu_cont = 1 }
+
+  n = length(line)
+  prev = ""
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+    top = (_bu_sp > 0) ? _bu_st[_bu_sp] : ""
+
+    if (top == "S") {
+      if (c == _bu_sq) { _bu_sp-- }
+      prev = c
+      continue
+    }
+
+    if (top == "D") {
+      if (c == "\"") { _bu_sp-- }
+      else if (c == "\\") { i++; prev = substr(line, i, 1); continue }
+      else if (c == "$" && substr(line, i + 1, 1) == "(") {
+        _bu_sp++; _bu_st[_bu_sp] = "C"; i++; prev = "("; continue
+      }
+      prev = c
+      continue
+    }
+
+    if (c == "\\") { i++; prev = substr(line, i, 1); continue }
+    if (c == _bu_sq) { _bu_sp++; _bu_st[_bu_sp] = "S"; prev = c; continue }
+    if (c == "\"") { _bu_sp++; _bu_st[_bu_sp] = "D"; prev = c; continue }
+    if (c == "#") {
+      if (prev == "" || prev == " " || prev == "\t" ||
+          prev == ";" || prev == "&" || prev == "|") { return }
+      prev = c
+      continue
+    }
+    if (c == "(") {
+      _bu_sp++
+      _bu_st[_bu_sp] = (prev == "$") ? "C" : ((prev == "=") ? "A" : "P")
+      prev = c
+      continue
+    }
+    if (c == ")") {
+      if (_bu_sp > 0) { _bu_sp-- }
+      prev = c
+      continue
+    }
+    if (c == "<" && substr(line, i + 1, 1) == "<") {
+      if (substr(line, i + 2, 1) == "<") { i += 2; prev = "<"; continue }
+      bu_scan_heredoc(substr(line, i + 2))
+      i++
+      prev = "<"
+      continue
+    }
+    prev = c
+  }
+}
+
+function bu_scan_open(   k) {
+  if (_bu_cont) { return 1 }
+  if (_bu_hd != "") { return 1 }
+  for (k = 1; k <= _bu_sp; k++) {
+    if (_bu_st[k] == "S" || _bu_st[k] == "D" || _bu_st[k] == "A") { return 1 }
+  }
+  return 0
+}
+
+# The open contexts, innermost last. Only the differential reads it: a real
+# shell file ends with nothing open, so a non-empty state at EOF is a lexer bug
+# and this says which context leaked.
+function bu_scan_stack(   k, s) {
+  s = ""
+  for (k = 1; k <= _bu_sp; k++) { s = s _bu_st[k] }
+  return s
+}
+
+# Gives every line of a multi-line statement the highest count recorded
+# anywhere in it. The DEBUG trap reports the statement on one line of the span
+# and which one depends on the Bash version, so the propagation runs in both
+# directions (#722, #1338). Mirrors the loop in get_all_line_hits.
+function bu_propagate(sl, hits, total,   ln, start, max, fill, h) {
+  bu_scan_reset()
+  start = 1
+  max = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] + 0 : 0
+    if (h > max) { max = h }
+    bu_scan_line(sl[ln])
+    if (bu_scan_open()) { continue }
+    if (max > 0 && start < ln) {
+      for (fill = start; fill <= ln; fill++) { hits[fill] = max }
+    }
+    start = ln + 1
+    max = 0
+  }
+}
 '
 
 # The DA/LF/LH block of one file's LCOV record, in one pass.
@@ -131,12 +274,7 @@ FILENAME == hitsfile {
 }
 
 END {
-  carry = 0
-  for (ln = 1; ln <= total; ln++) {
-    h = (ln in hits) ? hits[ln] + 0 : 0
-    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
-    if (h > 0 && bu_ends_with_continuation(src[ln])) { carry = h } else { carry = 0 }
-  }
+  bu_propagate(src, hits, total)
 
   executable = 0
   hit = 0
@@ -187,14 +325,7 @@ _BASHUNIT_COVERAGE_AWK_STATS='
   }
   close(src)
 
-  # The DEBUG trap attributes a multi-line statement to its starting line, so
-  # the count carries forward across the backslash chain (#722).
-  carry = 0
-  for (ln = 1; ln <= total; ln++) {
-    h = (ln in hits) ? hits[ln] : 0
-    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
-    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
-  }
+  bu_propagate(sl, hits, total)
 
   executable = 0
   hit = 0
@@ -254,14 +385,7 @@ BEGIN { print "TN:" }
   }
   close(src)
 
-  # The DEBUG trap attributes a multi-line statement to its starting line, so
-  # the count carries forward across the backslash chain (#722).
-  carry = 0
-  for (ln = 1; ln <= total; ln++) {
-    h = (ln in hits) ? hits[ln] : 0
-    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
-    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
-  }
+  bu_propagate(sl, hits, total)
 
   bu_fn_reset()
   bu_br_reset()

--- a/src/coverage/rules_awk.sh
+++ b/src/coverage/rules_awk.sh
@@ -164,15 +164,19 @@ function bu_scan_line(line,   i, n, c, prev, top, body) {
     c = substr(line, i, 1)
     top = (_bu_sp > 0) ? _bu_st[_bu_sp] : ""
 
+    # Nothing but the closing quote is reported inside a single-quoted string.
     if (top == "S") {
       if (c == _bu_sq) { _bu_sp-- }
       prev = c
       continue
     }
 
+    # A backslash escapes the next character in both remaining contexts; inside
+    # a single-quoted string it is literal, and the branch above took that case.
+    if (c == "\\") { i++; prev = substr(line, i, 1); continue }
+
     if (top == "D") {
       if (c == "\"") { _bu_sp-- }
-      else if (c == "\\") { i++; prev = substr(line, i, 1); continue }
       else if (c == "$" && substr(line, i + 1, 1) == "(") {
         _bu_sp++; _bu_st[_bu_sp] = "C"; i++; prev = "("; continue
       }
@@ -180,7 +184,6 @@ function bu_scan_line(line,   i, n, c, prev, top, body) {
       continue
     }
 
-    if (c == "\\") { i++; prev = substr(line, i, 1); continue }
     if (c == _bu_sq) { _bu_sp++; _bu_st[_bu_sp] = "S"; prev = c; continue }
     if (c == "\"") { _bu_sp++; _bu_st[_bu_sp] = "D"; prev = c; continue }
     if (c == "#") {

--- a/tests/acceptance/bashunit_coverage_multiline_test.sh
+++ b/tests/acceptance/bashunit_coverage_multiline_test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A statement that ran counts as covered on every line it spans, whichever way
+# it spans them. #722 established that for a backslash chain; an array literal,
+# a multi-line string and a heredoc are the same statement over several lines
+# and used to cost one uncovered line each (#1338).
+#
+# End to end rather than at the reader, because the defect depended on where the
+# DEBUG trap put the hit: Bash 3.2 reports an array assignment on its closing
+# `)` -- a line the classifier calls non-executable, so the hit was dropped
+# outright -- and Bash 5.x reports its opening line. Only a real run exercises
+# whichever of the two this machine does.
+
+function set_up_before_script() {
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+}
+
+# A source file whose every function spans lines a different way, and a test
+# that runs all of them.
+function _project() { # $1 = dir
+  mkdir -p "$1/src"
+  cat >"$1/src/multiline.sh" <<'SRC'
+#!/usr/bin/env bash
+
+function multi_line_array() {
+  local commands=(
+    "start"
+    "stop"
+    "status"
+  )
+
+  printf '%s\n' "${commands[@]}"
+}
+
+function backslash_continuation() {
+  printf '%s\n' \
+    "start" \
+    "stop"
+}
+
+function multi_line_string() {
+  printf '%s' '{
+    "index": "spend",
+    "alias": "filters"
+  }'
+}
+
+function here_document() {
+  cat <<EOF
+one
+two
+EOF
+}
+SRC
+  cat >"$1/t_test.sh" <<'TEST'
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/src/multiline.sh"
+
+function test_multi_line_array() {
+  assert_contains "start" "$(multi_line_array)"
+}
+
+function test_backslash_continuation() {
+  assert_contains "start" "$(backslash_continuation)"
+}
+
+function test_multi_line_string() {
+  assert_contains "spend" "$(multi_line_string)"
+}
+
+function test_here_document() {
+  assert_contains "one" "$(here_document)"
+}
+TEST
+}
+
+function _run_coverage() { # $1 = dir
+  local dir="$1"
+  shift
+  (cd "$dir" && BASHUNIT_COVERAGE_SHOW_UNCOVERED=true \
+    "$ROOT_DIR/bashunit" --no-parallel --coverage --coverage-paths src \
+    --no-coverage-report "$@" t_test.sh 2>&1) || true
+}
+
+function test_every_line_of_a_multi_line_statement_that_ran_is_covered() {
+  local dir
+  dir="$(bashunit::temp_dir)"
+  _project "$dir"
+
+  local output
+  output="$(_run_coverage "$dir" | strip_ansi)"
+
+  assert_contains "16/ 16 lines (100%)" "$output"
+  assert_not_contains "Uncovered Lines" "$output"
+}
+
+# The same numbers have to come out of the LCOV writer, which reaches them
+# through the batch awk pass rather than the Bash reader.
+function test_the_lcov_report_agrees_with_the_terminal_report() {
+  local dir
+  dir="$(bashunit::temp_dir)"
+  _project "$dir"
+
+  (cd "$dir" && "$ROOT_DIR/bashunit" --no-parallel --coverage \
+    --coverage-paths src --coverage-report lcov.info \
+    t_test.sh >/dev/null 2>&1) || true
+
+  assert_file_contains "$dir/lcov.info" "LF:16"
+  assert_file_contains "$dir/lcov.info" "LH:16"
+}
+
+# A span nothing ran still counts against the file: the fix credits statements
+# that executed, it does not remove lines from the denominator.
+function test_a_multi_line_statement_that_never_ran_stays_uncovered() {
+  local dir
+  dir="$(bashunit::temp_dir)"
+  _project "$dir"
+  cat >>"$dir/src/multiline.sh" <<'SRC'
+
+function never_called() {
+  local unused=(
+    "a"
+    "b"
+  )
+  printf '%s\n' "${unused[@]}"
+}
+SRC
+
+  local output
+  output="$(_run_coverage "$dir" | strip_ansi)"
+
+  assert_contains "16/ 20 lines" "$output"
+  assert_matches "src/multiline.sh:[0-9]+-[0-9]+" "$output"
+}

--- a/tests/unit/coverage/classifier_differential_test.sh
+++ b/tests/unit/coverage/classifier_differential_test.sh
@@ -1,21 +1,32 @@
 #!/usr/bin/env bash
 
-# The awk classifier and the Bash one must agree on every line of every shell
-# file in the repo. A disagreement moves coverage numbers silently, which is
-# exactly what #1005 warned about when it reproduced the old regex quirk for
-# quirk -- so this compares them line by line rather than trusting either.
+# The awk rules and the Bash ones must agree on every line of every shell file
+# in the repo. A disagreement moves coverage numbers silently, which is exactly
+# what #1005 warned about when it reproduced the old regex quirk for quirk --
+# so this compares them line by line rather than trusting either.
+#
+# Two rule sets share the walk, because both are per-line and both have a Bash
+# reference with an awk mirror: whether a line is executable (#1005) and whether
+# the statement on it continues onto the next one (#722, #1338). The scanner
+# also carries state between lines, so the file's end state is compared too --
+# and asserted clean, since real shell files balance their quotes.
 
 function set_up_before_script() {
   ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+  LF="
+"
 }
 
-# Classifies every line of $1 with awk, printing "<lineno> <0|1>".
+# Reports every line of $1 with awk as "<lineno> <executable> <open>", then a
+# final "end <stack> <heredoc>" holding the scanner state the file left behind.
 # $2 overrides the rule source, which is how the mutation below is injected.
 function awk_classification() { # $1 = file, $2 = optional rule source
   local rules="${2:-$(bashunit::coverage::awk_rules)}"
   local out status=0
   out=$(env LC_ALL=C "$AWK" "$rules"'
-    { printf "%s %s\n", FNR, bu_is_executable($0) }
+    BEGIN { bu_scan_reset() }
+    { bu_scan_line($0); printf "%s %s %s\n", FNR, bu_is_executable($0), bu_scan_open() }
+    END { printf "end %s %s\n", bu_scan_stack(), _bu_hd }
   ' "$1") || status=$?
 
   # An awk that failed prints nothing, and empty output is indistinguishable
@@ -35,17 +46,21 @@ function awk_classification() { # $1 = file, $2 = optional rule source
   fi
 }
 
-# Classifies every line of $1 with the Bash reference, same format.
+# Reports every line of $1 with the Bash reference, same format.
 function bash_classification() { # $1 = file
-  local lineno=0 line
+  local lineno=0 line executable open
+  bashunit::coverage::scan_reset
   while IFS= read -r line || [ -n "$line" ]; do
     lineno=$((lineno + 1))
-    if bashunit::coverage::is_executable_line "$line" "$lineno"; then
-      printf '%s 1\n' "$lineno"
-    else
-      printf '%s 0\n' "$lineno"
-    fi
+    executable=0
+    bashunit::coverage::is_executable_line "$line" "$lineno" && executable=1
+    bashunit::coverage::scan_line "$line"
+    open=0
+    bashunit::coverage::scan_is_open && open=1
+    printf '%s %s %s\n' "$lineno" "$executable" "$open"
   done <"$1"
+  printf 'end %s %s\n' \
+    "$_BASHUNIT_COVERAGE_SCAN_STACK" "$_BASHUNIT_COVERAGE_SCAN_HEREDOC"
 }
 
 # Renders the difference between two strings, for the report of a file that
@@ -62,7 +77,7 @@ function diff_of() { # $1 = bash side, $2 = awk side
 }
 
 
-function test_both_classifiers_agree_on_every_shell_file_in_the_repo() {
+function test_both_rule_sets_agree_on_every_shell_file_in_the_repo() {
   # 460 files, each an awk fork plus a Bash loop over its lines: 4.8s here,
   # but minutes under Git Bash, where the shard hung until CI cancelled it.
   # GNU awk (Ubuntu) and BusyBox awk (Alpine) both run this, which is what the
@@ -70,6 +85,10 @@ function test_both_classifiers_agree_on_every_shell_file_in_the_repo() {
   bashunit::skip_on windows "460 awk forks per run takes minutes under Git Bash"
 
   local disagreements=""
+  # A shell file that parses has every quote, parenthesis and heredoc closed by
+  # the time it ends, so a leftover context is the scanner mis-reading real code
+  # -- the check that the state machine is right, not merely mirrored (#1338).
+  local unclean=""
   local file tmp_a tmp_b
   tmp_a=$(bashunit::temp_file cls_a)
   tmp_b=$(bashunit::temp_file cls_b)
@@ -93,9 +112,16 @@ function test_both_classifiers_agree_on_every_shell_file_in_the_repo() {
 $file
 $diff_out"
     fi
+
+    local end_state="${bash_out##*"$LF"}"
+    if [ "$end_state" != "end  " ]; then
+      unclean="$unclean
+$file left $end_state"
+    fi
   done
 
   assert_empty "$disagreements"
+  assert_empty "$unclean"
 }
 
 # The differential is only worth anything if it can fail. The mutation removes
@@ -121,7 +147,7 @@ function test_the_differential_catches_a_broken_awk_rule() {
   assert_not_equals "$reference" "$mutated"
 }
 
-function test_the_classifiers_agree_on_the_quirk_cases() {
+function test_the_rule_sets_agree_on_the_quirk_cases() {
   local fixture
   fixture="$(bashunit::temp_file)"
   {
@@ -137,9 +163,42 @@ function test_the_classifiers_agree_on_the_quirk_cases() {
     printf '%s\n' 'function bashunit::x() {'
     printf '%s\n' 'name() {'
     printf '%s\n' '((i++))'
+    # The scanner's own quirks: an array literal spans, a substitution does not,
+    # and a quote is only a quote where the shell reads one (#1338).
+    printf '%s\n' 'arr=('
+    printf '%s\n' '  "one"'
+    printf '%s\n' ')'
+    printf '%s\n' "s='multi"
+    printf '%s\n' "line'"
+    printf '%s\n' "echo hi  # don't"
+    printf '%s\n' 'y="$(f '"'"'a"b'"'"')"'
+    printf '%s\n' 'cat <<-EOF'
+    printf '\t%s\n' 'body'
+    printf '\t%s\n' 'EOF'
+    printf '%s\n' 'read -r v <<<"here"'
   } >"$fixture"
 
   assert_same "$(bash_classification "$fixture")" "$(awk_classification "$fixture")"
+}
+
+# The scanner half of the differential needs its own mutation guard: a rule
+# removed from the awk copy has to surface as a disagreement, not as an awk
+# that refuses to run.
+function test_the_differential_catches_a_broken_awk_scanner_rule() {
+  local fixture
+  fixture="$(bashunit::temp_file)"
+  printf '%s\n' 'arr=(' '  "one"' ')' >"$fixture"
+
+  local mutated_rules
+  mutated_rules=$(bashunit::coverage::awk_rules |
+    sed 's|(prev == "=") ? "A" : "P"|"P"|')
+
+  local mutated reference
+  mutated=$(awk_classification "$fixture" "$mutated_rules")
+  reference=$(bash_classification "$fixture")
+
+  assert_not_empty "$mutated"
+  assert_not_equals "$reference" "$mutated"
 }
 
 # The differential compares two outputs, so anything that empties one of them

--- a/tests/unit/coverage/spans_test.sh
+++ b/tests/unit/coverage/spans_test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC1003 # intentional literal trailing backslashes in test inputs
+
+# Multi-line statement spans (#1338).
+#
+# #722 taught the report that a backslash chain is one statement. A statement
+# that spans lines because a quote, an array literal or a heredoc is still open
+# is the same shape, and the DEBUG trap attributes it to one line of the span --
+# which line depends on the Bash version: 3.2 reports an array assignment on its
+# closing `)`, 5.x on its opening line. So the propagation has to cover the whole
+# span from a hit anywhere inside it.
+
+function set_up() {
+  WORK="$(bashunit::temp_dir)/spans"
+  mkdir -p "$WORK"
+  _BASHUNIT_COVERAGE_DATA_FILE="$WORK/coverage.data"
+  : >"$_BASHUNIT_COVERAGE_DATA_FILE"
+  bashunit::coverage::invalidate_hits_aggregation
+}
+
+function tear_down() {
+  _BASHUNIT_COVERAGE_DATA_FILE=""
+  bashunit::coverage::invalidate_hits_aggregation
+}
+
+# Records one hit per "<line>" argument and returns the propagated hit list.
+function hits_for() { # $1 = source file, $@ = line numbers to record
+  local src="$1"
+  shift
+  local ln
+  for ln in "$@"; do
+    echo "${src}:${ln}" >>"$_BASHUNIT_COVERAGE_DATA_FILE"
+  done
+  bashunit::coverage::invalidate_hits_aggregation
+  bashunit::coverage::get_all_line_hits "$src"
+}
+
+# --- the scanner -------------------------------------------------------------
+
+# Runs the scanner over the given lines and reports the open flag of each, so a
+# state machine bug points at the line that broke it.
+function open_flags() { # $@ = source lines
+  local line out=""
+  bashunit::coverage::scan_reset
+  for line in "$@"; do
+    bashunit::coverage::scan_line "$line"
+    if bashunit::coverage::scan_is_open; then
+      out="${out}1"
+    else
+      out="${out}0"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+function test_an_array_literal_stays_open_until_its_closing_paren() {
+  assert_same "1110" "$(open_flags 'local commands=(' '  "start"' '  "stop"' ')')"
+}
+
+function test_a_single_line_array_literal_opens_nothing() {
+  assert_same "0" "$(open_flags 'local commands=("start" "stop")')"
+}
+
+function test_a_command_substitution_is_not_a_span() {
+  assert_same "00" "$(open_flags 'x=$(' ')')"
+}
+
+function test_a_subshell_is_not_a_span() {
+  assert_same "00" "$(open_flags '(' ')')"
+}
+
+function test_a_process_substitution_is_not_a_span() {
+  assert_same "0" "$(open_flags 'while read -r l; do :; done < <(printf x)')"
+}
+
+function test_a_multi_line_single_quoted_string_stays_open() {
+  assert_same "110" "$(open_flags "x='{" '  "a": 1' "}'")"
+}
+
+function test_a_multi_line_double_quoted_string_stays_open() {
+  assert_same "10" "$(open_flags 'x="one' 'two"')"
+}
+
+function test_a_quote_inside_a_comment_opens_nothing() {
+  assert_same "0" "$(open_flags "# it's a comment")"
+}
+
+function test_a_trailing_comment_does_not_swallow_a_quote() {
+  assert_same "0" "$(open_flags "echo hi  # don't")"
+}
+
+function test_a_hash_in_a_parameter_expansion_is_not_a_comment() {
+  assert_same "0" "$(open_flags 'echo "${#arr[@]}" "${x#pre}"')"
+}
+
+function test_a_quote_inside_a_command_substitution_inside_a_string() {
+  # "$(f 'a"b')" -- the inner double quote belongs to the single-quoted word of
+  # the substituted command, not to the outer string.
+  assert_same "0" "$(open_flags 'y="$(f '"'"'a"b'"'"')"')"
+}
+
+function test_an_escaped_quote_does_not_open_a_string() {
+  assert_same "0" "$(open_flags 'echo \" done')"
+}
+
+function test_a_heredoc_body_stays_open_until_its_terminator() {
+  assert_same "1110" "$(open_flags 'cat <<EOF' 'a' 'b' 'EOF')"
+}
+
+function test_a_quoted_heredoc_delimiter_is_recognised() {
+  assert_same "110" "$(open_flags "cat <<'EOF'" "it's fine" 'EOF')"
+}
+
+function test_a_here_string_is_not_a_heredoc() {
+  assert_same "0" "$(open_flags 'read -r x <<<"value"')"
+}
+
+function test_a_backslash_continuation_is_open() {
+  assert_same "10" "$(open_flags 'printf %s \' '  value')"
+}
+
+function test_an_arithmetic_expansion_balances() {
+  assert_same "0" "$(open_flags 'count=$((count + 1))')"
+}
+
+function test_a_case_arm_does_not_unbalance_the_stack() {
+  assert_same "000" "$(open_flags 'case "$x" in' '  --flag) run ;;' 'esac')"
+}
+
+# --- span propagation --------------------------------------------------------
+
+function test_an_array_hit_on_the_closing_paren_covers_the_whole_span() {
+  # What Bash 3.2 records: the assignment is attributed to the `)` line.
+  local src="$WORK/array_close.sh"
+  printf '%s\n' 'local commands=(' '  "start"' '  "stop"' ')' 'echo done' >"$src"
+
+  assert_same "$(printf '%s\n' '1:1' '2:1' '3:1' '4:1')" "$(hits_for "$src" 4)"
+}
+
+function test_an_array_hit_on_the_opening_line_covers_the_whole_span() {
+  # What Bash 5.x records: the assignment is attributed to its first line.
+  local src="$WORK/array_open.sh"
+  printf '%s\n' 'local commands=(' '  "start"' '  "stop"' ')' 'echo done' >"$src"
+
+  assert_same "$(printf '%s\n' '1:1' '2:1' '3:1' '4:1')" "$(hits_for "$src" 1)"
+}
+
+function test_a_multi_line_string_hit_covers_its_interior() {
+  local src="$WORK/string.sh"
+  printf '%s\n' "printf '%s' '{" '  "index": "spend"' "}'" 'echo done' >"$src"
+
+  assert_same "$(printf '%s\n' '1:1' '2:1' '3:1')" "$(hits_for "$src" 1)"
+}
+
+function test_a_heredoc_hit_covers_its_body() {
+  local src="$WORK/heredoc.sh"
+  printf '%s\n' 'cat <<EOF' 'one' 'two' 'EOF' 'echo done' >"$src"
+
+  assert_same "$(printf '%s\n' '1:1' '2:1' '3:1' '4:1')" "$(hits_for "$src" 1)"
+}
+
+function test_a_multi_line_command_substitution_is_left_alone() {
+  # Its interior lines are real commands: they get their own DEBUG hits, so
+  # crediting them from the opening line would report lines that never ran.
+  local src="$WORK/cmdsub.sh"
+  printf '%s\n' 'x=$(' '  compute_a' '  compute_b' ')' >"$src"
+
+  assert_same "1:1" "$(hits_for "$src" 1)"
+}
+
+function test_a_span_that_never_ran_stays_uncovered() {
+  local src="$WORK/cold.sh"
+  printf '%s\n' 'local commands=(' '  "start"' ')' 'echo done' >"$src"
+
+  assert_same "4:1" "$(hits_for "$src" 4)"
+}
+
+function test_the_highest_count_in_a_span_wins() {
+  local src="$WORK/counts.sh"
+  printf '%s\n' 'local commands=(' '  "start"' ')' >"$src"
+
+  assert_same "$(printf '%s\n' '1:3' '2:3' '3:3')" "$(hits_for "$src" 3 3 3)"
+}
+
+# #722 stays exactly as it was: a chain propagates, an unrelated line does not.
+function test_a_backslash_chain_still_propagates() {
+  local src="$WORK/chain.sh"
+  printf '%s\n' 'echo start \' '  middle \' '  end' 'echo other' >"$src"
+
+  assert_same "$(printf '%s\n' '1:2' '2:2' '3:2' '4:1')" "$(hits_for "$src" 1 1 4)"
+}


### PR DESCRIPTION
## 🤔 Background

Related #1338

Bash reports one executed statement to the DEBUG trap on a single line, even when it is written over several. #722 handled the backslash chain; every other way a statement spans lines was left out, so an array literal written one element per line cost one uncovered line per element. On Bash 3.2 the assignment is reported on its closing `)`, which is non-executable, so the hit was discarded and the whole array read as uncovered.

## 💡 Changes

- Group source lines into statement spans and give every line of a span the highest count recorded in it, so a statement that ran is covered wherever the trap attributed it. Array literals, multi-line strings and heredoc bodies are now covered; the `#722` backslash chain is unchanged.
- A multi-line `$( )` is deliberately left alone: its interior lines are commands tracked in their own right, and crediting them would report lines that never ran.
- One scanner, a Bash reference mirrored in awk, replacing five copies of the old propagation loop. The differential now compares the scanner too over every repo shell file, and asserts each one lexes to a clean end state.
- Coverage rises where a multi-line statement really did run, and the report phase is 20-30% slower (3-5% of a whole `--coverage` run) — the cost of a per-line lexer. Verified on Bash 3.0, 3.2 and 5.3.

